### PR TITLE
final HDU update

### DIFF
--- a/bin/fiberassign
+++ b/bin/fiberassign
@@ -230,6 +230,10 @@ if args.gfafile is not None:
         fileid = gfa_file.split('/')[-1].split('_')[-1].split('.')[0]
         gfa_tile_id[fileid] = gfa_file
 
+def add_potential_data_columns(potential_data, tile_data, fiberassign_data, mtl_data, sky_data, positioner_data):
+    n_objects = len(potential_data)
+    
+
 def add_fiber_data_columns(tile_data, fiberassign_data, mtl_data, sky_data, positioner_data):
     n_objects = len(fiberassign_data)
     
@@ -289,8 +293,19 @@ def make_target_hdu_data(fiberassign_data, mtl_data):
     print('  adding all columns from mtl data in make_target_hdu_data')
     print(' Total of MTL points {}. Total of new_target_data {}'.format(
             len(mtl_data), len(new_target_data)))
+    columns=['TARGETID','SUBPRIORITY', 'BRICKID', 'BRICK_OBJID', 'REF_ID',
+             'FLUX_G', 'FLUX_R', 'FLUX_Z', 'FLUX_W1', 'FLUX_W2', 
+             'MW_TRANSMISSION_G', 'MW_TRANSMISSION_R', 'MW_TRANSMISSION_Z',
+             'PSFDEPTH_G', 'PSFDEPTH_R', 'PSFDEPTH_Z',
+             'GALDEPTH_G', 'GALDEPTH_R', 'GALDEPTH_Z', 
+             'SHAPEDEV_R', 'SHAPEDEV_E1', 'SHAPEDEV_E2', 
+             'SHAPEEXP_R', 'SHAPEEXP_E1', 'SHAPEEXP_E2',
+             'FIBERFLUX_G', 'FIBERFLUX_R', 'FIBERFLUX_Z', 
+             'FIBERTOTFLUX_G', 'FIBERTOTFLUX_R', 'FIBERTOTFLUX_Z', 'HPXPIXEL']
+#to be implemented
+#'PSFDEPTH_W1', 'PSFDEPTH_W1',
 
-    new_target_data = join(new_target_data, mtl_data, join_type='left', keys='TARGETID')
+    new_target_data = join(new_target_data, mtl_data[columns], join_type='left', keys='TARGETID')
     if new_target_data.masked:
         unmatched = new_target_data['SUBPRIORITY'].mask
         new_target_data['SUBPRIORITY'][unmatched] = 1
@@ -320,6 +335,9 @@ for sky_id in sky_tile_id.keys():
         target_data = make_target_hdu_data(fiber_data, mtl_data[mtl_tile_indices[int(sky_id)]])
         tile_data  = footprint[footprint['TILEID']==np.int(sky_id)]
         fiber_data = add_fiber_data_columns(tile_data, fiber_data, mtl_data[mtl_tile_indices[int(sky_id)]], sky_data, positioner_data)
+
+        # Make sur that the TARGETID ordering is the same both for target_data and fiber_data
+        assert np.all(target_data['TARGETID'] == fiber_data['TARGETID'])
 
         #- Rename some columns (leave C++ alone; it is being refactored)
         colnames = list(fiber_data.dtype.names)

