### PR TITLE
fix POTENTIAL table

### DIFF
--- a/bin/fiberassign
+++ b/bin/fiberassign
@@ -367,14 +367,22 @@ for sky_id in sky_tile_id.keys():
         sky_data = fitsio.read(sky_tile_id[sky_id])
         fiber_data = fitsio.read(target_tile_id[sky_id], ext=1)
         potential_data = fitsio.read(target_tile_id[sky_id], ext=2)
-        
+
         target_data = make_target_hdu_data(fiber_data, mtl_data[mtl_tile_indices[int(sky_id)]])
         tile_data  = footprint[footprint['TILEID']==np.int(sky_id)]
         fiber_data = add_fiber_data_columns(tile_data, fiber_data, mtl_data[mtl_tile_indices[int(sky_id)]], sky_data, positioner_data)
-        potential_data = add_potential_data_columns(potential_data, fiber_data)
-        
-        # Make sure that the TARGETID ordering is the same both for target_data and fiber_data
+
+        #- The joins in make_target_hdu_data and add_fiber_data_columns
+        #- sort by TARGETID; get back to FIBERID sorting to be able to
+        #- interpret the potential_data list
         assert np.all(target_data['TARGETID'] == fiber_data['TARGETID'])
+        ii = np.argsort(fiber_data['FIBER'])
+        target_data = target_data[ii]
+        fiber_data = fiber_data[ii]
+        assert np.all(target_data['TARGETID'] == fiber_data['TARGETID'])
+
+        #- Unpack the potential targetids into FIBER LOCATION TARGETID
+        potential_data = add_potential_data_columns(potential_data, fiber_data)
 
         #- Rename some columns (leave C++ alone; it is being refactored)
         colnames = list(fiber_data.dtype.names)
@@ -396,11 +404,10 @@ for sky_id in sky_tile_id.keys():
         fiber_data.dtype.names = tuple(colnames)
 
         tileout = os.path.join(args.outdir, 'tile_{}.fits'.format(sky_id))
-        ii = np.argsort(fiber_data['FIBER'])
-        fitsio.write(tileout, fiber_data[ii], extname='FIBERASSIGN', clobber=True)
+        fitsio.write(tileout, fiber_data, extname='FIBERASSIGN', clobber=True)
         fitsio.write(tileout, potential_data, extname='POTENTIAL')
         fitsio.write(tileout, sky_data, extname='SKYETC')
-        fitsio.write(tileout, target_data[ii], extname='TARGETS')
+        fitsio.write(tileout, target_data, extname='TARGETS')
 
         if args.gfafile is not None:
             gfa_data = fitsio.read(gfa_tile_id[sky_id])

--- a/bin/qa-fiberassign
+++ b/bin/qa-fiberassign
@@ -47,8 +47,9 @@ for filename in args.tilefiles:
     fa = Table.read(filename, 'FIBERASSIGN')
     fa.sort('FIBER')
     assigned.append(fa)
-    tmp = Table.read(filename, 'POTENTIAL')['TARGETID']
-    covered.append(np.unique(tmp))
+    potential = Table.read(filename, 'POTENTIAL')
+    covered.append(np.unique(potential['TARGETID']))
+
     errors = list()
 
     if len(np.unique(fa['FIBER'])) != 5000:
@@ -56,6 +57,15 @@ for filename in args.tilefiles:
 
     if len(np.unique(fa['LOCATION'])) != 5000:
         errors.append('Repeated location numbers')
+
+    #- There should be a faster way to do this
+    for fiber, targetid in zip(fa['FIBER'], fa['TARGETID']):
+        if targetid<0:
+            continue
+        ii = (potential['FIBER'] == fiber)
+        if targetid not in potential['TARGETID'][ii]:
+            errors.append('Assigned targets not in covered targets list')
+            break
 
     num_no_desitarget = np.count_nonzero(fa['DESI_TARGET'] == 0)
     if num_no_desitarget > 0:


### PR DESCRIPTION
This PR fixes #155 where the assigned TARGETID for each fiber didn't appear in the potential assignments list for each fiber.  It was a side affect of PR #147 that ensured that the FIBERASSIGN HDU output was sorted by TARGETID.

I also added a check in `qa-fiberassign` that would have caught this.

@tskisner a new fiberassign run of the 18.11 target list is in /global/cscratch1/sd/sjbailey/desi/fiberassign/18.11-redo .  Please check whether those potential assignments more closely match what you have in the tsk_refactor branch.