### PR TITLE
cleanup makefile; new exec names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,10 @@ patrol*
 10m*
 simple*
 assign*
-src/assign*
+src/fiberassign
+src/fiberassign_surveysim
+src/split_*
+bin/fiberassign
+bin/fiberassign_surveysim
+bin/split_*
 slurm*

--- a/Makefile
+++ b/Makefile
@@ -16,44 +16,17 @@ export TOPDIR
 # where to place built executables
 
 ifndef INSTALL
-  INSTALL := $(TOPDIR)
+  INSTALL := $(TOPDIR)/bin
 endif
 
 export INSTALL
 
+all : 
+	@cd src; $(MAKE) all
 
-all_mtl : 
-	@cd src; $(MAKE) all_mtl
+install :
+	@cd src; $(MAKE) install
 
-install_mtl :
-	@cd src; $(MAKE) install_mtl
-
-clean_mtl :
-	@cd src; $(MAKE) clean_mtl
-
-all_fa : 
-	@cd src; $(MAKE) all_fa
-
-install_fa :
-	@cd src; $(MAKE) install_fa
-
-clean_fa :
-	@cd src; $(MAKE) clean_fa
-
-all_pipeline : 
-	@cd src; $(MAKE) all_pipeline
-
-install_pipeline :
-	@cd src; $(MAKE) install_pipeline
-
-clean_pipeline :
-	@cd src; $(MAKE) clean_pipeline
-all_targ : 
-	@cd src; $(MAKE) all_targ
-
-install_targ :
-	@cd src; $(MAKE) install_targ
-
-clean_targ :
-	@cd src; $(MAKE) clean_targ
+clean :
+	@cd src; $(MAKE) clean
 

--- a/script/cori_fa
+++ b/script/cori_fa
@@ -8,4 +8,4 @@ cd $SLURM_SUBMIT_DIR
 export OMP_NUM_THREADS=32
 echo "# Running assign"
 
-srun  -N 1  ./assign_fa fa_features.txt
+srun  -N 1  bin/fiberassign_surveysim fa_features.txt

--- a/script/cori_mtl_bright
+++ b/script/cori_mtl_bright
@@ -8,4 +8,4 @@ cd $SLURM_SUBMIT_DIR
 export OMP_NUM_THREADS=24
 echo "# Running assign"
 
-srun -N 1 ./assign_targ bright_time_features.txt
+srun -N 1 bin/split_targ_secret bright_time_features.txt

--- a/script/cori_pipeline
+++ b/script/cori_pipeline
@@ -1,13 +1,10 @@
 #!/bin/bash -l
-
 #SBATCH -p debug
 #SBATCH -N 1
 #SBATCH -t 0:29:59
-
-
 
 cd $SLURM_SUBMIT_DIR
 export OMP_NUM_THREADS=32
 echo "# Running assign"
 
-srun  -N 1  ./assign_pipeline pipeline_features.txt
+srun  -N 1  bin/fiberassign pipeline_features.txt

--- a/script/cori_run_bright_time
+++ b/script/cori_run_bright_time
@@ -8,4 +8,4 @@ cd $SLURM_SUBMIT_DIR
 export OMP_NUM_THREADS=32
 echo "# Running assign"
 
-srun -N 1 ./assign_fa bright_time_features.txt
+srun -N 1 bin/fiberassign_surveysim bright_time_features.txt

--- a/script/cori_run_mtl
+++ b/script/cori_run_mtl
@@ -8,4 +8,4 @@ cd $SLURM_SUBMIT_DIR
 export OMP_NUM_THREADS=24
 echo "# Running assign"
 
-srun -N 1 ./assign_mtl mtl_features.txt
+srun -N 1 bin/split_targ_secret_sky_std mtl_features.txt

--- a/script/cori_shortrun_fa
+++ b/script/cori_shortrun_fa
@@ -1,13 +1,10 @@
 #!/bin/bash -l
