### PR TITLE
fixed missing collision check for SS and SF

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,6 +6,7 @@ fiberassign change log
 
 * Fixed indexing bug for LOCATION output
 * added WIP bin/qa-fiberassign
+* Fixed missing collision checks (PR #81)
 
 0.5.1 (2019-06-30)
 ------------------

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -352,7 +352,7 @@ void new_replace( int j, int p, MTL& M, Plates& P, const FP& pp, const Feat& F, 
                         int g_old=A.TF[j][k];//what is now at (j,k)  g_old can't be -1 or we would have used it already in assign_sf
 			//require that this galaxy is used only once to keep things simple
                         if(g_old!=-1 && !M[g_old].SS && !M[g_old].SF && A.GL[g_old].size()==1){
-                            if (M[g_old].priority_class==c&&A.is_assigned_jg(j,g,M,F)==-1 && ok_for_limit_SS_SF(g,j,k,M,P,pp,F)){
+                            if (M[g_old].priority_class==c&&A.is_assigned_jg(j,g,M,F)==-1 && ok_for_limit_SS_SF(g,j,k,M,P,pp,F)&&ok_assign_g_to_jk(g,j,k,P,M,pp,F,A)){
                                 //right priority; this SS not already assigned on this plate
 			      could_be_replaced.push_back(g_old);
 			    }
@@ -407,7 +407,7 @@ void new_replace( int j, int p, MTL& M, Plates& P, const FP& pp, const Feat& F, 
                         int g_old=A.TF[j][k];//what is now at (j,k)
 
                         if(g_old!=-1 && !M[g_old].SS && !M[g_old].SF && A.GL[g_old].size()==1){
-                            if (M[g_old].priority_class==c&&A.is_assigned_jg(j,g,M,F)==-1 && ok_for_limit_SS_SF(g,j,k,M,P,pp,F)){
+                            if (M[g_old].priority_class==c&&A.is_assigned_jg(j,g,M,F)==-1 && ok_for_limit_SS_SF(g,j,k,M,P,pp,F)&&ok_assign_g_to_jk(g,j,k,P,M,pp,F,A)){
 			      could_be_replaced.push_back(g_old);
 			    }
 			}


### PR DESCRIPTION
Submitting a PR on behalf of @rncahn who debugged and fixed this (thanks!)

Fixes #80 by adding missing fiber collision checks that resulted in some targets being assigned to two different fibers on the same tile.

I independently verified that this fixes the problem reported in #80.