--- a/bin/fiberassign
+++ b/bin/fiberassign
@@ -301,25 +301,14 @@ def add_fiber_data_columns(tile_data, fiberassign_data, mtl_data, sky_data, posi
 
 
 def make_target_hdu_data(fiberassign_data, mtl_data):
-    new_target_data = fiberassign_data.copy()
+    new_target_data = fiberassign_data[['TARGETID']]
     n_objects = len(new_target_data)
     
     print('  adding all columns from mtl data in make_target_hdu_data')
     print(' Total of MTL points {}. Total of new_target_data {}'.format(
             len(mtl_data), len(new_target_data)))
-    columns=['TARGETID','SUBPRIORITY', 'BRICKID', 'BRICK_OBJID', 'REF_ID',
-             'FLUX_G', 'FLUX_R', 'FLUX_Z', 'FLUX_W1', 'FLUX_W2', 
-             'MW_TRANSMISSION_G', 'MW_TRANSMISSION_R', 'MW_TRANSMISSION_Z',
-             'PSFDEPTH_G', 'PSFDEPTH_R', 'PSFDEPTH_Z',
-             'GALDEPTH_G', 'GALDEPTH_R', 'GALDEPTH_Z', 
-             'SHAPEDEV_R', 'SHAPEDEV_E1', 'SHAPEDEV_E2', 
-             'SHAPEEXP_R', 'SHAPEEXP_E1', 'SHAPEEXP_E2',
-             'FIBERFLUX_G', 'FIBERFLUX_R', 'FIBERFLUX_Z', 
-             'FIBERTOTFLUX_G', 'FIBERTOTFLUX_R', 'FIBERTOTFLUX_Z', 'HPXPIXEL']
-#to be implemented
-#'PSFDEPTH_W1', 'PSFDEPTH_W1',
 
-    new_target_data = join(new_target_data, mtl_data[columns], join_type='left', keys='TARGETID')
+    new_target_data = join(new_target_data, mtl_data, join_type='left', keys='TARGETID')
     if new_target_data.masked:
         unmatched = new_target_data['SUBPRIORITY'].mask
         new_target_data['SUBPRIORITY'][unmatched] = 1

--- a/bin/fiberassign
+++ b/bin/fiberassign
@@ -230,8 +230,22 @@ if args.gfafile is not None:
         fileid = gfa_file.split('/')[-1].split('_')[-1].split('.')[0]
         gfa_tile_id[fileid] = gfa_file
 
-def add_potential_data_columns(potential_data, tile_data, fiberassign_data, mtl_data, sky_data, positioner_data):
+def add_potential_data_columns(potential_data, fiberassign_data):
+    potential_data.dtype.names = tuple(['TARGETID'])
     n_objects = len(potential_data)
+    assert (np.sum(fiberassign_data['NUMTARGET'])==len(potential_data))
+    fiber_array = np.ones(n_objects, dtype=np.int32) # 'FIBER'
+    location_array = np.ones(n_objects, dtype=np.int32) # `LOCATION`
+
+    for i in range(len(fiberassign_data)):
+        min_i = fiberassign_data['NUMTARGET'][:i].sum()
+        max_i = min_i + fiberassign_data['NUMTARGET'][i]
+        fiber_array[min_i:max_i] = fiberassign_data['FIBER'][i]
+        location_array[min_i:max_i] = fiberassign_data['LOCATION'][i]
+
+    potential_data = np.lib.recfunctions.append_fields(potential_data, 'FIBER', fiber_array, dtypes=np.int32)
+    potential_data = np.lib.recfunctions.append_fields(potential_data, 'LOCATION', location_array, dtypes=np.int32)  
+    return potential_data
     
 
 def add_fiber_data_columns(tile_data, fiberassign_data, mtl_data, sky_data, positioner_data):
@@ -332,11 +346,13 @@ for sky_id in sky_tile_id.keys():
         sky_data = fitsio.read(sky_tile_id[sky_id])
         fiber_data = fitsio.read(target_tile_id[sky_id], ext=1)
         potential_data = fitsio.read(target_tile_id[sky_id], ext=2)
+        
         target_data = make_target_hdu_data(fiber_data, mtl_data[mtl_tile_indices[int(sky_id)]])
         tile_data  = footprint[footprint['TILEID']==np.int(sky_id)]
         fiber_data = add_fiber_data_columns(tile_data, fiber_data, mtl_data[mtl_tile_indices[int(sky_id)]], sky_data, positioner_data)
-
-        # Make sur that the TARGETID ordering is the same both for target_data and fiber_data
+        potential_data = add_potential_data_columns(potential_data, fiber_data)
+        
+        # Make sure that the TARGETID ordering is the same both for target_data and fiber_data
         assert np.all(target_data['TARGETID'] == fiber_data['TARGETID'])
 
         #- Rename some columns (leave C++ alone; it is being refactored)

--- a/bin/fiberassign
+++ b/bin/fiberassign
@@ -281,6 +281,23 @@ def add_fiber_data_columns(tile_data, fiberassign_data, mtl_data, sky_data, posi
     
     return np.array(fiberassign_data)
 
+
+def make_target_hdu_data(fiberassign_data, mtl_data):
+    new_target_data = fiberassign_data.copy()
+    n_objects = len(new_target_data)
+    
+    print('  adding all columns from mtl data in make_target_hdu_data')
+    print(' Total of MTL points {}. Total of new_target_data {}'.format(
+            len(mtl_data), len(new_target_data)))
+
+    new_target_data = join(new_target_data, mtl_data, join_type='left', keys='TARGETID')
+    if new_target_data.masked:
+        unmatched = new_target_data['SUBPRIORITY'].mask
+        new_target_data['SUBPRIORITY'][unmatched] = 1
+    
+    return np.array(new_target_data)
+
+
 mtl_data = fitsio.read(args.mtl)
 sky_data = fitsio.read(args.sky)
 positioner_data = fitsio.read(args.positioners)
@@ -300,6 +317,7 @@ for sky_id in sky_tile_id.keys():
         sky_data = fitsio.read(sky_tile_id[sky_id])
         fiber_data = fitsio.read(target_tile_id[sky_id], ext=1)
         potential_data = fitsio.read(target_tile_id[sky_id], ext=2)
+        target_data = make_target_hdu_data(fiber_data, mtl_data[mtl_tile_indices[int(sky_id)]])
         tile_data  = footprint[footprint['TILEID']==np.int(sky_id)]
         fiber_data = add_fiber_data_columns(tile_data, fiber_data, mtl_data[mtl_tile_indices[int(sky_id)]], sky_data, positioner_data)
 
@@ -325,6 +343,7 @@ for sky_id in sky_tile_id.keys():
         fitsio.write(tileout, fiber_data, extname='FIBERASSIGN', clobber=True)
         fitsio.write(tileout, potential_data, extname='POTENTIAL')
         fitsio.write(tileout, sky_data, extname='SKYETC')
+        fitsio.write(tileout, target_data, extname='TARGETS')
 
         if args.gfafile is not None:
             gfa_data = fitsio.read(gfa_tile_id[sky_id])


### PR DESCRIPTION
This PR solves #96. It finally implements all the changes in the HDUs to follow this datamodel
https://desidatamodel.readthedocs.io/en/mockobserving/DESI_TARGET/fiberassign/tile-TILEID-FIELDNUM.html

There are only two fields missing in HDU `TARGETS`: `PSFDEPTH_W1` and `PSFDEPTH_W1` that are not included in the latest `target` files.