-
 #SBATCH -p debug
 #SBATCH -N 1
 #SBATCH -t 0:29:59
-
-
 
 cd $SLURM_SUBMIT_DIR
 export OMP_NUM_THREADS=32
 echo "# Running assign"
 
-srun  -N 1  ./assign_fa shortrun_features.txt
+srun -N 1 bin/fiberassign_surveysim shortrun_features.txt

--- a/script/cori_shortrun_mtl
+++ b/script/cori_shortrun_mtl
@@ -1,13 +1,10 @@
 #!/bin/bash -l
-
 #SBATCH -p debug
 #SBATCH -N 1
 #SBATCH -t 0:29:59
-
-
 
 cd $SLURM_SUBMIT_DIR
 export OMP_NUM_THREADS=32
 echo "# Running assign"
 
-srun  -N 1  ./assign_mtl shortrun_features.txt
+srun -N 1 bin/split_targ_secret_sky_std shortrun_features.txt

--- a/script/pipelinerun_fa
+++ b/script/pipelinerun_fa
@@ -7,4 +7,4 @@ cd $PBS_O_WORKDIR
 export OMP_NUM_THREADS=24
 echo "# Running assign"
 
-aprun -n 1 -N 1 -d 24 ./assign_pipeline pipeline_features.txt
+aprun -n 1 -N 1 -d 24 bin/fiberassign pipeline_features.txt

--- a/script/run
+++ b/script/run
@@ -7,4 +7,4 @@ cd $PBS_O_WORKDIR
 export OMP_NUM_THREADS=24
 echo "# Running assign"
 
-aprun -n 1 -N 1 -d 24 ./assign features.txt
+aprun -n 1 -N 1 -d 24 bin/fiberassign features.txt

--- a/script/run_bright_time
+++ b/script/run_bright_time
@@ -7,4 +7,4 @@ cd $PBS_O_WORKDIR
 export OMP_NUM_THREADS=24
 echo "# Running assign"
 
-aprun -n 1 -N 1 -d 24 ./assign bright_time_features.txt
+aprun -n 1 -N 1 -d 24 bin/fiberassign bright_time_features.txt

--- a/script/run_fa
+++ b/script/run_fa
@@ -7,4 +7,4 @@ cd $PBS_O_WORKDIR
 export OMP_NUM_THREADS=12
 echo "# Running assign"
 
-aprun -n 1 -N 1 -d 12 ./assign_fa fa_features.txt
+aprun -n 1 -N 1 -d 12 bin/fiberassign_surveysim fa_features.txt

--- a/script/run_mtl
+++ b/script/run_mtl
@@ -7,4 +7,4 @@ cd $PBS_O_WORKDIR
 export OMP_NUM_THREADS=24
 echo "# Running assign"
 
-aprun -n 1 -N 1 -d 24 ./assign_mtl mtl_features.txt
+aprun -n 1 -N 1 -d 24 bin/split_targ_secret_sky_std mtl_features.txt

--- a/script/shortrun_fa
+++ b/script/shortrun_fa
@@ -7,4 +7,4 @@ cd $PBS_O_WORKDIR
 export OMP_NUM_THREADS=24
 echo "# Running assign"
 
-aprun -n 1 -N 1 -d 24 ./assign_fa shortrun_features.txt
+aprun -n 1 -N 1 -d 24 bin/fiberassign_surveysim shortrun_features.txt

--- a/script/shortrun_mtl
+++ b/script/shortrun_mtl
@@ -7,4 +7,4 @@ cd $PBS_O_WORKDIR
 export OMP_NUM_THREADS=24
 echo "# Running assign"
 
-aprun -n 1 -N 1 -d 24 ./assign_mtl small_mtl_features.txt
+aprun -n 1 -N 1 -d 24 bin/split_targ_secret_sky_std small_mtl_features.txt

--- a/src/Makefile
+++ b/src/Makefile
@@ -10,7 +10,7 @@ global.h \
 misc.h \
 structs.h
 
