### PR TITLE
Add option to print version to stdout

### DIFF
--- a/bin/fiberassign
+++ b/bin/fiberassign
@@ -19,8 +19,8 @@ import shutil
 import subprocess
 
 parser = argparse.ArgumentParser()
-parser.add_argument("--mtl", type=str,  help="input targets (FITS file)", required=True)
-parser.add_argument("--sky", type=str,  help="input sky positions (FITS file)", required=True)
+parser.add_argument("--mtl", type=str,  help="input targets (FITS file)")
+parser.add_argument("--sky", type=str,  help="input sky positions (FITS file)")
 parser.add_argument("--stdstar", type=str,  help="input std stars (FITS file)")
 parser.add_argument("--fibstatusfile", type=str,  help="list of positioners and its status (ECSV or txt file)")
 parser.add_argument("--footprint", type=str,  help="list of tiles defining the footprint (FITS file)")
@@ -42,9 +42,17 @@ parser.add_argument("--nstarpetal", type=int, help="number of standard stars per
 parser.add_argument("--nskypetal", type=int, help="number of sky fibers per petal (default=40)", default=40)
 
 parser.add_argument("--nocleanup", dest='cleanup', default=True, action='store_false')
+parser.add_argument("--version",help='Print C code version and exit',action='store_true')
 
 args = parser.parse_args()
 
+if args.version:
+    cmd ="fiberassign_exec --version"
+    err = subprocess.call(cmd.split())
+    sys.exit(err)
+else:
+    if args.mtl is None or args.sky is None:
+        parser.error("fiberassign: error: the following arguments are required: --mtl, --sky")
 
 if args.footprint is None:
     args.footprint =  desimodel.io.findfile('footprint/desi-tiles.fits')

--- a/src/feat.cpp
+++ b/src/feat.cpp
@@ -16,6 +16,7 @@
 #include "misc.h"
 #include "collision.h"
 #include "feat.h"
+#include "version.h"
 
 
 void Usage (char * ExecName) {
@@ -32,6 +33,9 @@ void Usage (char * ExecName) {
     std::cout << " --nstarpetal <number of standard stars per petal>";
     std::cout << " --nskypetal <numer of sky fibers per petal>";
     std::cout << " [--rundate <YYYY-MM-DD>]" << std::endl;
+    std::cout << std::endl;
+    std::cout << " Or to print version to STDOUT: ";
+    std::cout << " --version" << std::endl;
     exit(0);
 }
 
@@ -133,6 +137,9 @@ void Feat::parseCommandLine (int argc, char * * argv) {
             Usage(argv[0]);
         } else if (!strcmp(argv[i], "-h") ) {
             Usage(argv[0]);
+        } else if (!strcmp(argv[i], "--version") ) {
+            std::cout << version() << std::endl;
+            exit(0);
         } else {
             fprintf (stderr, "\nUnrecognized option: %s\n\n", argv[i]);
             Usage(argv[0]);


### PR DESCRIPTION
I wanted to get at the version string stored in the executable from the command line, so I added a `--version` option to the C code and the python wrapper.  To make this work I changed the wrapper to handle required arguments manually rather than via `required=True` in `argparse`.

```
apcooper@cori19:~/desi/code/fiberassign> ./bin/fiberassign --version
0.9.0.dev2241
```