### PR TITLE
Fix fiber location

### DIFF
--- a/src/fiberassign.cpp
+++ b/src/fiberassign.cpp
@@ -47,6 +47,7 @@ int main(int argc, char **argv) {
     //combine the three input files
     M=Targ;
     printf(" Target size %d \n",M.size());
+    std::cout.flush();
     //need to be able to match immutable target id to position in list
     std::map<long long,int> invert_target;
     std::map<long long,int>::iterator targetid_to_idx;

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -1021,7 +1021,7 @@ void fa_write (int j, str outdir, const MTL & M, const Plates & P, const FP & pp
                 int g = A.TF[j][fib];
                 
                 fiber_id[i] = fib;
-                positioner_id[i] = fib;
+                positioner_id[i] = pp[i].location;//previously absent 4/11/17
                 num_target[i] = P[j].av_gals[fib].size();
 
 

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -914,7 +914,7 @@ void fa_write (int j, str outdir, const MTL & M, const Plates & P, const FP & pp
     strcpy(tform[0], "J");
     strcpy(tunit[0], "");
     
-    strcpy(ttype[1], "POSITIONER");
+    strcpy(ttype[1], "LOCATION");
     strcpy(tform[1], "J");
     strcpy(tunit[1], "");
     

--- a/src/structs.cpp
+++ b/src/structs.cpp
@@ -394,10 +394,11 @@ FP  read_fiber_positions(const Feat& F) {
     printf("before reading positioners \n");
     std::cout.flush();
     while (fs.eof()==0) {
-        double x,y; int fiber,positioner,spectro,remove; 
-        std::istringstream(buf) >> fiber >> positioner >> spectro >> x >> y;
+        double x,y; int fiber,location,spectro,remove; 
+        std::istringstream(buf) >> fiber >> location >> spectro >> x >> y;
     try{
 	    fiber_pos.fib_num=fiber;
+	    fiber_pos.location=location;
             fiber_pos.fp_x=x;
             fiber_pos.fp_y=y;
             int sp = F.Pacman ? inv[spectro] : spectro;

--- a/src/structs.h
+++ b/src/structs.h
@@ -21,6 +21,7 @@ class fpos {
     int fib_num; //number of fiber(!)  not positioner, read from fibpos file
     double fp_x; //x position in mm of positioner
     double fp_y; //y position in mm of positioner
+    int location; //location of fiber
     int spectrom;//which spectrometer 0 - 9
     std::vector<int> N;// Identify neighboring positioners : neighbors of fiber k are N[k] 
     dpair coords; 


### PR DESCRIPTION
Fixes #70 so that POSITIONER != FIBER in output files.  Also renames output column from POSITIONER (the hardware object serial number) to LOCATION (the place where it is put in the focal plane).

Bob and I both verified that this changes only that column of the output; all other columns are identical.