### PR TITLE
fix desitarget imports

### DIFF
--- a/bin/qa-fiberassign
+++ b/bin/qa-fiberassign
@@ -13,7 +13,7 @@ import numpy as np
 from astropy.table import Table, vstack
 from astropy.io import fits
 
-from desitarget import desi_mask
+from desitarget.targetmask import desi_mask
 import desimodel.io
 
 parser = argparse.ArgumentParser()

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -1,10 +1,10 @@
 fiberassign change log
 ======================
 
-0.7.0 (unreleased)
+0.7.1 (unreleased)
 ------------------
 
-* No changes yet.
+* Fixed `qa-fiberassign` imports for desitarget 0.19.0
 
 0.7.0 (2018-02-23)
 ------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -4,7 +4,7 @@ fiberassign change log
 0.7.1 (unreleased)
 ------------------
 
-* Fixed `qa-fiberassign` imports for desitarget 0.19.0
+* Fixed `qa-fiberassign` imports for desitarget 0.19.0 (PR #102)
 
 0.7.0 (2018-02-23)
 ------------------


### PR DESCRIPTION
Small update to `qa-fiberassign` to fix `desitarget.targetmask.desi_mask` import to make it compatible with desitarget 0.19.0 (which moved some imports to fix a readthedocs build...)