### PR TITLE
set NO_TARGET bit for unassigned/broken fibers

### DIFF
--- a/bin/fiberassign
+++ b/bin/fiberassign
@@ -284,6 +284,10 @@ def add_potential_data_columns(potential_data, fiberassign_data):
 
 def add_fiber_data_columns(tile_data, fiberassign_data, mtl_data, sky_data, positioner_data):
     n_objects = len(fiberassign_data)
+
+    # update DESI_TARGET for unassigned / broken / stuck fibers
+    ii = (fiberassign_data['FIBERMASK'] != 0)
+    fiberassign_data['DESI_TARGET'][ii] = desi_mask.NO_TARGET
     
     #print('  adding new columns by computation')
     #print('TILE info', tile_data['RA'], tile_data['DEC'])

--- a/bin/qa-fiberassign
+++ b/bin/qa-fiberassign
@@ -57,6 +57,10 @@ for filename in args.tilefiles:
     if len(np.unique(fa['LOCATION'])) != 5000:
         errors.append('Repeated location numbers')
 
+    num_no_desitarget = np.count_nonzero(fa['DESI_TARGET'] == 0)
+    if num_no_desitarget > 0:
+        errors.append('{} fibers with DESI_TARGET=0'.format(num_no_desitarget))
+
     is_stuck = ((fa['FIBERSTATUS'] & stuck_mask) != 0)
     is_broken = ((fa['FIBERSTATUS'] & broken_mask) != 0)
     is_unassigned = (fa['TARGETID'] < 0)

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -4,7 +4,10 @@ fiberassign change log
 0.10.3 (unreleased)
 -------------------
 
-* No changes yet.
+* Set `OBJTYPE='BAD'` and `DESI_TARGET=desi_mask.NO_TARGET` for broken, stuck,
+  and unassigned fibers (PR `#154`_).
+
+.. _`#154`: https://github.com/desihub/fiberassign/pull/154
 
 0.10.2 (2018-11-07)
 -------------------


### PR DESCRIPTION
Sets `DESI_TARGET` bit `NO_TARGET` in the case that a fiber isn't assigned to any target, e.g. because the fiber is broken/stuck and couldn't reach a target, or because there were no input targets covered by that fiber.  This fixes a downstream problem when `DESI_TARGET==0`, and also correctly sets these as `OBJTYPE='BAD'` instead of `TGT`.

I also added this to `qa-fiberassign` so that if we miss this in the refactored branch, it will be highlighted by the QA.

I'd like to include this with the 18.12 release so planning to self-merge.