### PR TITLE
standard star DESI_TARGET mask as input option 

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,8 +6,11 @@ fiberassign change log
 
 * New FIBERMASK columns in fibermap files. (PR `#112`_).
 * Computes RA+dec for unassigned, stuck, and broken fibers. (PR `#112`_).
+* Standard star DESI_TARGET mask as input parameter (PR `#114`_)
 
 .. _`#112`: https://github.com/desihub/fiberassign/pull/112
+.. _`#114`: https://github.com/desihub/fiberassign/pull/114
+
 
 0.8.0 (2019-03-29)
 ------------------

--- a/src/feat.cpp
+++ b/src/feat.cpp
@@ -29,6 +29,7 @@ void Usage(char *ExecName)
     std::cout << " --positioners <fiberpos_filename> ";
     std::cout << " --fibstatusfile <fiberstatus_filename> ";
     std::cout << " --outdir <outputdirectory> ";
+    std::cout << " --starmask <starmask_integer>";
     std::cout << " [--rundate <YYYY-MM-DD>]"<< std::endl;
     exit(0);
 }
@@ -48,6 +49,7 @@ Feat::Feat() {
     InterPlate = 0;
     Collision = false;
     Exact = true;
+    StarMask = 4;
 }
 
 
@@ -73,7 +75,6 @@ void Feat::readInputFile(const char file[]) {
             if (tok[0]=="SStarsfile")SStarsfile=tok[1];
             if (tok[0]=="SkyFfile") SkyFfile=tok[1];
             if (tok[0]=="runDate") runDate=tok[1];
-                
     }
   }  
   fIn.close();
