### PR TITLE
Remake fiber positioner

### DIFF
--- a/doc/Guide_to_FiberAssignment.tex.old
+++ b/doc/Guide_to_FiberAssignment.tex.old
@@ -48,13 +48,13 @@ The existing fiber assignment code was initiated by Martin White and expanded by
 \subsection{\file{fiberassign.cpp}}
 The main portion of the code contains several parts:
 \begin{itemize}
-\item Read input files for targets, sky fibers, and standard stars.   The location of the files is specified through \file{F.Targfile,  F.SStarsfile, F.Skyfile}.  If fiberassign is run through the python code in desisim, the location is specified in the calling sequence for quicksurvey, which specifies the location of a ``features'' file.  Reading the features file is actually the first action and sets out many of the parameters (F.xxx) for the code .  If fiberassign is run directly, the target file must be provided.  If fiberassign is run from the python wrapper in desisim, an mtl file is provided by \file{make\_mtl.py} in desitarget.
+\item Read input files for targets, sky fibers, and standard stars.   The location of the files is specified through \file{F.Targfile,  F.SStarsfile, F.Skyfile}.  If fiberassign is run through the python code in desisim, the location is specified in the calling sequence for quicksurvey, which specifies the location of a ``features'' file.  Reading the features file is actually the first action and sets out many of the parameters (F.xxx) for the code .  Currently (Feb. 2017) \file{F.Targfile} is \newline \file{/project/projectdirs/desi/datachallenge/quicksurvey2016/input/dark/targets.fits}.
 
 \item Combine these into a structure of type \struc{MTL}.  Each galaxy carries a number of characteristics as specified in \file{structs.cpp}, including RA, dec, and priority.  
  The complete list read by fiberassign: TARGETID, RA, DEC, DESI\_TARGET, MWS\_TARGET, BGS\_TARGET, OBSCONDITIONS, BRICKNAME, SUBPRIORITY, PRIORITY.  The fiberassign code doesn't know the true nature or redshifts of the targets.   TARGETID enables us to relate a single galaxy appearing in several files.  
 
 \item Determine the number of different priorities and create priority classes, collections of targets all of which have the same priority.  For example, there might be just three for ELGs, LRGs, and QSOs.  
-\item Read the file containing the locations of the positioners in the focal plane.  Determine which fibers are neighbors and note which petal each fiber is on. 
+\item Read the file containing the locations of the positioners in the focal plane.  Determine which fibers are neighbors and note which petal each fiber is on.
 \item Read the RA and dec of the centers of each of the 10,000 or so plates (tiles), i.e. the centers of the fields to be observed.  In addition, read \var{IN\_DESI}, specifying whether a tile is in the footprint, \var{TILEID}, \var{OBSCONDITIONS}, specifying under which conditions the tile may be observed,
 obsconditions:
 \begin{itemize}
@@ -88,10 +88,10 @@ pairs \var{(j,k)}.
 This establishes many of the basic features of the code.
 \begin{itemize}
 \item \func{read\_MTLfile} reads a fits file, extracting for each target, among other things,  the \var{targetid} (should be a long long),\var{numobs} (the number of observations remaining to be taken), \var{RA}, \var{dec} \var{priority}, \var{subpriority} (a random number that is permanently affixed to this target).
-\item \func{read\_fiber\_positions} does that, in x,y coordinates in mm. Fiber positioners are in \class{fpos}, whose members are \var{fib\_num}, the immutable number of the fiber, which may or may not be its position in the list being read, \var{fp\_x} and \var{fp\_y}, the x and y coordinates in the focal plane in mm (roughly -400$<x,y<$400), \var{spectrom}, the spectrometer number (0-9) to which this fiber is connected.  After the fiber locations are read, we first re-order the fibers by their true number, \var{fib\_num}.  We then compute 
-\var{N[i]}  for fiber $i$, the list of all other fibers within a distance \var{F.NeighborRad} and
-the  list \var{fibers\_of\_sp[k]} of fibers that go to spectrometer $k$ (or petal) 0, 1,...9
-\item \func{read\_plate\_centers} gets the tile-id,  RA and dec, for each tile and the pass (0 - 4 or 1-5?) to which it
+\item \func{read\_fiber\_positions} does that, in x,y coordinates in mm. Each fiber position takes up two entries in the list of fiber positions.
+\item \func{get\_neighbors} \var{N[i]}  for fiber $i$ is list of all other fibers within a distance \var{F.NeighborRad}.
+\item \func{compute\_fibsofsp}  gives list \var{fibers\_of\_sp[k}]of fibers that go to spectrometer $k$ (or petal) 0, 1,...9
+\item \func{read\_plate\_centers} gets the tileid,  RA and dec, for each tile and the pass (0 - 4 or 1-5?) to which it
  belongs.
  \item A mapping, \var{invert\_tile}, between the true tileid and where it is in the list of tiles.
 
@@ -317,13 +317,16 @@ Miscellaneous tools for list, tables, etc.
 
 \subsection{\file{structs.h}}
 \begin{itemize}
-\item \class{FP}
+\item \class{PP}
 	Plate parameters:
 	\begin{itemize}
