### PR TITLE
desiInstall compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,22 +10,21 @@ include platforms/$(PLATFORM)
 
 # absolute path to top source directory
 
-TOPDIR := $(shell pwd)
-export TOPDIR
+export TOPDIR := $(shell pwd)
 
 # where to place built executables
-
+ifdef INSTALL_DIR
+export INSTALL := $(INSTALL_DIR)
+endif
 ifndef INSTALL
-  INSTALL := $(TOPDIR)/bin
+export INSTALL := $(TOPDIR)/bin
 endif
 
-export INSTALL
-
 all : 
-	@cd src; $(MAKE) all
+	$(MAKE) -C src all
 
 install :
-	@cd src; $(MAKE) install
+	$(MAKE) -C src install
 
 clean :
-	@cd src; $(MAKE) clean
+	$(MAKE) -C src clean

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ export TOPDIR := $(shell pwd)
 
 # where to place built executables
 ifdef INSTALL_DIR
-export INSTALL := $(INSTALL_DIR)
+export INSTALL := $(INSTALL_DIR)/bin
 endif
 ifndef INSTALL
 export INSTALL := $(TOPDIR)/bin


### PR DESCRIPTION
This PR fixes #54 by setting the internal `INSTALL` variable to `$(INSTALL_DIR)/bin` where `INSTALL_DIR` is defined by desiInstall.

I have tested this by hand on Edison.