### PR TITLE
Checks on success of reading input MTL

### DIFF
--- a/src/fiberassign.cpp
+++ b/src/fiberassign.cpp
@@ -31,11 +31,15 @@ int main(int argc, char **argv) {
     F.readInputFile(argv[1]);
     printFile(argv[1]);
 
-    init_time_at(time,"# read target, SS, SF files",t);
-    MTL Targ=read_MTLfile(F.Targfile,F,0,0);
-    MTL SStars=read_MTLfile(F.SStarsfile,F,1,0);
-    MTL SkyF=read_MTLfile(F.SkyFfile,F,0,1);
+    // Read input files for standards, skys and targets.
+    // Try to read SS and SF before targets to avoid wasting time if these
+    // smaller files can't be read.
+    init_time_at(time,"# Read target, SS, SF files",t);
+    MTL SStars = read_MTLfile(F.SStarsfile,F,1,0);
+    MTL SkyF   = read_MTLfile(F.SkyFfile,  F,0,1);
+    MTL Targ   = read_MTLfile(F.Targfile,  F,0,0);
     print_time(time,"# ... took :");
+
     //combine the three input files
     M=Targ;
     printf(" Target size %d \n",M.size());


### PR DESCRIPTION
Fixes in respect of #38.

Checks return code from cfitsio read routines and throws an exception on failure. Code will no longer run to completion with missing or unreadable MTL input for targets, skys or standards. This behavior might have been useful for debugging -- it could be reinstated with a parameter file or preprocessor switch if desired. 