### PR TITLE
Update Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,4 @@ bin/fiberassign_surveysim
 bin/split_*
 slurm*
 *.pyc
-script/*
-test/*
 *diff*

--- a/Makefile
+++ b/Makefile
@@ -70,8 +70,8 @@ all :
 	@ for f in $(SUBDIRS); do $(MAKE) -C $$f all ; done
 
 install : all
-	/bin/mkdir -p ${INSTALL_DIR}
-	@ for d in bin py script test; do  /bin/cp -a $$d ${INSTALL_DIR} ; done
+	- /bin/mkdir -p $(INSTALL_DIR)
+	@ for d in bin py script test; do test ! -d $(INSTALL_DIR)/$$d && /bin/cp -a $$d $(INSTALL_DIR) ; done
 	@ for f in $(SUBDIRS); do $(MAKE) -C $$f install ; done
 
 clean :

--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,7 @@ include platforms/$(PLATFORM)
 #
 # This is a message to make that these targets are 'actions' not files.
 #
-# .PHONY : all clean install uninstall version
-.PHONY : all clean install
+.PHONY : all clean install version
 #
 # This should compile all code prior to it being installed.
 #

--- a/Makefile
+++ b/Makefile
@@ -1,30 +1,77 @@
-
-# check if we are using platform-specific options,
-# otherwise use the 
-
+#
+# Template Makefile for use with desiInstall.  You can assume that
+# desiInstall will set these environment variables:
+#
+# WORKING_DIR   : The directory containing the svn export
+# INSTALL_DIR   : The directory the installed product will live in.
+# (PRODUCT)     : Where (PRODUCT) is replaced with the name of the
+#                 product in upper case, e.g. DESITEMPLATE.  This should
+#                 be the same as WORKING_DIR for typical installs.
+#
+# Use this shell to interpret shell commands, & pass its value to sub-make
+#
+export SHELL = /bin/sh
+#
+# This is like doing 'make -w' on the command line.  This tells make to
+# print the directory it is in.
+#
+MAKEFLAGS = w
+#
+# This is a list of subdirectories that make should descend into.  Makefiles
+# in these subdirectories should also understand 'make all' & 'make clean'.
+# This list can be empty, but should still be defined.
+#
+SUBDIRS = src
+#
+# Set INSTALL_DIR
+#
+ifndef INSTALL_DIR
+  export INSTALL_DIR := $(shell pwd)
+endif
+#
+# Check if we are using platform-specific options, otherwise use the generic
+# configuration.
+#
 ifndef PLATFORM
-  PLATFORM := generic
+
+ifdef NERSC_HOST
+
+ifeq ($(NERSC_HOST), edison)
+PLATFORM := nersc_edison
+else ($(NERSC_HOST), cori)
+PLATFORM := nesrc_cori_haswell
 endif
 
+else
+
+UNAME := $(shell uname)
+
+ifeq ($(UNAME), Darwin)
+PLATFORM := osx
+else
+#
+# Not sure of the best way to select 'fedora'.
+#
+PLATFORM := generic
+endif
+
+endif
 include platforms/$(PLATFORM)
+#
+# This is a message to make that these targets are 'actions' not files.
+#
+# .PHONY : all clean install uninstall version
+.PHONY : all clean install
+#
+# This should compile all code prior to it being installed.
+#
+all :
+	@ for f in $(SUBDIRS); do $(MAKE) -C $$f all ; done
 
-# absolute path to top source directory
-
-export TOPDIR := $(shell pwd)
-
-# where to place built executables
-ifdef INSTALL_DIR
-export INSTALL := $(INSTALL_DIR)/bin
-endif
-ifndef INSTALL
-export INSTALL := $(TOPDIR)/bin
-endif
-
-all : 
-	$(MAKE) -C src all
-
-install :
-	$(MAKE) -C src install
+install : all
+	/bin/mkdir -p ${INSTALL_DIR}
+	@ for d in bin py; do  /bin/cp -a $$d ${INSTALL_DIR} ; done
+	@ for f in $(SUBDIRS); do $(MAKE) -C $$f install ; done
 
 clean :
-	$(MAKE) -C src clean
+	@ for f in $(SUBDIRS); do $(MAKE) -C $$f clean ; done

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,8 @@ ifdef NERSC_HOST
 
 ifeq ($(NERSC_HOST), edison)
 PLATFORM := nersc_edison
-else ($(NERSC_HOST), cori)
+endif
+ifeq ($(NERSC_HOST), cori)
 PLATFORM := nesrc_cori_haswell
 endif
 
@@ -54,7 +55,7 @@ else
 #
 PLATFORM := generic
 endif
-
+endif
 endif
 include platforms/$(PLATFORM)
 #
@@ -70,8 +71,14 @@ all :
 
 install : all
 	/bin/mkdir -p ${INSTALL_DIR}
-	@ for d in bin py; do  /bin/cp -a $$d ${INSTALL_DIR} ; done
+	@ for d in bin py script test; do  /bin/cp -a $$d ${INSTALL_DIR} ; done
 	@ for f in $(SUBDIRS); do $(MAKE) -C $$f install ; done
 
 clean :
 	@ for f in $(SUBDIRS); do $(MAKE) -C $$f clean ; done
+#
+# Enable 'make version' to update the version string.
+# Do make TAG=0.1.2 version to set the tag explicitly.
+#
+version :
+	$(MAKE) -C src version

--- a/README.rst
+++ b/README.rst
@@ -15,9 +15,19 @@ Compiling
 To compile the code, set ``$PLATFORM`` to one of the recipes in the
 ``platforms/`` and then run ``make install``;  *e.g.* on Cori Haswell::
 
-    PLATFORM=nesrc_cori_haswell make install
+    make PLATFORM=nesrc_cori_haswell install
 
 This will create the ``bin/fiberassign`` executable.
+
+The version of fiberassign can be updated with::
+
+    make version
+
+or::
+
+    make TAG=1.2.3 version
+
+to set the version when tagging.
 
 Running
 -------

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,10 @@
 fiberassign
 ===========
 
-This repository provides code for DESI fiber assignment, i.e. assigning
+Introduction
+------------
+
+This repository provides code for DESI fiber assignment, *i.e.* assigning
 which fibers of which telescope pointings (tiles) should be assigned to
 observe which objects in a target catalog.
 
@@ -10,9 +13,9 @@ Compiling
 ---------
 
 To compile the code, set ``$PLATFORM`` to one of the recipes in the
-``platforms/`` and then run ``make install``.  e.g. on Cori Haswell::
+``platforms/`` and then run ``make install``;  *e.g.* on Cori Haswell::
 
-PLATFORM=nesrc_cori_haswell make install
+    PLATFORM=nesrc_cori_haswell make install
 
 This will create the ``bin/fiberassign`` executable.
 
@@ -28,4 +31,3 @@ file locations.  Run ``config-fiberassign --help`` for options.
 ``doc/Guide_to_FiberAssignment.tex`` contains more details.  A pdf snapshot
 is available to DESI collaborators at
 https://desi.lbl.gov/DocDB/cgi-bin/private/ShowDocument?docid=2742 .
-

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -4,10 +4,10 @@ fiberassign change log
 0.7.2 (unreleased)
 ------------------
 
-* Make fiberassign take more responsibility for installing itself (PR `#103`_).
+* Make fiberassign take more responsibility for installing itself (PR `#104`_).
 * Allow fiberassign to report its version.
 
-.. _`#103`: https://github.com/desihub/fiberassign/pull/103
+.. _`#103`: https://github.com/desihub/fiberassign/pull/104
 
 0.7.1 (2018-03-01)
 ------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -1,36 +1,54 @@
 fiberassign change log
 ======================
 
-0.7.1 (unreleased)
+0.7.2 (unreleased)
 ------------------
 
-* Fixed `qa-fiberassign` imports for desitarget 0.19.0 (PR #102)
+* Make fiberassign take more responsibility for installing itself (PR `#103`_).
+* Allow fiberassign to report its version.
+
+.. _`#103`: https://github.com/desihub/fiberassign/pull/103
+
+0.7.1 (2018-03-01)
+------------------
+
+* Fixed ``qa-fiberassign`` imports for desitarget 0.19.0 (PR `#102`_).
+
+.. _`#102`: https://github.com/desihub/fiberassign/pull/102
 
 0.7.0 (2018-02-23)
 ------------------
 
-* Fill unassigned fibers with sky and stdstars if possible (PR #100)
-* Account for broken fibers and stuck positioners (PR #101)
+* Fill unassigned fibers with sky and stdstars if possible (PR `#100`_).
+* Account for broken fibers and stuck positioners (PR `#101`_).
+
+.. _`#101`: https://github.com/desihub/fiberassign/pull/101
+.. _`#100`: https://github.com/desihub/fiberassign/pull/100
 
 0.6.0 (2017-11-09)
 ------------------
 
-* Guarantee that higher priority targets are placed first (PR #84)
-* Keep ra,dec as double precision, not single precision (PR #88)
+* Guarantee that higher priority targets are placed first (PR `#84`_).
+* Keep RA, Dec as double precision, not single precision (PR `#88`_).
+
+.. _`#84`: https://github.com/desihub/fiberassign/pull/84
+.. _`#88`: https://github.com/desihub/fiberassign/pull/88
 
 0.5.3 (2017-09-30)
 ------------------
 
-* bin/qa-fiberassign bug fixes
+* ``bin/qa-fiberassign`` bug fixes.
 
 0.5.2 (2017-09-30)
 ------------------
 
-* Fixed indexing bug for LOCATION output
-* added WIP bin/qa-fiberassign
-* Fixed missing collision checks (PR #81)
+* Fixed indexing bug for ``LOCATION`` output.
+* added WIP ``bin/qa-fiberassign``.
+* Fixed missing collision checks (PR `#81`_).
+
+.. _`#81`: https://github.com/desihub/fiberassign/pull/81
 
 0.5.1 (2017-06-30)
 ------------------
 
-* Reference tag
+* Reference tag.

--- a/platforms/nersc_cori_haswell
+++ b/platforms/nersc_cori_haswell
@@ -1,8 +1,4 @@
 
-# The install location of CFITSIO and other compiled
-# libraries
-DESI_EXTRA := $(DESI_CONDA)_extra
-
 # The serial C++ compiler
 export CXX := g++
 
@@ -13,5 +9,5 @@ export CXXFLAGS := -O3 -std=c++11 -fPIC -DNDEBUG
 export OMPFLAGS := -fopenmp
 
 # CFITSIO include and linking commands
-export CFITSIO_CPPFLAGS := -I$(DESI_EXTRA)/include
-export CFITSIO := -L$(DESI_EXTRA)/lib -lcfitsio -lm
+export CFITSIO_CPPFLAGS := -I$(DESICONDA_EXTRA)/include
+export CFITSIO := -L$(DESICONDA_EXTRA)/lib -lcfitsio -lm

--- a/platforms/nersc_edison
+++ b/platforms/nersc_edison
@@ -1,8 +1,4 @@
 
-# The install location of CFITSIO and other compiled
-# libraries
-DESI_EXTRA := $(DESI_CONDA)_extra
-
 # The serial C++ compiler
 export CXX := g++
 
@@ -13,5 +9,5 @@ export CXXFLAGS := -O3 -std=c++11 -fPIC -DNDEBUG
 export OMPFLAGS := -fopenmp
 
 # CFITSIO include and linking commands
-export CFITSIO_CPPFLAGS := -I$(DESI_EXTRA)/include
-export CFITSIO := -L$(DESI_EXTRA)/lib -lcfitsio -lm
+export CFITSIO_CPPFLAGS := -I$(DESICONDA_EXTRA)/include
+export CFITSIO := -L$(DESICONDA_EXTRA)/lib -lcfitsio -lm

--- a/src/Makefile
+++ b/src/Makefile
@@ -8,7 +8,9 @@ collision.h \
 feat.h \
 global.h \
 misc.h \
-structs.h
+structs.h \
+version.h \
+_version.h
 
 OBJS_SURVEYSIM = \
 surveysim.o \
@@ -16,7 +18,8 @@ collision.o \
 feat.o \
 global.o \
 misc.o \
-structs.o
+structs.o \
+version.o
 
 OBJS_FIBERASSIGN = \
 fiberassign.o \
@@ -24,9 +27,10 @@ collision.o \
 feat.o \
 global.o \
 misc.o \
-structs.o
+structs.o \
+version.o
 
-EXECUTABLES = fiberassign 
+EXECUTABLES = fiberassign
 COMPILE = $(CXXFLAGS) $(OMPFLAGS) -I. $(CFITSIO_CPPFLAGS)
 # valgrind
 #COMPILE = -g -O0 -m64 -fPIC -DNDEBUG -std=c++11 $(OMPFLAGS) -I. $(CFITSIO_CPPFLAGS)
@@ -36,7 +40,7 @@ LINK = $(OMPFLAGS) $(CFITSIO)
 all : $(EXECUTABLES)
 
 install : all
-	cp $(EXECUTABLES) $(INSTALL)
+	/bin/cp -a $(EXECUTABLES) $(INSTALL_DIR)/bin
 
 fiberassign : $(OBJS_FIBERASSIGN)
 	$(CXX) -o $@ $^ $(LINK)
@@ -48,8 +52,21 @@ fiberassign_surveysim : $(OBJS_SURVEYSIM)
 %.o : %.cpp $(HEADERS)
 	$(CXX) $(COMPILE) -o $@ -c $<
 
-
+#
+# GNU make pre-defines $(RM).  The - in front of $(RM) causes make to
+# ignore any errors produced by $(RM).
+#
 clean :
-	rm -f $(EXECUTABLES)
-	rm -f *.o *~
-	@cd $(INSTALL); rm -f $(EXECUTABLES)
+	- $(RM) $(EXECUTABLES)
+	- $(RM) *.o *~
+	@ for e in $(EXECUTABLES); do $(RM) $(INSTALL_DIR)/bin/$$e ; done
+#
+# Enable 'make version' to update the version string.
+# Do make TAG=0.1.2 version to set the tag explicitly.
+#
+LASTTAG := $(shell git describe --tags --dirty --always | cut -d- -f1)
+COUNT := $(shell git rev-list --count HEAD)
+version :
+	- $(RM) _version.h
+	@ if test -n "$(TAG)"; then v=$(TAG); else v=$(LASTTAG).dev$(COUNT); fi; \
+		echo "#define VERSION_STRING \"$$v\"" > _version.h

--- a/src/_version.h
+++ b/src/_version.h
@@ -1,0 +1,1 @@
+#define VERSION_STRING "0.7.1.dev2084"

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -1,0 +1,7 @@
+#include "version.h"
+
+std::string version(void)
+{
+    std::string theVersion(VERSION_STRING);
+    return theVersion;
+}

--- a/src/version.h
+++ b/src/version.h
@@ -1,0 +1,9 @@
+#ifndef FIBERASSIGN_VERSION__H
+#define FIBERASSIGN_VERSION__H
+
+#include <string>
+#include "_version.h"
+
+std::string version(void);
+
+#endif


### PR DESCRIPTION
This PR fixes #103 by having the Makefile(s) take more responsibility for how they install files.

As a bonus, I have added a function that can report the version of fiberassign programmatically.