### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ all :
 
 install : all
 	- /bin/mkdir -p $(INSTALL_DIR)
-	@ for d in bin py script test; do test ! -d $(INSTALL_DIR)/$$d && /bin/cp -a $$d $(INSTALL_DIR) ; done
+	@ for d in bin py script test; do if [ ! -d $(INSTALL_DIR)/$$d ]; then /bin/cp -a $$d $(INSTALL_DIR) ; fi ; done
 	@ for f in $(SUBDIRS); do $(MAKE) -C $$f install ; done
 
 clean :

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ ifeq ($(NERSC_HOST), edison)
 PLATFORM := nersc_edison
 endif
 ifeq ($(NERSC_HOST), cori)
-PLATFORM := nesrc_cori_haswell
+PLATFORM := nersc_cori_haswell
 endif
 
 else


### PR DESCRIPTION
This PR fixes #106.  There were two problems: a dumb typo, and a shell mini-script that didn't play nice with `make`.