### PR TITLE
Subpriority

### DIFF
--- a/src/feat.cpp
+++ b/src/feat.cpp
@@ -107,8 +107,8 @@ void Feat::readInputFile(const char file[]) {
                 init_types();
                 init_ids_types();
             }
-            if (tok[0]=="prio")  for (int i=0; i<Categories; i++){prio.push_back(s2i(tok[i+1]));}
-            if (tok[0]=="priopost") for (int i=0; i<Categories; i++) priopost.push_back(s2i(tok[i+1]));
+            //if (tok[0]=="prio")  for (int i=0; i<Categories; i++){prio.push_back(s2i(tok[i+1]));}
+            //if (tok[0]=="priopost") for (int i=0; i<Categories; i++) priopost.push_back(s2i(tok[i+1]));
             if (tok[0]=="goal") for (int i=0; i<Categories; i++) goal.push_back(s2i(tok[i+1]));
             if (tok[0]=="goalpost") for (int i=0; i<Categories; i++) goalpost.push_back(s2i(tok[i+1]));
             if (tok[0]=="lastpass") for(int i=0; i<Categories;i++)lastpass.push_back(s2i(tok[i+1]));

--- a/src/feat.h
+++ b/src/feat.h
@@ -34,8 +34,8 @@ class Feat { // F for features
     bool PrintAscii;
     bool diagnose;
 
-    List prio; // Priorities  int
-    List priopost; // Priorities when we know the kind int
+    //List prio; // Priorities  int
+    //List priopost; // Priorities when we know the kind int
     List goal;
     List goalpost;
     List SS;

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -140,7 +140,7 @@ inline int find_best(int j, int k, const MTL& M, const Plates& P, const PP& pp, 
                 double subprio = M[g].subpriority;
                 // Takes it if better priority, or if same, if it needs more observations, so shares observations if two QSOs are close
                 if (prio>pbest || (prio==pbest && m>mbest)){
-                    if (prio>pbest || (prio==pbest && m>mbest)||(prio=pbest && m=mbest && subprio>subpbest)){
+                    if (prio>pbest || (prio==pbest && m>mbest)||(prio==pbest && m==mbest && subprio>subpbest)){
 
                     // Check that g is not assigned yet on this plate, or on the InterPlate around, check with ok_to_assign
                     int isa=A.is_assigned_jg(j,g,M,F);

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -127,7 +127,7 @@ inline bool ok_for_limit_SS_SF(int g, int j, int k, const MTL& M, const Plates& 
 // Null list means you can take all possible kinds, otherwise you can only take, for the galaxy, a kind among this list
 // Not allowed to take the galaxy of id no_g
 inline int find_best(int j, int k, const MTL& M, const Plates& P, const PP& pp, const Feat& F, const Assignment& A) {
-    int best = -1; int mbest = -1; int pbest = 0;
+    int best = -1; int mbest = -1; int pbest = 0; double subpbest=0.;
     List av_gals = P[j].av_gals[k];
     // For all available galaxies
     for (int gg=0; gg<av_gals.size(); gg++) {
@@ -137,14 +137,18 @@ inline int find_best(int j, int k, const MTL& M, const Plates& P, const PP& pp, 
             int m = M[g].nobs_remain; // Check whether it needs further observation
             if (m>=1) {
                 int prio = M[g].t_priority;
+                double subprio = M[g].subpriority;
                 // Takes it if better priority, or if same, if it needs more observations, so shares observations if two QSOs are close
                 if (prio>pbest || (prio==pbest && m>mbest)){
+                    if (prio>pbest || (prio==pbest && m>mbest)||(prio=pbest && m=mbest && subprio>subpbest)){
+
                     // Check that g is not assigned yet on this plate, or on the InterPlate around, check with ok_to_assign
                     int isa=A.is_assigned_jg(j,g,M,F);
                     int ok=ok_assign_g_to_jk(g,j,k,P,M,pp,F,A);
                     if (isa==-1 && ok) {
                         best = g;
                         pbest = prio;
+                        subpbest=subprio;
                         mbest = m;
                     }
                 }

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -139,7 +139,7 @@ inline int find_best(int j, int k, const MTL& M, const Plates& P, const PP& pp, 
                 int prio = M[g].t_priority;
                 double subprio = M[g].subpriority;
                 // Takes it if better priority, or if same, if it needs more observations, so shares observations if two QSOs are close
-                if (prio>pbest || (prio==pbest && m>mbest)){
+
                     if (prio>pbest || (prio==pbest && m>mbest)||(prio==pbest && m==mbest && subprio>subpbest)){
 
                     // Check that g is not assigned yet on this plate, or on the InterPlate around, check with ok_to_assign

--- a/src/structs.cpp
+++ b/src/structs.cpp
@@ -380,7 +380,8 @@ MTL read_MTLfile(str readfile, const Feat& F, int SS, int SF){
              Q.nhat[0]    = cos(phi)*sin(theta);
              Q.nhat[1]    = sin(phi)*sin(theta);
              Q.nhat[2]    = cos(theta);
-             Q.t_priority = priority[ii];//priority is proxy for id, starts at zero
+             Q.t_priority = priority[ii];//priority is proxy for target type, starts at zero
+             Q.subpriority= rand();
              Q.nobs_remain= numobs[ii];
              Q.nobs_done=0;//need to keep track of this, too
              Q.once_obs=0;//changed only in update_plan

--- a/src/structs.h
+++ b/src/structs.h
@@ -52,12 +52,13 @@ std::vector<int>count_galaxies(const Gals& G);
 //target -----------------------------------------------------
 class target {
     public:
-  long id; 
-  int nobs_remain, nobs_done;
-  double nhat[3];
-  double ra, dec;
-  long desi_target, mws_target, bgs_target;
-  int SS,SF,lastpass, priority_class, t_priority, once_obs;
+    long id;
+    int nobs_remain, nobs_done;
+    double nhat[3];
+    double ra, dec;
+    double subpriority;//substitutes for random number or differentiates between similar targets
+    long desi_target, mws_target, bgs_target;
+    int SS,SF,lastpass, priority_class, t_priority, once_obs;
   Plist av_tfs;
 };
 class MTL : public std::vector<struct target> {

--- a/src/surveysim.cpp
+++ b/src/surveysim.cpp
@@ -257,12 +257,12 @@ int main(int argc, char **argv) {
     FFREE = fopen("free_fibers.txt","w");
     int nrows=F.NUsedplate/20 +1;
     for (int i=0;i<nrows;++i){
-        for(int j=0);j<20;++j){
-            fprintf(" %d ",free[20*i+j]);
+        for(int j=0;j<20;++j){
+            fprintf(FFREE," %d ",free[20*i+j]);
         }
     }
     for (int i=nrows*20;i<F.NUsedplate;i++){
-        fprintf(" %d ",free[i]);
+        fprintf(FFREE," %d ",free[i]);
     }
     
     std::vector<int> tot_free(F.NUsedplate,0);
@@ -272,11 +272,11 @@ int main(int argc, char **argv) {
     }
     for (int i=0;i<nrows;++i){
         for(int j=0;j<20;++j){
-            fprintf(" %d ",tot_free[20*i+j]);
+            fprintf(FFREE," %d ",tot_free[20*i+j]);
         }
     }
     for (int i=nrows*20;i<F.NUsedplate;i++){
-        fprintf(" %d ",tot_free[i]);
+        fprintf(FFREE," %d ",tot_free[i]);
     }
     
     

--- a/src/surveysim.cpp
+++ b/src/surveysim.cpp
@@ -245,7 +245,7 @@ int main(int argc, char **argv) {
     for (int jused=0;jused<F.NUsedplate;jused++){
         int free=0;
         int j=A.suborder[jused];
-        for (int k=0);k<F.Nfiber;++k){
+        for (int k=0;k<F.Nfiber;++k){
             if A.TF[j][k]==-1{
                 free+=1;
                 free_tot+=1;

--- a/src/surveysim.cpp
+++ b/src/surveysim.cpp
@@ -242,7 +242,7 @@ int main(int argc, char **argv) {
     //special for clustering group 6/28/16
     //for each tile how many fibers free?  how many to each type of target?
     int free_tot=0;
-    for (int jused=0);jused<F.NUsedplate;jused++){
+    for (int jused=0;jused<F.NUsedplate;jused++){
         int free=0;
         j=int j=A.suborder[jused];
         for (int k=0);k<F.Nfiber;++k){

--- a/src/surveysim.cpp
+++ b/src/surveysim.cpp
@@ -255,7 +255,7 @@ int main(int argc, char **argv) {
     }
     FILE * FFREE;
     FFREE = fopen("free_fibers.txt","w");
-    int nrows=F.NUsedplate/20 +1;
+    int nrows=F.NUsedplate/20 ;
     for (int i=0;i<nrows;++i){
         for(int j=0;j<20;++j){
             fprintf(FFREE," %d ",free[20*i+j]);

--- a/src/surveysim.cpp
+++ b/src/surveysim.cpp
@@ -241,18 +241,44 @@ int main(int argc, char **argv) {
     
     //special for clustering group 6/28/16
     //for each tile how many fibers free?  how many to each type of target?
-    int free_tot=0;
+    std::vector<int> free(F.NUsed,0);
+    
     for (int jused=0;jused<F.NUsedplate;jused++){
-        int free=0;
         int j=A.suborder[jused];
+        this_tile=0;
         for (int k=0;k<F.Nfiber;++k){
             if (A.TF[j][k]==-1){
-                free+=1;
-                free_tot+=1;
+                this_tile+=1;
             }
         }
-        printf(" jused  %d   j  %d   free   %d   free total  %d \n",jused,j,free,free_tot);
+        free[jused]=this_tile;
     }
+    FILE * FFREE;
+    FFREE = fopen("free_fibers.txt","w");
+    int nrows=F.NUsed/20 +1
+    for (int i=0;i<nrows;++i){
+        for(int j=0);j<20;++j){
+            fprintf(" %d ",free[20*i+j]);
+        }
+    }
+    for (int i=nrows*20);i<F.NUsed;i++){
+        fprintf(" %d ",free[i]);
+    }
+    
+    std::vector<int> tot_free(F.NUsed,0);
+    tot_free[0]=free[0];
+    for (i=1;i<F.NUsed;++i){
+        tot_free[i]=tot_free[i-1]+free[i];
+    }
+    for (int i=0;i<nrows;++i){
+        for(int j=0);j<20;++j){
+            fprintf(" %d ",tot_free[20*i+j]);
+        }
+    }
+    for (int i=nrows*20);i<F.NUsed;i++){
+        fprintf(" %d ",tot_free[i]);
+    }
+    
     
     
     if (F.PrintAscii){

--- a/src/surveysim.cpp
+++ b/src/surveysim.cpp
@@ -251,7 +251,7 @@ int main(int argc, char **argv) {
                 free_tot+=1;
             }
         }
-        printf(" jused  %d   j  %d   free   %d   free total  %d \n",jused,j,free,free_tot)
+        printf(" jused  %d   j  %d   free   %d   free total  %d \n",jused,j,free,free_tot);
     }
     
     

--- a/src/surveysim.cpp
+++ b/src/surveysim.cpp
@@ -244,7 +244,7 @@ int main(int argc, char **argv) {
     int free_tot=0;
     for (int jused=0;jused<F.NUsedplate;jused++){
         int free=0;
-        j=int j=A.suborder[jused];
+        int j=A.suborder[jused];
         for (int k=0);k<F.Nfiber;++k){
             if A.TF[j][k]==-1{
                 free+=1;

--- a/src/surveysim.cpp
+++ b/src/surveysim.cpp
@@ -238,6 +238,23 @@ int main(int argc, char **argv) {
 
  
     // Results -------------------------------------------------------
+    
+    //special for clustering group 6/28/16
+    //for each tile how many fibers free?  how many to each type of target?
+    int free_tot=0;
+    for (int jused=0);jused<F.NUsedplate;jused++){
+        int free=0;
+        j=int j=A.suborder[jused];
+        for (int k=0);k<F.Nfiber;++k){
+            if A.TF[j][k]==-1{
+                free+=1;
+                free_tot+=1;
+            }
+        }
+        printf(" jused  %d   j  %d   free   %d   free total  %d \n",jused,j,free,free_tot)
+    }
+    
+    
     if (F.PrintAscii){
         for (int jused=0; jused<F.NUsedplate; jused++){
             int j=A.suborder[jused];

--- a/src/surveysim.cpp
+++ b/src/surveysim.cpp
@@ -241,11 +241,11 @@ int main(int argc, char **argv) {
     
     //special for clustering group 6/28/16
     //for each tile how many fibers free?  how many to each type of target?
-    std::vector<int> free(F.NUsed,0);
+    std::vector<int> free(F.NUsedplate,0);
     
     for (int jused=0;jused<F.NUsedplate;jused++){
         int j=A.suborder[jused];
-        this_tile=0;
+        int this_tile=0;
         for (int k=0;k<F.Nfiber;++k){
             if (A.TF[j][k]==-1){
                 this_tile+=1;
@@ -255,13 +255,13 @@ int main(int argc, char **argv) {
     }
     FILE * FFREE;
     FFREE = fopen("free_fibers.txt","w");
-    int nrows=F.NUsedplate/20 +1
+    int nrows=F.NUsedplate/20 +1;
     for (int i=0;i<nrows;++i){
         for(int j=0);j<20;++j){
             fprintf(" %d ",free[20*i+j]);
         }
     }
-    for (int i=nrows*20);i<F.NUsedplate;i++){
+    for (int i=nrows*20;i<F.NUsedplate;i++){
         fprintf(" %d ",free[i]);
     }
     
@@ -271,11 +271,11 @@ int main(int argc, char **argv) {
         tot_free[i]=tot_free[i-1]+free[i];
     }
     for (int i=0;i<nrows;++i){
-        for(int j=0);j<20;++j){
+        for(int j=0;j<20;++j){
             fprintf(" %d ",tot_free[20*i+j]);
         }
     }
-    for (int i=nrows*20);i<F.NUsedplate;i++){
+    for (int i=nrows*20;i<F.NUsedplate;i++){
         fprintf(" %d ",tot_free[i]);
     }
     

--- a/src/surveysim.cpp
+++ b/src/surveysim.cpp
@@ -260,12 +260,12 @@ int main(int argc, char **argv) {
         for(int j=0;j<20;++j){
             fprintf(FFREE," %d ",free[20*i+j]);
         }
-        fprintf("  \n");
+        fprintf(FFREE,"  \n");
     }
     for (int i=nrows*20;i<F.NUsedplate;i++){
         fprintf(FFREE," %d ",free[i]);
     }
-        fprintf("  \n");
+        fprintf(FFREE,"  \n");
     
     std::vector<int> tot_free(F.NUsedplate,0);
     tot_free[0]=free[0];
@@ -276,12 +276,12 @@ int main(int argc, char **argv) {
         for(int j=0;j<20;++j){
             fprintf(FFREE," %d ",tot_free[20*i+j]);
         }
-        fprintf("  \n");
+        fprintf(FFREE,"  \n");
     }
     for (int i=nrows*20;i<F.NUsedplate;i++){
         fprintf(FFREE," %d ",tot_free[i]);
     }
-        fprintf("  \n");
+
     
     
     

--- a/src/surveysim.cpp
+++ b/src/surveysim.cpp
@@ -267,7 +267,7 @@ int main(int argc, char **argv) {
     
     std::vector<int> tot_free(F.NUsedplate,0);
     tot_free[0]=free[0];
-    for (i=1;i<F.NUsedplate;++i){
+    for (int i=1;i<F.NUsedplate;++i){
         tot_free[i]=tot_free[i-1]+free[i];
     }
     for (int i=0;i<nrows;++i){

--- a/src/surveysim.cpp
+++ b/src/surveysim.cpp
@@ -255,19 +255,19 @@ int main(int argc, char **argv) {
     }
     FILE * FFREE;
     FFREE = fopen("free_fibers.txt","w");
-    int nrows=F.NUsed/20 +1
+    int nrows=F.NUsedplate/20 +1
     for (int i=0;i<nrows;++i){
         for(int j=0);j<20;++j){
             fprintf(" %d ",free[20*i+j]);
         }
     }
-    for (int i=nrows*20);i<F.NUsed;i++){
+    for (int i=nrows*20);i<F.NUsedplate;i++){
         fprintf(" %d ",free[i]);
     }
     
-    std::vector<int> tot_free(F.NUsed,0);
+    std::vector<int> tot_free(F.NUsedplate,0);
     tot_free[0]=free[0];
-    for (i=1;i<F.NUsed;++i){
+    for (i=1;i<F.NUsedplate;++i){
         tot_free[i]=tot_free[i-1]+free[i];
     }
     for (int i=0;i<nrows;++i){
@@ -275,7 +275,7 @@ int main(int argc, char **argv) {
             fprintf(" %d ",tot_free[20*i+j]);
         }
     }
-    for (int i=nrows*20);i<F.NUsed;i++){
+    for (int i=nrows*20);i<F.NUsedplate;i++){
         fprintf(" %d ",tot_free[i]);
     }
     

--- a/src/surveysim.cpp
+++ b/src/surveysim.cpp
@@ -246,7 +246,7 @@ int main(int argc, char **argv) {
         int free=0;
         int j=A.suborder[jused];
         for (int k=0;k<F.Nfiber;++k){
-            if A.TF[j][k]==-1{
+            if (A.TF[j][k]==-1){
                 free+=1;
                 free_tot+=1;
             }

--- a/src/surveysim.cpp
+++ b/src/surveysim.cpp
@@ -260,10 +260,12 @@ int main(int argc, char **argv) {
         for(int j=0;j<20;++j){
             fprintf(FFREE," %d ",free[20*i+j]);
         }
+        fprintf("  \n");
     }
     for (int i=nrows*20;i<F.NUsedplate;i++){
         fprintf(FFREE," %d ",free[i]);
     }
+        fprintf("  \n");
     
     std::vector<int> tot_free(F.NUsedplate,0);
     tot_free[0]=free[0];
@@ -274,10 +276,12 @@ int main(int argc, char **argv) {
         for(int j=0;j<20;++j){
             fprintf(FFREE," %d ",tot_free[20*i+j]);
         }
+        fprintf("  \n");
     }
     for (int i=nrows*20;i<F.NUsedplate;i++){
         fprintf(FFREE," %d ",tot_free[i]);
     }
+        fprintf("  \n");
     
     
     


### PR DESCRIPTION
This established subpriority as a member of target.  Eventually subpriority will be given for each target by MTL but for now it is artificially created at the time read_MTL is executed.  The subpriority is used only by find_best in the event that two targets have the same priority and the same number of remaining observations.  In this case, the higher priority wins.

Subpriority can also be used by those who want to established a detailed ordering of their targets, say in the MWS.