### PR TITLE
Pass footprint arg to all load_tiles calls

### DIFF
--- a/bin/fiberassign
+++ b/bin/fiberassign
@@ -437,7 +437,7 @@ positioner_data = fitsio.read(args.positioners)
 footprint = fitsio.read(args.footprint)
 
 #- Load DESI tiles to provide header keywords; convert to dict for fast lookup
-tiles = desimodel.io.load_tiles()
+tiles = desimodel.io.load_tiles(tilesfile=args.footprint)
 tileinfo = dict()
 for i in range(len(tiles)):
     tileid = tiles['TILEID'][i]


### PR DESCRIPTION
When `bin/fiberassign` calls `load_tiles()`, I think it should always use the `tilefiles` argument to pass the tilefile path given in `args.footprint`.

This was missing in a call to `load_tiles` added in a recent commit, so tileids from a custom tileset would be confused with those in the default DESI tile set (in the loop just below the change).