-		\item \var{fp\_x, fp\_y} fiber positions (x,y) in mm.
+		\item \var{fp} fiber positions (x,y) in mm.
 		\item  \var{spectrom} All spectrometer assignments of fibers.	
 		\item \var{fibers\_of\_sp} fibers associated with a spectrometer.
 		\item \var{N} fibers that neighbor fiber k.
+		\item \func{read\_fiber\_positions}
+		\item \func{get\_neighbors}
+		\item \func{fibs\_of\_some\_pet} fibers of a petal
 		\item \var{coords} coordinates (x,y) of fiber k
 		\end{itemize}
 \item \class{galaxy} contains truth information

--- a/src/fiberassign.cpp
+++ b/src/fiberassign.cpp
@@ -83,23 +83,15 @@ int main(int argc, char **argv) {
 
     init_time_at(time,"# Start positioners",t);
     // fiber positioners
-    PP pp;
-    pp.read_fiber_positions(F); 
-    std::vector<int> spectrom_init=pp.spectrom;
-    pp.spectrom=sort_by_fiber_number(pp,spectrom_init);
-    printf("sorted positioners\n");
-    std::cout.flush();
-    Dlist fp_init=pp.fp;
-    pp.fp=sort_doublet_by_fiber_number(pp,fp_init);
     
+    FP pp =read_fiber_positions(F); 
     //order the fibers by their fiber number (fib_num) not simply order in list
     //need to fix spectrom (List) and fp
     
-    F.Nfiber = pp.fp.size()/2; //each fiber has two co-ordinates so divide by two
-    F.Npetal = max(pp.spectrom)+1;//spectrometers run 0 to 9
-    F.Nfbp = (int) (F.Nfiber/F.Npetal);// fibers per petal = 500
-    pp.get_neighbors(F); //list of all fibers within F.NeighborRad of given fiber
-    pp.compute_fibsofsp(F);//list of fibers on each spectrometer
+    F.Nfiber = pp.size(); //each fiber has two co-ordinates so divide by two
+    F.Npetal = 10;//spectrometers run 0 to 9 unless pacman
+    F.Nfbp = F.Nfiber/F.Npetal;// fibers per petal = 500
+
     print_time(time,"# ..posiioners  took :");
     //
     init_time_at(time,"# Start plates",t);

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -25,7 +25,7 @@
     Time t; // t for global, time for local
     
 // Collecting information from input -------------------------------------------------------------------------------------
-void collect_galaxies_for_all(const MTL& M, const htmTree<struct target>& T, Plates& P, const PP& pp, const Feat& F) {
+void collect_galaxies_for_all(const MTL& M, const htmTree<struct target>& T, Plates& P, const FP& pp, const Feat& F) {
     //provides list of galaxies available to fiber k on tile j: P[j].av_gals[k]
     
     init_time(t,"# Begin collecting available galaxies");
@@ -46,6 +46,7 @@ void collect_galaxies_for_all(const MTL& M, const htmTree<struct target>& T, Pla
             // Takes neighboring galaxies that fall on this plate
             std::vector<int> nbr = T.near(M,p.nhat,rad);
             // Projects thoses galaxies on the focal plane
+	    printf(" size of nbr  %d \n",nbr.size());
             Onplates O;
             for (int gg=0; gg<nbr.size(); gg++) {
                 int g = nbr[gg];
@@ -60,13 +61,18 @@ void collect_galaxies_for_all(const MTL& M, const htmTree<struct target>& T, Pla
             KDtree<struct onplate> kdT(O,2);
             // For each fiber, finds all reachable galaxies within patrol radius, thanks to the tree
             for (int k=0; k<F.Nfiber; k++) {
-                dpair X = pp.coords(k);
-                std::vector<int> gals = kdT.near(&(pp.fp[2*k]),0.0,F.PatrolRad);
+	      dpair X = pp[k].coords;
+	      std::vector<double>posit={pp[k].fp_x,pp[k].fp_y};
+	      std::vector<int> gals = kdT.near(&posit[0],0.0,F.PatrolRad);
+	      if(k<10 && j<10){
+		printf("j % d k %d pp[k].coords.f %f  pp[k].coords.s %f  size %d\n",j,k, pp[k].coords.f,  pp[k].coords.s,gals.size() );
+	      }	
                 for (int g=0; g<gals.size(); g++) {
                     dpair Xg = projection(gals[g],j,M,P);
                     if (sq(Xg,X)<sq(F.PatrolRad)){
                         P[j].av_gals[k].push_back(gals[g]);
-                        int q=pp.spectrom[k];
+                        int q=pp[k].spectrom;
+
                         //better to make SS & SF assigned to fibers
 
                         if(M[gals[g]].SS){
@@ -110,12 +116,12 @@ bool int_pairCompare(const std::pair<int, int>& firstElem, const std::pair<int, 
 	return firstElem.first < secondElem.first;//used to sort fibers by fib_num
 }
 
-List sort_by_fiber_number(PP & pp,std::vector<int> init){
+List sort_by_fiber_number(FP & pp,std::vector<int> init){
   //sorts all the Lists associated with pp by fiber number
   List out;
   std::vector<std::pair<int,int> >pairs;
-  for(int f=0;f<pp.fib_num.size();++f){
-    std::pair <int,int> this_pair (pp.fib_num[f],f);
+  for(int f=0;f<pp.size();++f){
+    std::pair <int,int> this_pair (pp[f].fib_num,f);
     pairs.push_back(this_pair);
   }
   std::sort(pairs.begin(),pairs.end(),int_pairCompare);
@@ -124,26 +130,7 @@ List sort_by_fiber_number(PP & pp,std::vector<int> init){
   }			 
   return out;
 }
-Dlist sort_doublet_by_fiber_number(PP & pp,Dlist init ){
-  //sorts all the Dlists associated with pp by fiber number
-  //needed for fp which has (x,y) entries
-  Dlist out;
-  std::vector<std::pair<int,int> >pairs;
-  for(int f=0;f<pp.fib_num.size();++f){
-    std::pair <int,int> this_pair (pp.fib_num[f],f);
-    pairs.push_back(this_pair);
-  }
-  printf("sorted by fib_num\n");
-  std::cout.flush();
-  std::sort(pairs.begin(),pairs.end(),int_pairCompare);
-  printf("sorted fp\n");
-  std::cout.flush();
-  for(int f=0;f<init.size()/2;++f){
-    out.push_back(init[2*pairs[f].second]);
-    out.push_back(init[2*pairs[f].second+1]);
-  }
-  return out;
-} 
+
      
 
 void collect_available_tilefibers(MTL& M, const Plates& P, const Feat& F) { 
@@ -170,9 +157,9 @@ void collect_available_tilefibers(MTL& M, const Plates& P, const Feat& F) {
 
 // Assignment sub-functions -------------------------------------------------------------------------------------
 // Allow (j,k) to observe g ?
-inline bool ok_assign_g_to_jk(int g, int j, int k, const Plates& P, const MTL& M, const PP& pp, const Feat& F, const Assignment& A) {
+inline bool ok_assign_g_to_jk(int g, int j, int k, const Plates& P, const MTL& M, const FP& pp, const Feat& F, const Assignment& A) {
 
-    if (F.Collision) for (int i=0; i<pp.N[k].size(); i++) if (g==A.TF[j][pp.N[k][i]]) return false; 
+    if (F.Collision) for (int i=0; i<pp[k].N.size(); i++) if (g==A.TF[j][pp[k].N[i]]) return false; 
     // Avoid 2 neighboring fibers observe the same galaxy (can happen only when Collision=true)
     if (A.find_collision(j,k,g,pp,M,P,F)!=-1){
         return false;} // No collision
@@ -182,11 +169,11 @@ inline bool ok_assign_g_to_jk(int g, int j, int k, const Plates& P, const MTL& M
 }
 
 // makes sure we don't exceed limit on SS and SF
-inline bool ok_for_limit_SS_SF(int g, int j, int k, const MTL& M, const Plates& P, const PP& pp, const Feat& F){
+inline bool ok_for_limit_SS_SF(int g, int j, int k, const MTL& M, const Plates& P, const FP& pp, const Feat& F){
      bool is_SF=M[g].SF;
-    bool too_many_SF=P[j].SF_in_petal[pp.spectrom[k]]>F.MaxSF-1;
+    bool too_many_SF=P[j].SF_in_petal[pp[k].spectrom]>F.MaxSF-1;
     bool is_SS=M[g].SS;
-    bool too_many_SS=P[j].SS_in_petal[pp.spectrom[k]]>F.MaxSS-1;
+    bool too_many_SS=P[j].SS_in_petal[pp[k].spectrom]>F.MaxSS-1;
     return !(is_SF && too_many_SF)&&!(is_SS && too_many_SS);
 }
 
@@ -195,7 +182,7 @@ inline bool ok_for_limit_SS_SF(int g, int j, int k, const MTL& M, const Plates& 
 // Find, for (j,k), find the best galaxy it can reach among the possible ones
 // Null list means you can take all possible kinds, otherwise you can only take, for the galaxy, a kind among this list
 // Not allowed to take the galaxy of id no_g
-inline int find_best(int j, int k, const MTL& M, const Plates& P, const PP& pp, const Feat& F, const Assignment& A) {        
+inline int find_best(int j, int k, const MTL& M, const Plates& P, const FP& pp, const Feat& F, const Assignment& A) {        
     int best = -1; int mbest = -1; int pbest = 0; double subpbest = 0.;
     List av_gals = P[j].av_gals[k];
     // For all available galaxies
@@ -232,7 +219,7 @@ inline int find_best(int j, int k, const MTL& M, const Plates& P, const PP& pp, 
 }
 
 // Tries to assign the fiber (j,k)
-inline int assign_fiber(int j, int k, MTL& M, Plates& P, const PP& pp, const Feat& F, Assignment& A) {
+inline int assign_fiber(int j, int k, MTL& M, Plates& P, const FP& pp, const Feat& F, Assignment& A) {
     if (A.is_assigned_tf(j,k)) return -1;
     int best = find_best(j,k,M,P,pp,F,A);
     if (best!=-1) A.assign(j,k,best,M,P,pp);
@@ -241,7 +228,7 @@ inline int assign_fiber(int j, int k, MTL& M, Plates& P, const PP& pp, const Fea
 
 
 
-inline int assign_galaxy(int g,  MTL& M, Plates& P, const PP& pp, const Feat& F, Assignment& A, int jstart) {
+inline int assign_galaxy(int g,  MTL& M, Plates& P, const FP& pp, const Feat& F, Assignment& A, int jstart) {
     // Tries to assign the galaxy g to one of the used plates after jstart
     //jstart runs possibly to F.Nplate
     int jb = -1; int kb = -1; int unusedb = -1;
@@ -252,7 +239,7 @@ inline int assign_galaxy(int g,  MTL& M, Plates& P, const PP& pp, const Feat& F,
         int k = av_tfs[tfs].s;
         // Check if the assignment is possible, if ok, if the tf is not used yet, and if the plate is in the list
         if (jstart<j && !A.is_assigned_tf(j,k) && ok_assign_g_to_jk(g,j,k,P,M,pp,F,A)&&ok_for_limit_SS_SF(g,j,k,M,P,pp,F)) {
-            int unused = A.unused[j][pp.spectrom[k]];//unused fibers on this petal
+            int unused = A.unused[j][pp[k].spectrom];//unused fibers on this petal
             if (unusedb<unused) {
                 jb = j; kb = k; unusedb = unused;//observe this galaxy by fiber on petal with most free fibefs
             }
@@ -266,7 +253,7 @@ inline int assign_galaxy(int g,  MTL& M, Plates& P, const PP& pp, const Feat& F,
 
 // Takes an unassigned fiber and tries to assign it with the "improve" technique described in the doc
 // not used for SS or SF   
-inline int improve_fiber(int jused_begin, int jused, int k, MTL& M, Plates& P, const PP& pp, const Feat& F, Assignment& A, int no_g=-1) {
+inline int improve_fiber(int jused_begin, int jused, int k, MTL& M, Plates& P, const FP& pp, const Feat& F, Assignment& A, int no_g=-1) {
 
     int j=A.suborder[jused];
     if (!A.is_assigned_tf(j,k)) { // Unused tilefiber (j,k)
@@ -294,7 +281,7 @@ inline int improve_fiber(int jused_begin, int jused, int k, MTL& M, Plates& P, c
                             if (best!=-1 && (A.is_assigned_jg(j,g,M,F)==-1 || jp==j)) {
                                 int prio = M[g].t_priority;
                                 int m = M[g].nobs_remain;
-                                int unused = A.unused[jp][pp.spectrom[kp]]; // We take the most unused
+                                int unused = A.unused[jp][pp[k].spectrom]; // We take the most unused
                                 if (prio>pb || (prio==pb && m>mb) || (prio==pb && m==mb && unused>unusedb)) {
                                     gb = g; bb = best; jpb = jp; kpb = kp; mb = m; pb = prio; unusedb = unused;
                             }}}}}}
@@ -312,7 +299,7 @@ inline int improve_fiber(int jused_begin, int jused, int k, MTL& M, Plates& P, c
 // Assignment functions ------------------------------------------------------------------------------------------
 // Assign fibers naively
 
-void simple_assign(MTL &M, Plates& P, const PP& pp, const Feat& F, Assignment& A) {
+void simple_assign(MTL &M, Plates& P, const FP& pp, const Feat& F, Assignment& A) {
     Time t;
     init_time(t,"# Begin simple assignment :");
     int countme=0;
@@ -328,7 +315,7 @@ void simple_assign(MTL &M, Plates& P, const PP& pp, const Feat& F, Assignment& A
     printf(" countme %d \n",countme);
 }
 
-void improve( MTL& M, Plates&P, const PP& pp, const Feat& F, Assignment& A, int jused_start) {
+void improve( MTL& M, Plates&P, const FP& pp, const Feat& F, Assignment& A, int jused_start) {
     //jstart is in list from 0 to F.NUsedplate
     Time t;
     init_time(t,"# Begin improve :");
@@ -348,7 +335,7 @@ void improve( MTL& M, Plates&P, const PP& pp, const Feat& F, Assignment& A, int 
 
 
 
-void new_replace( int j, int p, MTL& M, Plates& P, const PP& pp, const Feat& F, Assignment& A) {
+void new_replace( int j, int p, MTL& M, Plates& P, const FP& pp, const Feat& F, Assignment& A) {
     // do standard stars,going through priority classes from least to most
     //keep track of reassignments
 
@@ -378,7 +365,7 @@ void new_replace( int j, int p, MTL& M, Plates& P, const PP& pp, const Feat& F, 
 		std::vector<int> sorted_could_be_replaced;
                 for(int i=0;i<tfs.size() && done==0;++i){//al the tile-fibers that can reach this standard star
 
-                    if(tfs[i].f==j&&pp.spectrom[tfs[i].s]==p){//a tile fiber from this petal
+                    if(tfs[i].f==j&&pp[tfs[i].s].spectrom==p){//a tile fiber from this petal
                         int k=tfs[i].s;//we know g can be reached by this petal of plate j and fiber k
                         int g_old=A.TF[j][k];//what is now at (j,k)  g_old can't be -1 or we would have used it already in assign_sf
 			//require that this galaxy is used only once to keep things simple
@@ -433,7 +420,7 @@ void new_replace( int j, int p, MTL& M, Plates& P, const PP& pp, const Feat& F, 
 		std::vector<int> could_be_replaced; 
                 for(int i=0;i<tfs.size() && done==0;++i){
 
-                    if(tfs[i].f==j&&pp.spectrom[tfs[i].s]==p){//g is accesible to j,k
+                    if(tfs[i].f==j&&pp[tfs[i].s].spectrom==p){//g is accesible to j,k
                         int k=tfs[i].s;//we know g can be reached by this petal of plate j and fiber k
                         int g_old=A.TF[j][k];//what is now at (j,k)
 
@@ -466,7 +453,7 @@ void new_replace( int j, int p, MTL& M, Plates& P, const PP& pp, const Feat& F, 
 
 
 
-void assign_unused(int j, MTL& M, Plates& P, const PP& pp, const Feat& F, Assignment& A) {
+void assign_unused(int j, MTL& M, Plates& P, const FP& pp, const Feat& F, Assignment& A) {
     // Tries to assign remaining fibers in tile jth tile with galaxies on it
     //even taking objects observed later
     //js is a tile with galaxies on it
@@ -511,7 +498,7 @@ void assign_unused(int j, MTL& M, Plates& P, const PP& pp, const Feat& F, Assign
 }
 
 
-void assign_sf_ss(int j, MTL& M, Plates& P, const PP& pp, const Feat& F, Assignment& A) {
+void assign_sf_ss(int j, MTL& M, Plates& P, const FP& pp, const Feat& F, Assignment& A) {
     //assigns sky fibers and standard stars to unused fibers
     bool thisgalaxy=false;
     for (int ppet=0; ppet<F.Npetal; ppet++) {
@@ -563,7 +550,7 @@ void assign_sf_ss(int j, MTL& M, Plates& P, const PP& pp, const Feat& F, Assignm
 
 }
 
-void redistribute_tf(MTL& M, Plates&P, const PP& pp, const Feat& F, Assignment& A, int jused_start) {
+void redistribute_tf(MTL& M, Plates&P, const FP& pp, const Feat& F, Assignment& A, int jused_start) {
     //diagnostic
     printf("start redistribute \n");
     Time t;
@@ -576,12 +563,12 @@ void redistribute_tf(MTL& M, Plates&P, const PP& pp, const Feat& F, Assignment& 
             if (Done[jused][k]==0) {
                 int g = A.TF[j][k];//current assignment of (j,k)  only look if assigned
                 if (g!=-1 && !M[g].SS && !M[g].SF) {
-                    int jpb = -1; int kpb = -1; int unusedb = A.unused[j][pp.spectrom[k]];
+                    int jpb = -1; int kpb = -1; int unusedb = A.unused[j][pp[k].spectrom];
                     Plist av_tfs = M[g].av_tfs;  //all possible tile fibers for this galaxy
                     for (int i=0; i<av_tfs.size(); i++) {
                         int jp = av_tfs[i].f;
                         int kp = av_tfs[i].s;
-                        int unused = A.unused[jp][pp.spectrom[kp]];//unused for jp, spectrom[kp]
+                        int unused = A.unused[jp][pp[kp].spectrom];//unused for jp, spectrom[kp]
                         if(A.inv_order[jp]!=-1)//necessary because underdense targets may leave some plates unused
                         {
                         if(A.inv_order[jp]>F.NUsedplate || A.inv_order[jp]<0)printf("**out range  %d\n",A.inv_order[jp]);
@@ -621,7 +608,7 @@ void redistribute_tf(MTL& M, Plates&P, const PP& pp, const Feat& F, Assignment& 
 
 
 
-void display_results(str outdir, const Gals& Secret,const MTL& M, const Plates& P, const PP& pp, Feat& F, const Assignment& A,  int last_tile,bool latex) {
+void display_results(str outdir, const Gals& Secret,const MTL& M, const Plates& P, const FP& pp, Feat& F, const Assignment& A,  int last_tile,bool latex) {
 	printf("# Results :\n");
 
 
@@ -874,7 +861,7 @@ void display_results(str outdir, const Gals& Secret,const MTL& M, const Plates& 
 
 
 
-void fa_write (int j, str outdir, const MTL & M, const Plates & P, const PP & pp, const Feat & F, const Assignment & A) {
+void fa_write (int j, str outdir, const MTL & M, const Plates & P, const FP & pp, const Feat & F, const Assignment & A) {
     
     // generate a quiet NaN to use for invalid entries.  We cannot
     // guarantee that we have C++11, so we can't use the nice functions
@@ -1178,7 +1165,7 @@ void fa_write (int j, str outdir, const MTL & M, const Plates & P, const PP & pp
 }
 
 
-void pyplotTile(int jused, str directory, const Gals& Secret, const MTL& M,const Plates& P, const PP& pp, const Feat& F, const Assignment& A) {
+void pyplotTile(int jused, str directory, const Gals& Secret, const MTL& M,const Plates& P, const FP& pp, const Feat& F, const Assignment& A) {
     std::vector<char> colors;
     colors.resize(F.Categories);
     colors[0] = 'k'; colors[1] = 'g'; colors[2] = 'r'; colors[3] = 'b'; colors[4] = 'm'; colors[5] = 'y'; colors[6] = 'w'; colors[7] = 'c';
@@ -1187,7 +1174,7 @@ void pyplotTile(int jused, str directory, const Gals& Secret, const MTL& M,const
 
     int j=A.suborder[jused];
     for (int k=0; k<F.Nfiber; k++) {
-        dpair O = pp.coords(k);
+      dpair O = pp[k].coords;
         int g = A.TF[j][k];
         if (g!=-1) {
             dpair Ga = projection(g,j,M,P);

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -46,7 +46,7 @@ void collect_galaxies_for_all(const MTL& M, const htmTree<struct target>& T, Pla
             // Takes neighboring galaxies that fall on this plate
             std::vector<int> nbr = T.near(M,p.nhat,rad);
             // Projects thoses galaxies on the focal plane
-	    printf(" size of nbr  %d \n",nbr.size());
+	   
             Onplates O;
             for (int gg=0; gg<nbr.size(); gg++) {
                 int g = nbr[gg];
@@ -64,9 +64,7 @@ void collect_galaxies_for_all(const MTL& M, const htmTree<struct target>& T, Pla
 	      dpair X = pp[k].coords;
 	      std::vector<double>posit={pp[k].fp_x,pp[k].fp_y};
 	      std::vector<int> gals = kdT.near(&posit[0],0.0,F.PatrolRad);
-	      if(k<10 && j<10){
-		printf("j % d k %d pp[k].coords.f %f  pp[k].coords.s %f  size %d\n",j,k, pp[k].coords.f,  pp[k].coords.s,gals.size() );
-	      }	
+
                 for (int g=0; g<gals.size(); g++) {
                     dpair Xg = projection(gals[g],j,M,P);
                     if (sq(Xg,X)<sq(F.PatrolRad)){

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -279,7 +279,7 @@ inline int improve_fiber(int jused_begin, int jused, int k, MTL& M, Plates& P, c
                             if (best!=-1 && (A.is_assigned_jg(j,g,M,F)==-1 || jp==j)) {
                                 int prio = M[g].t_priority;
                                 int m = M[g].nobs_remain;
-                                int unused = A.unused[jp][pp[k].spectrom]; // We take the most unused
+                                int unused = A.unused[jp][pp[kp].spectrom]; // We take the most unused
                                 if (prio>pb || (prio==pb && m>mb) || (prio==pb && m==mb && unused>unusedb)) {
                                     gb = g; bb = best; jpb = jp; kpb = kp; mb = m; pb = prio; unusedb = unused;
                             }}}}}}

--- a/src/global.h
+++ b/src/global.h
@@ -20,49 +20,49 @@
 
 // Collect -----------------------------------------------------------
 // From the HTM tree, collects for each fiber and for each plate, the available galaxies
-void collect_galaxies_for_all(const MTL& M, const htmTree<struct target>& T, Plates& P, const PP& pp, const Feat& F);
+void collect_galaxies_for_all(const MTL& M, const htmTree<struct target>& T, Plates& P, const FP& pp, const Feat& F);
 
 // From the previous computations, computes the inverse map, that is to say, for each target, computes the tile-fibers which can reach it
 void collect_available_tilefibers(MTL& M, const Plates& P, const Feat& F);
 
 // Assignment functions ----------------------------------------------
 // First simple assignment plan, executing find_best on every plate on every fiber
-void simple_assign(MTL& M, Plates& P, const PP& pp, const Feat& F, Assignment& A);
+void simple_assign(MTL& M, Plates& P, const FP& pp, const Feat& F, Assignment& A);
 
 // More fine first assignment plan, 
 
-void improve(MTL& M, Plates&P, const PP& pp, const Feat& F, Assignment& A, int jstart);
+void improve(MTL& M, Plates&P, const FP& pp, const Feat& F, Assignment& A, int jstart);
 
-void improve_from_kind(MTL& M, const Plates&P, const PP& pp, const Feat& F, Assignment& A, str kind, int next=-1);
+void improve_from_kind(MTL& M, const Plates&P, const FP& pp, const Feat& F, Assignment& A, str kind, int next=-1);
 
-void update_plan_from_one_obs(int j, const Gals& G, MTL& M, Plates&P, const PP& pp, const Feat& F, Assignment& A);
+void update_plan_from_one_obs(int j, const Gals& G, MTL& M, Plates&P, const FP& pp, const Feat& F, Assignment& A);
 
-//void redistribute_tf(MTL& M, Plates&P, const PP& pp, const Feat& F, Assignment& A, int next=-1);
-void redistribute_tf(MTL& M, Plates&P, const PP& pp, const Feat& F, Assignment& A, int jstart);
-void assign_sf_ss(int j, MTL& M, Plates& P, const PP& pp, const Feat& F, Assignment& A);
+//void redistribute_tf(MTL& M, Plates&P, const FP& pp, const Feat& F, Assignment& A, int next=-1);
+void redistribute_tf(MTL& M, Plates&P, const FP& pp, const Feat& F, Assignment& A, int jstart);
+void assign_sf_ss(int j, MTL& M, Plates& P, const FP& pp, const Feat& F, Assignment& A);
 
-void assign_unused(int j, MTL& M,  Plates& P, const PP& pp, const Feat& F, Assignment& A);
+void assign_unused(int j, MTL& M,  Plates& P, const FP& pp, const Feat& F, Assignment& A);
 
 void diagnostic(const Gals& G, Feat& F, const Assignment& A);
 // Results functions --------------------------------------------------
 
-void display_results(str outdir, const Gals& G, const MTL& M, const Plates &P, const PP& pp, Feat& F, const Assignment& A, int last_tile, bool latex=false);
+void display_results(str outdir, const Gals& G, const MTL& M, const Plates &P, const FP& pp, Feat& F, const Assignment& A, int last_tile, bool latex=false);
 
 void diagnostic(const MTL& M, const Gals& G, Feat& F, const Assignment& A);
 
-void write_FAtile_ascii(int j, str outdir, const MTL& M, const Plates& P, const PP& pp, const Feat& F, const Assignment& A);
+void write_FAtile_ascii(int j, str outdir, const MTL& M, const Plates& P, const FP& pp, const Feat& F, const Assignment& A);
 
 
-void fa_write(int j, str outdir, const MTL& M, const Plates& P, const PP& pp, const Feat& F, const Assignment& A);
+void fa_write(int j, str outdir, const MTL& M, const Plates& P, const FP& pp, const Feat& F, const Assignment& A);
 
-void write_save_av_gals(int j, str outdir, const MTL& M, const Plates& P, const PP& pp, const Feat& F);
+void write_save_av_gals(int j, str outdir, const MTL& M, const Plates& P, const FP& pp, const Feat& F);
 
-void pyplotTile(int j, str fname, const Gals& Secret, const MTL& M, const Plates& P, const PP& pp, const Feat& F, const Assignment& A);
+void pyplotTile(int j, str fname, const Gals& Secret, const MTL& M, const Plates& P, const FP& pp, const Feat& F, const Assignment& A);
 
 void overlappingTiles(str fname, const Feat& F, const Assignment& A);
 #endif
 bool myorder(int i, int j);
 
 
-List sort_by_fiber_number(PP & pp,std::vector<int> v);
-Dlist sort_doublet_by_fiber_number(PP & pp, Dlist v);
+List sort_by_fiber_number(FP & pp,std::vector<int> v);
+Dlist sort_doublet_by_fiber_number(FP & pp, Dlist v);

--- a/src/structs.h
+++ b/src/structs.h
@@ -15,8 +15,33 @@
 #include        <map>
 #include        "feat.h"
 #include <cstdint>
+// fiber-positioner  -----------------------------------
+class fpos {
+    public:
+    int fib_num; //number of fiber(!)  not positioner, read from fibpos file
+    double fp_x; //x position in mm of positioner
+    double fp_y; //y position in mm of positioner
+    int spectrom;//which spectrometer 0 - 9
+    std::vector<int> N;// Identify neighboring positioners : neighbors of fiber k are N[k] 
+    dpair coords; 
+};
+
+class FP  : public std::vector<struct fpos>{ 
+    public:
+
+
+    void get_neighbors(const Feat& F);
+    Table fibers_of_sp;// Inv map of spectrom, fibers_of_sp[sp] are fibers of spectrom sp, redundant
+
+};
+
+FP  read_fiber_positions(const Feat& F);
+
+
+
 
 // PP ---------------------------------------------------
+/*
 class PP { // PP for plate parameters
     public:
     Dlist fp; // All fiber positions (x,y) in mm
@@ -33,7 +58,7 @@ class PP { // PP for plate parameters
     List fibs_of_same_pet(int k) const;
     dpair coords(int k) const; // Coords of fiber k
 };
-
+*/
 // galaxy truth -------------------------------------------
 class galaxy {
     public:
@@ -108,7 +133,7 @@ class plate {
     std::vector<int> SF_in_petal;
     bool is_used;  //true if tile has some galaxies within reach
     uint16_t obsconditions; // mask defining the kind of program (DARK, BRIGHT, GRAY)
-    List av_gals_plate(const Feat& F, const MTL& M,const PP& pp) const; // Av gals of the plate
+    List av_gals_plate(const Feat& F, const MTL& M,const FP& pp) const; // Av gals of the plate
 };
 class Plates : public std::vector<struct plate> {};
 
@@ -138,12 +163,12 @@ class Assignment {
     //// ----- Methods
     Assignment(const MTL& M, const Feat& F);
     ~Assignment();
-    void assign(int j, int k, int g,  MTL& M, Plates& P, const PP& pp);
-    void unassign(int j, int k, int g, MTL& M, Plates& P, const PP& pp);
-    int find_collision(int j, int k, int g, const PP& pp, const MTL& M, const Plates& P, const Feat& F, int col=-1) const;
-    bool find_collision(int j, int k, int kn, int g, int gn, const PP& pp, const MTL& M, const Plates& P, const Feat& F, int col=-1) const;
-    int is_collision(int j, int k, const PP& pp, const MTL& M, const Plates& P, const Feat& F) const;
-    void verif(const Plates& P, const MTL& M, const PP& pp, const Feat& F) const; // Verif mappings are right
+    void assign(int j, int k, int g,  MTL& M, Plates& P, const FP& pp);
+    void unassign(int j, int k, int g, MTL& M, Plates& P, const FP& pp);
+    int find_collision(int j, int k, int g, const FP& pp, const MTL& M, const Plates& P, const Feat& F, int col=-1) const;
+    bool find_collision(int j, int k, int kn, int g, int gn, const FP& pp, const MTL& M, const Plates& P, const Feat& F, int col=-1) const;
+    int is_collision(int j, int k, const FP& pp, const MTL& M, const Plates& P, const Feat& F) const;
+    void verif(const Plates& P, const MTL& M, const FP& pp, const Feat& F) const; // Verif mappings are right
     int is_assigned_jg(int j, int g) const;
     int is_assigned_jg(int j, int g, const MTL& M, const Feat& F) const;
     bool is_assigned_tf(int j, int k) const; 
@@ -151,11 +176,11 @@ class Assignment {
     int nobs(int g, const MTL& M, const Feat& F, bool tmp=true) const; // Counts how many more times object should be observed. If tmp=true, return maximum for this kind (temporary information)
     //if tmp=false we actually know the true type from the start
     Plist chosen_tfs(int g, const Feat& F, int begin=0) const; // Pairs (j,k) chosen by g, amongst size plates from begin
-    int nkind(int j, int k, int kind, const MTL& M, const Plates& P, const PP& pp, const Feat& F, bool pet=false) const; // Number of fibers assigned to the kind "kind" on the petal of (j,k). If pet=true, we don't take k but the petal p directly instead
-    List fibs_of_kind(int kind, int j, int pet, const MTL& M, const PP& pp, const Feat& F) const; // Sublist of fibers assigned to a galaxy of type kind for (j,p)
+    int nkind(int j, int k, int kind, const MTL& M, const Plates& P, const FP& pp, const Feat& F, bool pet=false) const; // Number of fibers assigned to the kind "kind" on the petal of (j,k). If pet=true, we don't take k but the petal p directly instead
+    List fibs_of_kind(int kind, int j, int pet, const MTL& M, const FP& pp, const Feat& F) const; // Sublist of fibers assigned to a galaxy of type kind for (j,p)
     //not used
-    List sort_fibs_dens(int j, const List& fibs, const MTL& M, const Plates& P, const PP& pp, const Feat& F) const; // Sort this list of fibers by decreasing density
-    List fibs_unassigned(int j, int pet, const MTL& M, const PP& pp, const Feat& F) const; // Sublist of unassigned fibers for (j,p)
+    List sort_fibs_dens(int j, const List& fibs, const MTL& M, const Plates& P, const FP& pp, const Feat& F) const; // Sort this list of fibers by decreasing density
+    List fibs_unassigned(int j, int pet, const MTL& M, const FP& pp, const Feat& F) const; // Sublist of unassigned fibers for (j,p)
 
     // Update information
     //void update_nobsv_tmp_for_one(int j, const Feat& F);//update for plate j
@@ -163,16 +188,16 @@ class Assignment {
 
     // Used to compute results at the end
     //not used
-    Table infos_petal(int j, int pet, const MTL& M, const Plates& P, const PP& pp, const Feat& F) const;
+    Table infos_petal(int j, int pet, const MTL& M, const Plates& P, const FP& pp, const Feat& F) const;
     //not used
     List unused_f(const Feat& F) const; //gives total number of unused fibers
-    Table unused_fbp(const PP& pp, const Feat& F) const; // Unused fibers by petal
-    float colrate(const PP& pp, const MTL& M, const Plates& P, const Feat& F, int j=-1) const; // Get collision rate, j = plate number
+    Table unused_fbp(const FP& pp, const Feat& F) const; // Unused fibers by petal
+    float colrate(const FP& pp, const MTL& M, const Plates& P, const Feat& F, int j=-1) const; // Get collision rate, j = plate number
     int nobs_time(int g, int j, const Gals& Secret,const MTL& M, const Feat& F) const; // Know the number of remaining observations of g when the program is at the tile j, for pyplotTile
 
     int unused_f(int j, const Feat& F) const; // Number of unused fiber on the j'th plate
     //not used
-    int unused_fbp(int j, int k, const PP& pp, const Feat& F) const; // Number of unassigned fibers of the petal corresponding to (j,k)
+    int unused_fbp(int j, int k, const FP& pp, const Feat& F) const; // Number of unassigned fibers of the petal corresponding to (j,k)
     //not used
     void update_nobsv_tmp(const Feat& F);
 };


### PR DESCRIPTION
This version redesigns the fiber-positioner aspect of the code, making a class fpos for fiber-positioners and replacing the old PP class with FP as a vector of fpos.  Previously the coordinates of the positioners and the spectrometer assignments were simply vectors in the order the fiber-positioners were read-in.  This new structure will facilitate developments like accounting for broken fibers and stuck positioners.