### PR TITLE
Add platform files for specific NERSC machines

### DIFF
--- a/platforms/nersc_cori_haswell
+++ b/platforms/nersc_cori_haswell
@@ -1,0 +1,17 @@
+
+# The install location of CFITSIO and other compiled
+# libraries
+DESI_EXTRA := $(DESI_CONDA)_extra
+
+# The serial C++ compiler
+export CXX := g++
+
+# Normal compile flags
+export CXXFLAGS := -O3 -fPIC -DNDEBUG
+
+# OpenMP flags (used for both compiling and linking)
+export OMPFLAGS := -fopenmp
+
+# CFITSIO include and linking commands
+export CFITSIO_CPPFLAGS := -I$(DESI_EXTRA)/include
+export CFITSIO := -L$(DESI_EXTRA)/lib -lcfitsio -lm

--- a/platforms/nersc_edison
+++ b/platforms/nersc_edison
@@ -1,0 +1,17 @@
+
+# The install location of CFITSIO and other compiled
+# libraries
+DESI_EXTRA := $(DESI_CONDA)_extra
+
+# The serial C++ compiler
+export CXX := g++
+
+# Normal compile flags
+export CXXFLAGS := -O3 -fPIC -DNDEBUG
+
+# OpenMP flags (used for both compiling and linking)
+export OMPFLAGS := -fopenmp
+
+# CFITSIO include and linking commands
+export CFITSIO_CPPFLAGS := -I$(DESI_EXTRA)/include
+export CFITSIO := -L$(DESI_EXTRA)/lib -lcfitsio -lm


### PR DESCRIPTION
Since we are not using hpcports for DESI dependencies, add a platform file for each NERSC system.  These currently just use gcc, but we might change them to use the Intel compiler in the future.