### PR TITLE
Only get git info when needed

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -63,10 +63,12 @@ clean :
 #
 # Enable 'make version' to update the version string.
 # Do make TAG=0.1.2 version to set the tag explicitly.
+# LASTTAG and COUNT are defined inside the recipe so they
+# only get defined when make version is invoked.
 #
-LASTTAG := $(shell git describe --tags --dirty --always | cut -d- -f1)
-COUNT := $(shell git rev-list --count HEAD)
 version :
 	- $(RM) _version.h
+	$(eval LASTTAG := $$(shell git describe --tags --dirty --always | cut -d- -f1))
+	$(eval COUNT := $$(shell git rev-list --count HEAD))
 	@ if test -n "$(TAG)"; then v=$(TAG); else v=$(LASTTAG).dev$(COUNT); fi; \
 		echo "#define VERSION_STRING \"$$v\"" > _version.h

--- a/src/_version.h
+++ b/src/_version.h
@@ -1,1 +1,1 @@
-#define VERSION_STRING "0.8.0.dev2111"
+#define VERSION_STRING "0.8.0.dev2112"

--- a/src/_version.h
+++ b/src/_version.h
@@ -1,1 +1,1 @@
-#define VERSION_STRING "0.7.1.dev2084"
+#define VERSION_STRING "0.8.0.dev2111"


### PR DESCRIPTION
This PR fixes desihub/desiutil#107 by only obtaining git metadata when it is actually needed (and when presumably one is actually inside a git clone).