-OBJS_FA = \
+OBJS_SURVEYSIM = \
 collision.o \
 feat.o \
 global.o \
@@ -18,7 +18,7 @@ fa.o \
 misc.o \
 structs.o
 
-OBJS_MTL = \
+OBJS_SKYSTD = \
 collision.o \
 feat.o \
 global.o \
@@ -26,7 +26,7 @@ mtl.o \
 misc.o \
 structs.o
 
-OBJS_TARG = \
+OBJS_TARG_SECRET = \
 collision.o \
 feat.o \
 global.o \
@@ -34,7 +34,7 @@ targ.o \
 misc.o \
 structs.o
 
-OBJS_PIPE = \
+OBJS_FIBERASSIGN = \
 collision.o \
 feat.o \
 global.o \
@@ -42,54 +42,31 @@ pipeline.o \
 misc.o \
 structs.o
 
-
-
+EXECUTABLES = fiberassign fiberassign_surveysim split_targ_secret_sky_std split_targ_secret
 COMPILE = $(CXXFLAGS) $(OMPFLAGS) -I. $(CFITSIO_CPPFLAGS)
 LINK = $(OMPFLAGS) $(CFITSIO)
 
-all_pipeline : assign_pipeline
+all : $(EXECUTABLES)
 
-install_pipeline : all_pipeline
-	cp assign_pipeline $(INSTALL)
+install : all
+	cp $(EXECUTABLES) $(INSTALL)
 
-all_mtl : assign_mtl
-
-install_mtl : all_mtl
-	cp assign_mtl $(INSTALL)
-
-all_targ : assign_targ
-
-install_targ : all_targ
-	cp assign_targ $(INSTALL)
-
-all_fa : assign_fa
-
-install_fa : all_fa
-	cp assign_fa $(INSTALL)
-
-assign_mtl : $(OBJS_MTL)
+split_targ_secret_sky_std : $(OBJS_SKYSTD)
 	$(CXX) -o $@ $^ $(LINK)
 
-assign_targ : $(OBJS_TARG)
+split_targ_secret : $(OBJS_TARG_SECRET)
 	$(CXX) -o $@ $^ $(LINK)
 
-assign_pipeline : $(OBJS_PIPE)
+fiberassign : $(OBJS_FIBERASSIGN)
 	$(CXX) -o $@ $^ $(LINK)
 
-assign_fa : $(OBJS_FA)
+fiberassign_surveysim : $(OBJS_SURVEYSIM)
 	$(CXX) -o $@ $^ $(LINK)
 
 %.o : %.cpp $(HEADERS)
 	$(CXX) $(COMPILE) -o $@ -c $<
 
-clean_mtl :
-	rm -f assign_mtl  *.o *~
-
-clean_targ :
-	rm -f assign_targ  *.o *~
-
-clean_fa :
-	rm -f assign_fa  *.o *~
-
-clean_pipeline :
-	rm -f assign_pipeline  *.o *~
+clean :
+	rm -f $(EXECUTABLES)
+	rm -f *.o *~
+	@cd $(INSTALL); rm -f $(EXECUTABLES)


### PR DESCRIPTION
This PR cleans up the Makefile so that "make", "make clean", and "make install" apply to all executables, instead of one make command per executable.  It also renames the executables:
  * fiberassign : the primary fiber assignment code
  * fiberassign_surveysim : runs fiber assignment within a survey operations simulation to assess the overall performance
  * split_* : utility executables for splitting the truth information, sky, and standard stars from an input target set.  Most users won't need these.

The executables are now installed into bin/ instead of the top level directory, and the batch scripts in scripts/ have been updated to point there.

Future cleanup that this PR does *not* include:
  * renaming *.cpp files with main() functions to match their corresponding executable
  * cleaning up script/ directory, e.g.
    * edison now uses slurm instead of PBS, so the old edison scripts won't work
    * renaming the scripts to be more similar to the new executable names
    * do the split scripts really take so long that they need to be run in batch?
  * documentation, tests...