### PR TITLE
do not assume tileid is 5 digits long

### DIFF
--- a/bin/fiberassign
+++ b/bin/fiberassign
@@ -155,7 +155,7 @@ sky_tile_id = {}
 for sky_file in skys:
     f = sky_file.split('/')[-1]
     fileid = f.split("_")[-1]
-    fileid = fileid[0:5]
+    fileid = fileid[:-5]
     sky_tile_id[fileid] = sky_file
 
 target_tile_id = {}
@@ -163,7 +163,7 @@ tile_id = []
 for target_file in targets:
     f = target_file.split('/')[-1]
     fileid = f.split("_")[-1]
-    fileid = fileid[0:5]
+    fileid = fileid[:-5]
     target_tile_id[fileid] = target_file
     tile_id.append(int(fileid))
 
@@ -191,7 +191,7 @@ if args.gfafile is not None:
     for gfa_file in gfas:
         f = gfa_file.split('/')[-1]
         fileid = f.split("_")[-1]
-        fileid = fileid[0:5]
+        fileid = fileid[:-5]
         gfa_tile_id[fileid] = gfa_file
     
 for sky_id in sky_tile_id.keys():

--- a/bin/qa-fiberassign
+++ b/bin/qa-fiberassign
@@ -34,10 +34,10 @@ assigned = list()
 covered = list()
 n5k = np.arange(5000, dtype=int)
 for filename in args.tilefiles:
-    fa = Table.read(filename, 'FIBER_ASSIGNMENTS')
+    fa = Table.read(filename, 'FIBERASSIGN')
     fa.sort('FIBER')
     assigned.append(fa)
-    tmp = Table.read(filename, 'POTENTIAL_ASSIGNMENTS')['POTENTIALTARGETID']
+    tmp = Table.read(filename, 'POTENTIAL')['POTENTIALTARGETID']
     covered.append(np.unique(tmp))
     errors = list()
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -4,15 +4,17 @@ fiberassign change log
 0.8.2 (unreleased)
 ------------------
 
-* Standard star DESI_TARGET mask as input parameter (PR `#114`_)
-* `fiberassign` is now a python wrapper around the C++ executable (PR `#116`_)
-* Adds sky monitor fiber assignments (PR `#119`_)
-* Adds GFA targets HDU $(PR `#122`_)
+* Standard star DESI_TARGET mask as input parameter (PR `#114`_).
+* `fiberassign` is now a python wrapper around the C++ executable (PR `#116`_).
+* Adds sky monitor fiber assignments (PR `#119`_).
+* Adds GFA targets HDU (PR `#122`_).
+* Bug fix: do not assume tileid is 5 digits long (PR `#126`_).
 
 .. _`#114`: https://github.com/desihub/fiberassign/pull/114
 .. _`#116`: https://github.com/desihub/fiberassign/pull/116
 .. _`#119`: https://github.com/desihub/fiberassign/pull/119
 .. _`#122`: https://github.com/desihub/fiberassign/pull/122
+.. _`#126`: https://github.com/desihub/fiberassign/pull/126
 
 
 0.8.1 (2018-05-10)


### PR DESCRIPTION
The solution is not particularly elegant, but it addresses #125.  Instead of assuming every tileid is 5 digits I assume that every file is a `.fits` file and trim the suffix from the filename to get the tileid.