### PR TITLE
Keep RA,dec as double not float

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,7 @@ fiberassign change log
 ------------------
 
 * Guarantee that higher priority targets are placed first (PR #84)
+* Keep ra,dec as double precision, not single precision
 
 0.5.3 (2017-09-30)
 ------------------

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -885,8 +885,9 @@ void fa_write (int j, str outdir, const MTL & M, const Plates & P, const FP & pp
     // guarantee that we have C++11, so we can't use the nice functions
     // included in that standard...
     
-    const unsigned maxU = ~0;
-    const double qNan = *((double*)&maxU);
+    // const unsigned long maxU = ~0;
+    // const double qNan = *((double*)&maxU);
+    double qNan = nan("");
     
     // constants for the filename length and fixed object
     // type length

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -886,7 +886,7 @@ void fa_write (int j, str outdir, const MTL & M, const Plates & P, const FP & pp
     // included in that standard...
     
     const unsigned maxU = ~0;
-    const float qNan = *((float*)&maxU);
+    const double qNan = *((double*)&maxU);
     
     // constants for the filename length and fixed object
     // type length
@@ -1009,14 +1009,14 @@ void fa_write (int j, str outdir, const MTL & M, const Plates & P, const FP & pp
     fits_report_error(stderr, status);
 
     int tileid = P[j].tileid;
-    float tilera = P[j].tilera;
-    float tiledec = P[j].tiledec;
+    double tilera = P[j].tilera;
+    double tiledec = P[j].tiledec;
 
     fits_write_key(fptr, TINT, "TILEID", &(tileid), "Tile ID number", &status);
     fits_report_error(stderr, status);
-    fits_write_key(fptr, TFLOAT, "TILERA", &(tilera), "Tile RA [deg]", &status);
+    fits_write_key(fptr, TDOUBLE, "TILERA", &(tilera), "Tile RA [deg]", &status);
     fits_report_error(stderr, status);
-    fits_write_key(fptr, TFLOAT, "TILEDEC", &(tiledec), "Tile DEC [deg]", &status);
+    fits_write_key(fptr, TDOUBLE, "TILEDEC", &(tiledec), "Tile DEC [deg]", &status);
     fits_report_error(stderr, status);
 
     
@@ -1043,10 +1043,10 @@ void fa_write (int j, str outdir, const MTL & M, const Plates & P, const FP & pp
     long long desi_target[optimal];
     long long bgs_target[optimal];
     long long mws_target[optimal];
-    float ra[optimal];
-    float dec[optimal];
-    float x_focal[optimal];
-    float y_focal[optimal];
+    double ra[optimal];
+    double dec[optimal];
+    double x_focal[optimal];
+    double y_focal[optimal];
     //new
     int t_priority[optimal];
     
@@ -1132,16 +1132,16 @@ void fa_write (int j, str outdir, const MTL & M, const Plates & P, const FP & pp
         fits_write_col(fptr, TLONGLONG, 8, offset+1, 1, n, mws_target, &status);
         fits_report_error(stderr, status);
 
-        fits_write_col(fptr, TFLOAT, 9, offset+1, 1, n, ra, &status);
+        fits_write_col(fptr, TDOUBLE, 9, offset+1, 1, n, ra, &status);
         fits_report_error(stderr, status);
 
-        fits_write_col(fptr, TFLOAT, 10, offset+1, 1, n, dec, &status);
+        fits_write_col(fptr, TDOUBLE, 10, offset+1, 1, n, dec, &status);
         fits_report_error(stderr, status);
 
-        fits_write_col(fptr, TFLOAT, 11, offset+1, 1, n, x_focal, &status);
+        fits_write_col(fptr, TDOUBLE, 11, offset+1, 1, n, x_focal, &status);
         fits_report_error(stderr, status);
 
-        fits_write_col(fptr, TFLOAT, 12, offset+1, 1, n, y_focal, &status);
+        fits_write_col(fptr, TDOUBLE, 12, offset+1, 1, n, y_focal, &status);
         fits_report_error(stderr, status);
 
         fits_write_col(fptr, TSTRING, 13, offset+1, 1, n, bn_tmp, &status);

--- a/src/structs.cpp
+++ b/src/structs.cpp
@@ -299,7 +299,7 @@ MTL read_MTLfile(str readfile, const Feat& F, int SS, int SF){
       for(ii=0;ii<nrows;ii++){
         str xname;
 
-	// make sure ra is between 0 and 360
+        // make sure ra is between 0 and 360
         if (ra[ii]<   0.) {ra[ii] += 360.;}
         if (ra[ii]>=360.) {ra[ii] -= 360.;}
         if (dec[ii]<=-90. || dec[ii]>=90.) {
@@ -315,7 +315,7 @@ MTL read_MTLfile(str readfile, const Feat& F, int SS, int SF){
              Q.nhat[0]    = cos(phi)*sin(theta);
              Q.nhat[1]    = sin(phi)*sin(theta);
              Q.nhat[2]    = cos(theta);
-	     Q.obsconditions = obsconditions[ii];
+             Q.obsconditions = obsconditions[ii];
              Q.t_priority = priority[ii];//priority not present for sky fibers or standard stars
              Q.subpriority = subpriority[ii];
              Q.nobs_remain= numobs[ii];
@@ -329,7 +329,7 @@ MTL read_MTLfile(str readfile, const Feat& F, int SS, int SF){
              Q.bgs_target = bgs_target[ii];
              Q.SS=SS;
              Q.SF=SF;
-	     strncpy(Q.brickname, brickname[ii], 9);
+             strncpy(Q.brickname, brickname[ii], 9);
              try{M.push_back(Q);}catch(std::exception& e) {myexception(e);}
  
              bool in=false;

--- a/src/structs.h
+++ b/src/structs.h
@@ -85,8 +85,8 @@ class Onplates : public std::vector<struct onplate> {};
 class plate {
     public:
     int tileid;
-    float tilera;
-    float tiledec;
+    double tilera;
+    double tiledec;
     double nhat[3]; // Unit vector pointing to plate
     int ipass; // Pass
     Table av_gals; // av_gals[k] : available galaxies of fiber k


### PR DESCRIPTION
This PR fixes #87 by keeping RA,dec as double precision instead of single precision float.  Internally the structures already stored them as double, but the I/O routine accidentally took them via a float array on their way to writing them into the FITS file back as doubles (!).

I verified that:
* tile output RA,dec now matches the MTL input RA,dec
* fiberassignments themselves are unchanged from the previous code
* the output RA,dec differs from the previous code RA,dec only due to float/double rounding in the previous code