@@ -84,6 +85,7 @@ void Feat::readInputFile(const char file[]) {
 void Feat::parseCommandLine(int argc, char **argv) {
     int i;
     for (i=1;i<argc;){
+        
         if (!strcmp(argv[i],"--mtl")){
             i++;
             Targfile = str(argv[i]);
@@ -116,9 +118,13 @@ void Feat::parseCommandLine(int argc, char **argv) {
             i++;
             fibstatusFile = str(argv[i]);
             i++;
-        }else if (!strcmp(argv[i],"-rundate")){
+        }else if (!strcmp(argv[i],"--rundate")){
             i++;
             runDate = str(argv[i]);
+            i++;   
+        }else if (!strcmp(argv[i],"--starMask")){
+            i++;
+            StarMask = atoi(argv[i]);
             i++;
         }else if (!strcmp(argv[i],"--help")){
             Usage(argv[0]);

--- a/src/feat.cpp
+++ b/src/feat.cpp
@@ -29,7 +29,7 @@ void Usage(char *ExecName)
     std::cout << " --positioners <fiberpos_filename> ";
     std::cout << " --fibstatusfile <fiberstatus_filename> ";
     std::cout << " --outdir <outputdirectory> ";
-    std::cout << " --starbit <starbit_integer]";
+    std::cout << " --starmask <starbit_mask]";
     std::cout << " [--rundate <YYYY-MM-DD>]"<< std::endl;
     exit(0);
 }
@@ -49,7 +49,7 @@ Feat::Feat() {
     InterPlate = 0;
     Collision = false;
     Exact = true;
-    StarBit = 33;
+    StarMask = 60129542144;
 }
 
 
@@ -122,9 +122,9 @@ void Feat::parseCommandLine(int argc, char **argv) {
             i++;
             runDate = str(argv[i]);
             i++;   
-        }else if (!strcmp(argv[i],"--starbit")){
+        }else if (!strcmp(argv[i],"--starmask")){
             i++;
-            StarBit = atoi(argv[i]);
+            StarMask = atol(argv[i]);
             i++;
         }else if (!strcmp(argv[i],"--help")){
             Usage(argv[0]);

--- a/src/feat.cpp
+++ b/src/feat.cpp
@@ -29,7 +29,7 @@ void Usage(char *ExecName)
     std::cout << " --positioners <fiberpos_filename> ";
     std::cout << " --fibstatusfile <fiberstatus_filename> ";
     std::cout << " --outdir <outputdirectory> ";
-    std::cout << " --starmask <starmask_integer>";
+    std::cout << " --starbit <starbit_integer]";
     std::cout << " [--rundate <YYYY-MM-DD>]"<< std::endl;
     exit(0);
 }

--- a/src/feat.cpp
+++ b/src/feat.cpp
@@ -49,7 +49,7 @@ Feat::Feat() {
     InterPlate = 0;
     Collision = false;
     Exact = true;
-    StarMask = 4;
+    StarBit = 33;
 }
 
 
@@ -122,9 +122,9 @@ void Feat::parseCommandLine(int argc, char **argv) {
             i++;
             runDate = str(argv[i]);
             i++;   
-        }else if (!strcmp(argv[i],"--starMask")){
+        }else if (!strcmp(argv[i],"--starbit")){
             i++;
-            StarMask = atoi(argv[i]);
+            StarBit = atoi(argv[i]);
             i++;
         }else if (!strcmp(argv[i],"--help")){
             Usage(argv[0]);

--- a/src/feat.h
+++ b/src/feat.h
@@ -31,7 +31,8 @@ class Feat { // F for features
     str runDate;
 
 
-    int StarMask;
+    int StarBit; //bit in desi_target that signals a standard star
+    
     int InterPlate; 
     int MaxSS;
     int MaxSF;

--- a/src/feat.h
+++ b/src/feat.h
@@ -31,7 +31,7 @@ class Feat { // F for features
     str runDate;
 
 
-    int StarBit; //bit in desi_target that signals a standard star
+    long StarMask; //bit in desi_target that signals a standard star
     
     int InterPlate; 
     int MaxSS;

--- a/src/feat.h
+++ b/src/feat.h
@@ -31,6 +31,7 @@ class Feat { // F for features
     str runDate;
 
 
+    int StarMask;
     int InterPlate; 
     int MaxSS;
     int MaxSF;

--- a/src/fiberassign.cpp
+++ b/src/fiberassign.cpp
@@ -41,9 +41,9 @@ int main(int argc, char **argv) {
     // Try to read SS and SF before targets to avoid wasting time if these
     // smaller files can't be read.
     init_time_at(time,"# Read target, SS, SF files",t);
-    MTL SStars = read_MTLfile(F.SStarsfile,F,F.StarBit,0);
-    MTL SkyF   = read_MTLfile(F.SkyFfile,  F,0,1);
-    MTL Targ   = read_MTLfile(F.Targfile,  F,0,0);
+    MTL SStars = read_MTLfile(F.SStarsfile, F, F.StarMask,0);
+    MTL SkyF   = read_MTLfile(F.SkyFfile,   F, 0,1);
+    MTL Targ   = read_MTLfile(F.Targfile,   F, 0,0);
 
     print_time(time,"# ...read targets  took :");
     //combine the three input files

--- a/src/fiberassign.cpp
+++ b/src/fiberassign.cpp
@@ -41,7 +41,7 @@ int main(int argc, char **argv) {
     // Try to read SS and SF before targets to avoid wasting time if these
     // smaller files can't be read.
     init_time_at(time,"# Read target, SS, SF files",t);
-    MTL SStars = read_MTLfile(F.SStarsfile,F,1,0);
+    MTL SStars = read_MTLfile(F.SStarsfile,F,F.StarBit,0);
     MTL SkyF   = read_MTLfile(F.SkyFfile,  F,0,1);
     MTL Targ   = read_MTLfile(F.Targfile,  F,0,0);
 

--- a/src/structs.cpp
+++ b/src/structs.cpp
@@ -46,6 +46,7 @@ MTL read_MTLfile(str readfile, const Feat& F, int SS, int SF){
     long *desi_target;
     long *bgs_target;
     long *mws_target;
+    long starflag = 2^SS;
     int *numobs;
     int *priority;
     double *ra;
@@ -54,7 +55,7 @@ MTL read_MTLfile(str readfile, const Feat& F, int SS, int SF){
     char **brickname;
     uint16_t *obsconditions;    
     double *subpriority;
-
+    fprintf(stdout, "star flag %ld\n", starflag); 
     // General purpose output stream for exceptions
     std::ostringstream o;
 
@@ -284,11 +285,16 @@ MTL read_MTLfile(str readfile, const Feat& F, int SS, int SF){
         myexit(status);
       }
 
-      
+      nkeep = 0;
+      for(ii=0;ii<nrows;ii++){
+           if( ((SS!=0) && ((desi_target[ii] & starflag)!=0)) || (SS==0) ){
+               nkeep++;
+           }
+      }
 
       
       // count how many rows we will keep and reserve that amount
-      nkeep = nrows;
+      //nkeep = nrows;
       printf("Keeping %d targets within ra/dec ranges\n", nkeep);
       try {M.reserve(nkeep);} catch (std::exception& e) {myexception(e);}
 
@@ -325,16 +331,19 @@ MTL read_MTLfile(str readfile, const Feat& F, int SS, int SF){
              Q.SS=SS;
              Q.SF=SF;
              strncpy(Q.brickname, brickname[ii], 9);
-             try{M.push_back(Q);}catch(std::exception& e) {myexception(e);}
- 
-             bool in=false;
-             for (int j=0;j<M.priority_list.size();++j){
-               if(Q.t_priority==M.priority_list[j]){
-                 in=true;
-               }
-             }
-             if(!in){
-               M.priority_list.push_back(Q.t_priority);
+          
+            if( ((SS!=0) && ((desi_target[ii] & starflag)!=0)) || (SS==0) ){
+                 try{M.push_back(Q);}catch(std::exception& e) {myexception(e);}
+         
+                 bool in=false;
+                 for (int j=0;j<M.priority_list.size();++j){
+                   if(Q.t_priority==M.priority_list[j]){
+                     in=true;
+                    }
+                 }
+                 if(!in){
+                   M.priority_list.push_back(Q.t_priority);
+                 }
              }
       } // end ii loop over targets
       std::sort(M.priority_list.begin(),M.priority_list.end());

--- a/src/structs.cpp
+++ b/src/structs.cpp
@@ -46,7 +46,7 @@ MTL read_MTLfile(str readfile, const Feat& F, int SS, int SF){
     long *desi_target;
     long *bgs_target;
     long *mws_target;
-    long starflag = 2^SS;
+    long starflag = 1L<<SS;
     int *numobs;
     int *priority;
     double *ra;
@@ -332,7 +332,7 @@ MTL read_MTLfile(str readfile, const Feat& F, int SS, int SF){
              Q.SF=SF;
              strncpy(Q.brickname, brickname[ii], 9);
           
-            if( ((SS!=0) && ((desi_target[ii] & starflag)!=0)) || (SS==0) ){
+            if( ((SS!=-1) && ((desi_target[ii] & starflag)!=0)) || (SS==0) ){
                  try{M.push_back(Q);}catch(std::exception& e) {myexception(e);}
          
                  bool in=false;

--- a/src/structs.cpp
+++ b/src/structs.cpp
@@ -25,7 +25,7 @@
 
 // targets -----------------------------------------------------------------------
 
-MTL read_MTLfile(str readfile, const Feat& F, int SS, int SF){
+MTL read_MTLfile(str readfile, const Feat& F, long SS, long SF){
   //reads fits files, specifically mtl, standard stars, sky fibers
     str s = readfile;
     MTL M;
@@ -46,7 +46,7 @@ MTL read_MTLfile(str readfile, const Feat& F, int SS, int SF){
     long *desi_target;
     long *bgs_target;
     long *mws_target;
-    long starflag = 1L<<SS;
+    long starmask = SS;
     int *numobs;
     int *priority;
     double *ra;
@@ -55,7 +55,7 @@ MTL read_MTLfile(str readfile, const Feat& F, int SS, int SF){
     char **brickname;
     uint16_t *obsconditions;    
     double *subpriority;
-    fprintf(stdout, "star flag %ld\n", starflag); 
+    fprintf(stdout, "star mask %ld\n", starmask); 
     // General purpose output stream for exceptions
     std::ostringstream o;
 
@@ -287,7 +287,7 @@ MTL read_MTLfile(str readfile, const Feat& F, int SS, int SF){
 
       nkeep = 0;
       for(ii=0;ii<nrows;ii++){
-           if( ((SS!=0) && ((desi_target[ii] & starflag)!=0)) || (SS==0) ){
+           if( ((SS!=0) && ((desi_target[ii] & starmask)!=0)) || (SS==0) ){
                nkeep++;
            }
       }
@@ -332,7 +332,7 @@ MTL read_MTLfile(str readfile, const Feat& F, int SS, int SF){
              Q.SF=SF;
              strncpy(Q.brickname, brickname[ii], 9);
           
-            if( ((SS!=-1) && ((desi_target[ii] & starflag)!=0)) || (SS==0) ){
+            if( ((SS!=-1) && ((desi_target[ii] & starmask)!=0)) || (SS==0) ){
                  try{M.push_back(Q);}catch(std::exception& e) {myexception(e);}
          
                  bool in=false;

--- a/src/structs.h
+++ b/src/structs.h
@@ -73,7 +73,7 @@ class MTL : public std::vector<struct target> {
     std::vector<int> priority_list;
 };
 
-MTL read_MTLfile(str filename, const Feat& F, int SS, int SF);
+MTL read_MTLfile(str filename, const Feat& F, long SS, long SF);
 
 void assign_priority_class(MTL & M);
 


### PR DESCRIPTION
This solves #64 by introducing the command line option `--starbit` to select the bit in the `desi_target` mask that signals a standard star. The default option is `33`.