### PR TITLE
Fixes to use of tileid values read from surveyFile in structs.cpp:read_plate_centers()

### DIFF
--- a/src/global.cpp
+++ b/src/global.cpp
@@ -1006,7 +1006,7 @@ void fa_write (int j, str outdir, const MTL & M, const Plates & P, const PP & pp
     float x_focal[optimal];
     float y_focal[optimal];
     //new
-    float t_priority[optimal];
+    int t_priority[optimal];
     
     std::vector <long long> potentialtargetid;
     

--- a/src/structs.cpp
+++ b/src/structs.cpp
@@ -10,7 +10,6 @@
 #include    <exception>
 #include    <stdexcept>
 #include    <sys/time.h>
-#include    <map>
 #include        <map>
 #include        <stdlib.h>     /* srand, rand */
 #include        "misc.h"

--- a/src/structs.cpp
+++ b/src/structs.cpp
@@ -632,7 +632,6 @@ Plates read_plate_centers(const Feat& F) {
     for(unsigned i=0;i<P.size();++i)
     {
         ret = invert_tile.insert(std::make_pair(P[i].tileid,i));
-        std::cout << "Insertng " << (ret.first)->first << " , " << (ret.first)->second << std::endl;
         // Check for duplicates (std::map.insert only creates keys, fails on duplicate keys)
         if ( ret.second == false ) {
             std::ostringstream o;


### PR DESCRIPTION
surveyFile is supposed to contain a list of tileid values that can be used to filter and sort the list of plates read from tileFile (specifically, only those plates with in_desi=1). The implementation of this in structs.cpp:read_plate_centers() had a couple of array index bugs that were showing up as mysterious segfaults on my machine but could easily pass with invalid values.

Problems fixed here:
- no checks that values were within the ranges corresponding to their use as indices (now throw range_error exceptions).
- related to that, no check that tileids specified in surveyFile were included and flagged with in_desi=1 in tileFile; such cases ended up being mapped to a negative index in the list of plate structs (now check for the negative index).
- implicit use of 1-based tileid as 0-based array index causing (mostly harmless?) off-by-one (now have explicit comments and tileid-1 when used in loops).

I also added a few more comments in read_plate_centers() and moved the definition of the magic number `total_tiles = 28810` to the start of the function for clarity.