### PR TITLE
fix uninitialized F.Npetal

### DIFF
--- a/src/fiberassign.cpp
+++ b/src/fiberassign.cpp
@@ -88,12 +88,12 @@ int main(int argc, char **argv) {
     init_time_at(time,"# Start positioners",t);
     // fiber positioners
     
+    F.Npetal = 10;//spectrometers run 0 to 9 unless pacman
     FP pp =read_fiber_positions(F); 
     //order the fibers by their fiber number (fib_num) not simply order in list
     //need to fix spectrom (List) and fp
     
     F.Nfiber = pp.size(); //each fiber has two co-ordinates so divide by two
-    F.Npetal = 10;//spectrometers run 0 to 9 unless pacman
     F.Nfbp = F.Nfiber/F.Npetal;// fibers per petal = 500
 
     print_time(time,"# ..posiioners  took :");

--- a/src/structs.cpp
+++ b/src/structs.cpp
@@ -397,13 +397,13 @@ FP  read_fiber_positions(const Feat& F) {
         double x,y; int fiber,location,spectro,remove; 
         std::istringstream(buf) >> fiber >> location >> spectro >> x >> y;
     try{
-	    fiber_pos.fib_num=fiber;
-	    fiber_pos.location=location;
+            fiber_pos.fib_num=fiber;
+            fiber_pos.location=location;
             fiber_pos.fp_x=x;
             fiber_pos.fp_y=y;
             int sp = F.Pacman ? inv[spectro] : spectro;
             fiber_pos.spectrom=spectro;  
-	    fiber_pos.coords=dpair(x,y);
+            fiber_pos.coords=dpair(x,y);
     } catch(std::exception& e) {myexception(e);}
     
         FibPos.push_back(fiber_pos);
@@ -440,15 +440,14 @@ FP  read_fiber_positions(const Feat& F) {
       FibPos.fibers_of_sp[FibPos[k].spectrom].push_back(k);
     }
 
-  
    //create table of Neighbors    
     for(int i=0; i<fiber_size; i++) {
         for (int j=0; j<fiber_size; j++) {
             if(i!=j) {
-	      if(sq(FibPos[i].fp_x-FibPos[j].fp_x)+sq(FibPos[i].fp_y-FibPos[j].fp_y) < sq(F.NeighborRad)) {
+                if(sq(FibPos[i].fp_x-FibPos[j].fp_x)+sq(FibPos[i].fp_y-FibPos[j].fp_y) < sq(F.NeighborRad)) {
                     FibPos[i].N.push_back(j); }
-	    }
-	}
+            }
+        }
     }   
     printf(" made neighbors \n");
     return (FibPos);


### PR DESCRIPTION
This PR fixes a bug where `read_fiber_positions(F)` was using `F.Npetal` to resize a vector prior to `F.Npetal = 10` being initilized.

I also converted some tabs to spaces while trying to read the code for debugging this.