### PR TITLE
fixes stdstar allocation

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -14,6 +14,7 @@ fiberassign change log
 * Fixes sign flip in x,y <-> RA,dec conversions  (PR `#127`_).
 * Checks for missing files (PR `#128`_).
 * Fix unclosed file error (PR `#129`_).
+* Bug fix: overflowing integer for SS flag (PR `#131`_).
 
 .. _`#114`: https://github.com/desihub/fiberassign/pull/114
 .. _`#116`: https://github.com/desihub/fiberassign/pull/116
@@ -25,6 +26,7 @@ fiberassign change log
 .. _`#127`: https://github.com/desihub/fiberassign/pull/127
 .. _`#128`: https://github.com/desihub/fiberassign/pull/128
 .. _`#129`: https://github.com/desihub/fiberassign/pull/129
+.. _`#131`: https://github.com/desihub/fiberassign/pull/131
 
 0.8.1 (2018-05-10)
 ------------------

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -383,13 +383,20 @@ void simple_assign (MTL & M, Plates & P, const FP & pp, const Feat & F,
     init_time(t, "# Begin simple assignment :");
     int countme = 0;
     for (int j = 0; j < F.Nplate; j++) {
+        fprintf(stdout, "plate %d out of %d\n", j, F.Nplate);
+        fflush(stdout);
         std::vector <std::pair <double, int> > pairs;
         for (int k = 0; k < F.Nfiber; k++) {
+            //fprintf(stdout, "fiber %d out of %d\n", k, F.Nfiber);
+            //        fflush(stdout);
+
             List av_gals = P[j].av_gals[k];
             double Max_fiber_priority = 0.;
             // loop over the potential list to find pbest and subpbest
             // and then combine them to give the fiber_weight
             for (size_t gg = 0; gg < av_gals.size(); gg++) {
+                //fprintf(stdout, "available gal %d out of %d\n", gg, av_gals.size());
+                //    fflush(stdout);
                 int g = av_gals[gg];
                 // not SS and SF
                 if (!M[g].SS && !M[g].SF) {
@@ -664,7 +671,7 @@ void assign_sf_ss (int j, MTL & M, Plates & P, const FP & pp, const Feat & F,
                 if (A.TF[j][k] == -1) {
                     // this fiber isn't assigned yet
                     int done = 0;
-                    for (size_t gg = 0; gg < SS_av_k.size() && done == 0; gg++) {
+		    for (size_t gg = 0; gg < SS_av_k.size() && done == 0; gg++) {
                         // SS on this with reach of this fiber
                         int g = SS_av_k[gg];
                         // if g isn't already assigned on this fiber and we

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -385,7 +385,6 @@ void simple_assign (MTL & M, Plates & P, const FP & pp, const Feat & F,
     for (int j = 0; j < F.Nplate; j++) {
         std::vector <std::pair <double, int> > pairs;
         for (int k = 0; k < F.Nfiber; k++) {
-
             List av_gals = P[j].av_gals[k];
             double Max_fiber_priority = 0.;
             // loop over the potential list to find pbest and subpbest
@@ -663,19 +662,19 @@ void assign_sf_ss (int j, MTL & M, Plates & P, const FP & pp, const Feat & F,
                 SS_av_k = sort_by_subpriority(M, SS_av_k_init);
                 SF_av_k = sort_by_subpriority(M, SF_av_k_init);
                 if (A.TF[j][k] == -1) {
-		   // this fiber isn't assigned yet
-		   int done = 0;
-		   for (size_t gg = 0; gg < SS_av_k.size() && done == 0; gg++) {
-                       // SS on this with reach of this fiber
-                       int g = SS_av_k[gg];
-                       // if g isn't already assigned on this fiber and we
-                       // still need it and it's ok to assign, then assign
-                       if ( (A.is_assigned_jg(j, g, M, F) == -1) &&
+                    // this fiber isn't assigned yet
+                    int done = 0;
+                    for (size_t gg = 0; gg < SS_av_k.size() && done == 0; gg++) {
+                        // SS on this with reach of this fiber
+                        int g = SS_av_k[gg];
+                        // if g isn't already assigned on this fiber and we
+                        // still need it and it's ok to assign, then assign
+                        if ( (A.is_assigned_jg(j, g, M, F) == -1) &&
                              ok_for_limit_SS_SF(g, j, k, M, P, pp, F) &&
                              ok_assign_g_to_jk(g, j, k, P, M, pp, F, A) ) {
-                           A.assign(j, k, g, M, P, pp);
-                           done = 1;
-                       }
+                            A.assign(j, k, g, M, P, pp);
+                            done = 1;
+                        }
                     }
                     for (size_t gg = 0; gg < SF_av_k.size()
                         && done == 0; gg++) {

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -383,8 +383,6 @@ void simple_assign (MTL & M, Plates & P, const FP & pp, const Feat & F,
     init_time(t, "# Begin simple assignment :");
     int countme = 0;
     for (int j = 0; j < F.Nplate; j++) {
-        fprintf(stdout, "plate %d out of %d\n", j, F.Nplate);
-        fflush(stdout);
         std::vector <std::pair <double, int> > pairs;
         for (int k = 0; k < F.Nfiber; k++) {
 
@@ -667,17 +665,16 @@ void assign_sf_ss (int j, MTL & M, Plates & P, const FP & pp, const Feat & F,
                 if (A.TF[j][k] == -1) {
 		   // this fiber isn't assigned yet
 		   int done = 0;
-
 		   for (size_t gg = 0; gg < SS_av_k.size() && done == 0; gg++) {
-                        // SS on this with reach of this fiber
+                       // SS on this with reach of this fiber
                        int g = SS_av_k[gg];
-                        // if g isn't already assigned on this fiber and we
-                        // still need it and it's ok to assign, then assign
+                       // if g isn't already assigned on this fiber and we
+                       // still need it and it's ok to assign, then assign
                        if ( (A.is_assigned_jg(j, g, M, F) == -1) &&
                              ok_for_limit_SS_SF(g, j, k, M, P, pp, F) &&
                              ok_assign_g_to_jk(g, j, k, P, M, pp, F, A) ) {
-                            A.assign(j, k, g, M, P, pp);
-                            done = 1;
+                           A.assign(j, k, g, M, P, pp);
+                           done = 1;
                        }
                     }
                     for (size_t gg = 0; gg < SF_av_k.size()

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -387,8 +387,6 @@ void simple_assign (MTL & M, Plates & P, const FP & pp, const Feat & F,
         fflush(stdout);
         std::vector <std::pair <double, int> > pairs;
         for (int k = 0; k < F.Nfiber; k++) {
-            //fprintf(stdout, "fiber %d out of %d\n", k, F.Nfiber);
-            //        fflush(stdout);
 
             List av_gals = P[j].av_gals[k];
             double Max_fiber_priority = 0.;
@@ -669,19 +667,20 @@ void assign_sf_ss (int j, MTL & M, Plates & P, const FP & pp, const Feat & F,
                 SS_av_k = sort_by_subpriority(M, SS_av_k_init);
                 SF_av_k = sort_by_subpriority(M, SF_av_k_init);
                 if (A.TF[j][k] == -1) {
-                    // this fiber isn't assigned yet
-                    int done = 0;
-		    for (size_t gg = 0; gg < SS_av_k.size() && done == 0; gg++) {
+		   // this fiber isn't assigned yet
+		   int done = 0;
+
+		   for (size_t gg = 0; gg < SS_av_k.size() && done == 0; gg++) {
                         // SS on this with reach of this fiber
-                        int g = SS_av_k[gg];
+                       int g = SS_av_k[gg];
                         // if g isn't already assigned on this fiber and we
                         // still need it and it's ok to assign, then assign
-                        if ( (A.is_assigned_jg(j, g, M, F) == -1) &&
+                       if ( (A.is_assigned_jg(j, g, M, F) == -1) &&
                              ok_for_limit_SS_SF(g, j, k, M, P, pp, F) &&
                              ok_assign_g_to_jk(g, j, k, P, M, pp, F, A) ) {
                             A.assign(j, k, g, M, P, pp);
                             done = 1;
-                        }
+                       }
                     }
                     for (size_t gg = 0; gg < SF_av_k.size()
                         && done == 0; gg++) {

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -393,8 +393,6 @@ void simple_assign (MTL & M, Plates & P, const FP & pp, const Feat & F,
             // loop over the potential list to find pbest and subpbest
             // and then combine them to give the fiber_weight
             for (size_t gg = 0; gg < av_gals.size(); gg++) {
-                //fprintf(stdout, "available gal %d out of %d\n", gg, av_gals.size());
-                //    fflush(stdout);
                 int g = av_gals[gg];
                 // not SS and SF
                 if (!M[g].SS && !M[g].SF) {

--- a/src/structs.cpp
+++ b/src/structs.cpp
@@ -321,12 +321,14 @@ MTL read_MTLfile (str readfile, const Feat & F, long SS, long SF) {
             Q.desi_target = desi_target[ii];
             Q.mws_target = mws_target[ii];
             Q.bgs_target = bgs_target[ii];
-	    if(SS!=0){
+
+	    if (SS != 0) {
 	      Q.SS = 1;
-	    }else{
+	    } else {
 	      Q.SS = SS;
 	    }
             Q.SF = SF;
+
             // These variables were not initialized elsewhere
             Q.lastpass = 0;
             Q.priority_class = 0;

--- a/src/structs.cpp
+++ b/src/structs.cpp
@@ -321,7 +321,11 @@ MTL read_MTLfile (str readfile, const Feat & F, long SS, long SF) {
             Q.desi_target = desi_target[ii];
             Q.mws_target = mws_target[ii];
             Q.bgs_target = bgs_target[ii];
-            Q.SS = SS;
+	    if(SS!=0){
+	      Q.SS = 1;
+	    }else{
+	      Q.SS = SS;
+	    }
             Q.SF = SF;
             // These variables were not initialized elsewhere
             Q.lastpass = 0;


### PR DESCRIPTION
Opening this PR on behalf of @forero .  This PR fixes #130 where an overflowing int when creating the standard star list, which resulted in no standard stars being assigned in some cases (also see desihub/desitest#9 for where this was originally discoverd).

@forero please remove the debugging print statements and the indentation change before merging.  If I don't hear from you I can do that but I didn't want to make simultaneous changes.