### PR TITLE
allow user to override sciencemask, stdmask, etc.

### DIFF
--- a/bin/fba_run
+++ b/bin/fba_run
@@ -10,8 +10,6 @@ import argparse
 
 from datetime import datetime
 
-import desimodel.io
-
 from desitarget.targetmask import desi_mask
 
 from fiberassign.utils import GlobalTimers, Logger
@@ -32,6 +30,7 @@ from fiberassign.targets import (str_to_target_type, TARGET_TYPE_SCIENCE,
                                  )
 
 from fiberassign.assign import (Assignment, write_assignment_fits, result_path)
+
 
 def main():
     log = Logger.get()
@@ -114,11 +113,13 @@ def main():
 
     parser.add_argument("--sciencemask", required=False,
                         default=get_sciencemask(),
-                        help="Default DESI_TARGET mask to use for science targets")
+                        help="Default DESI_TARGET mask to use for science "
+                             "targets")
 
     parser.add_argument("--stdmask", required=False,
                         default=get_stdmask(),
-                        help="Default DESI_TARGET mask to use for stdstar targets")
+                        help="Default DESI_TARGET mask to use for stdstar "
+                             "targets")
 
     parser.add_argument("--skymask", required=False,
                         default=get_skymask(),
@@ -152,11 +153,13 @@ def main():
     if type(args.excludemask) == str:
         args.excludemask = desi_mask.mask(args.excludemask)
 
-    log.info('sciencemask {}'.format(' '.join(desi_mask.names(args.sciencemask))))
-    log.info('stdmask     {}'.format(' '.join(desi_mask.names(args.stdmask))))
-    log.info('skymask     {}'.format(' '.join(desi_mask.names(args.skymask))))
-    log.info('safemask    {}'.format(' '.join(desi_mask.names(args.safemask))))
-    log.info('excludemask {}'.format(' '.join(desi_mask.names(args.excludemask))))
+    log.info("sciencemask {}".format(
+        " ".join(desi_mask.names(args.sciencemask))))
+    log.info("stdmask     {}".format(" ".join(desi_mask.names(args.stdmask))))
+    log.info("skymask     {}".format(" ".join(desi_mask.names(args.skymask))))
+    log.info("safemask    {}".format(" ".join(desi_mask.names(args.safemask))))
+    log.info("excludemask {}".format(
+        " ".join(desi_mask.names(args.excludemask))))
 
     # Get run date
     rundate = None
@@ -192,11 +195,11 @@ def main():
     if not args.overwrite:
         for tileid in tiles.id:
             outfile = result_path(tileid, dir=args.dir,
-                    prefix=args.prefix, split=args.split)
+                                  prefix=args.prefix, split=args.split)
             if os.path.exists(outfile):
                 outdir = os.path.split(outfile)[0]
-                log.error('Output files already exist in {}'.format(outdir))
-                log.error('either remove them or use --overwrite')
+                log.error("Output files already exist in {}".format(outdir))
+                log.error("either remove them or use --overwrite")
                 sys.exit(1)
 
     # Create empty target list
@@ -211,12 +214,11 @@ def main():
             # we are forcing the target type for this file
             typeforce = str_to_target_type(tgprops[1])
         load_target_file(tgs, tgfile, typeforce=typeforce,
-            sciencemask=args.sciencemask,
-            stdmask=args.stdmask,
-            skymask=args.skymask,
-            safemask=args.safemask,
-            excludemask=args.excludemask,
-            )
+                         sciencemask=args.sciencemask,
+                         stdmask=args.stdmask,
+                         skymask=args.skymask,
+                         safemask=args.safemask,
+                         excludemask=args.excludemask)
 
     # Create a hierarchical triangle mesh lookup of the targets positions
     tree = TargetTree(tgs)

--- a/bin/fba_run
+++ b/bin/fba_run
@@ -12,6 +12,8 @@ from datetime import datetime
 
 import desimodel.io
 
+from desitarget.targetmask import desi_mask
+
 from fiberassign.utils import GlobalTimers, Logger
 
 from fiberassign.hardware import load_hardware
@@ -24,10 +26,12 @@ from fiberassign.targets import (str_to_target_type, TARGET_TYPE_SCIENCE,
                                  TARGET_TYPE_SKY, TARGET_TYPE_STANDARD,
                                  TARGET_TYPE_SAFE, Targets, TargetsAvailable,
                                  TargetTree, FibersAvailable,
-                                 load_target_file)
+                                 load_target_file,
+                                 get_sciencemask, get_stdmask, get_skymask,
+                                 get_safemask, get_excludemask
+                                 )
 
 from fiberassign.assign import (Assignment, write_assignment_fits, result_path)
-
 
 def main():
     log = Logger.get()
@@ -108,7 +112,51 @@ def main():
                         action="store_true",
                         help="Overwrite any pre-existing output files")
 
+    parser.add_argument("--sciencemask", required=False,
+                        default=get_sciencemask(),
+                        help="Default DESI_TARGET mask to use for science targets")
+
+    parser.add_argument("--stdmask", required=False,
+                        default=get_stdmask(),
+                        help="Default DESI_TARGET mask to use for stdstar targets")
+
+    parser.add_argument("--skymask", required=False,
+                        default=get_skymask(),
+                        help="Default DESI_TARGET mask to use for sky targets")
+
+    parser.add_argument("--safemask", required=False,
+                        default=get_safemask(),
+                        help="Default DESI_TARGET mask to use for safe "
+                        "backup targets")
+
+    parser.add_argument("--excludemask", required=False,
+                        default=get_excludemask(),
+                        help="Default DESI_TARGET mask to exclude from "
+                        "any assignments")
+
     args = parser.parse_args()
+
+    # Allow sciencemask, stdmask, etc. to be int or string
+    if type(args.sciencemask) == str:
+        args.sciencemask = desi_mask.mask(args.sciencemask)
+
+    if type(args.stdmask) == str:
+        args.stdmask = desi_mask.mask(args.stdmask)
+
+    if type(args.skymask) == str:
+        args.skymask = desi_mask.mask(args.skymask)
+
+    if type(args.safemask) == str:
+        args.safemask = desi_mask.mask(args.safemask)
+
+    if type(args.excludemask) == str:
+        args.excludemask = desi_mask.mask(args.excludemask)
+
+    log.info('sciencemask {}'.format(' '.join(desi_mask.names(args.sciencemask))))
+    log.info('stdmask     {}'.format(' '.join(desi_mask.names(args.stdmask))))
+    log.info('skymask     {}'.format(' '.join(desi_mask.names(args.skymask))))
+    log.info('safemask    {}'.format(' '.join(desi_mask.names(args.safemask))))
+    log.info('excludemask {}'.format(' '.join(desi_mask.names(args.excludemask))))
 
     # Get run date
     rundate = None
@@ -162,7 +210,13 @@ def main():
         if len(tgprops) > 1:
             # we are forcing the target type for this file
             typeforce = str_to_target_type(tgprops[1])
-        load_target_file(tgs, tgfile, typeforce=typeforce)
+        load_target_file(tgs, tgfile, typeforce=typeforce,
+            sciencemask=args.sciencemask,
+            stdmask=args.stdmask,
+            skymask=args.skymask,
+            safemask=args.safemask,
+            excludemask=args.excludemask,
+            )
 
     # Create a hierarchical triangle mesh lookup of the targets positions
     tree = TargetTree(tgs)

--- a/py/fiberassign/assign.py
+++ b/py/fiberassign/assign.py
@@ -180,14 +180,14 @@ def write_assignment_fits_tile(asgn, fulltarget, overwrite, params):
 
         if os.path.isfile(tile_file):
             if overwrite:
-                log.warning('Overwriting {}'.format(tile_file))
+                log.warning("Overwriting {}".format(tile_file))
                 os.remove(tile_file)
             else:
                 raise RuntimeError("output file {} already exists"
                                    .format(tile_file))
         # This tile has some available targets
         log.info("Writing tile {}".format(tile_id))
-        tmp_file = tile_file + '.tmp'
+        tmp_file = tile_file + ".tmp"
         fd = fitsio.FITS(tmp_file, "rw")
 
         tm.stop()
@@ -612,7 +612,8 @@ def read_assignment_fits_tile(params):
             if col == "FBATYPE":
                 # targets_data[col] = [desi_target_type(x) for x in
                 #                      fbassign["DESI_TARGET"][tgrows]]
-                targets_data[col] = desi_target_type(fbassign["DESI_TARGET"][tgrows])
+                targets_data[col] = \
+                    desi_target_type(fbassign["DESI_TARGET"][tgrows])
             else:
                 targets_data[col] = fbassign[col][tgrows]
         del fbassign

--- a/py/fiberassign/assign.py
+++ b/py/fiberassign/assign.py
@@ -610,8 +610,9 @@ def read_assignment_fits_tile(params):
         targets_data = np.zeros(ntarget, dtype=targets_dtype)
         for col in results_targets_columns.keys():
             if col == "FBATYPE":
-                targets_data[col] = [desi_target_type(x) for x in
-                                     fbassign["DESI_TARGET"][tgrows]]
+                # targets_data[col] = [desi_target_type(x) for x in
+                #                      fbassign["DESI_TARGET"][tgrows]]
+                targets_data[col] = desi_target_type(fbassign["DESI_TARGET"][tgrows])
             else:
                 targets_data[col] = fbassign[col][tgrows]
         del fbassign

--- a/py/fiberassign/targets.py
+++ b/py/fiberassign/targets.py
@@ -36,8 +36,9 @@ def str_to_target_type(input):
         raise ValueError("unknown target type '{}'".format(input))
     return None
 
+
 def get_sciencemask():
-    '''Returns default mask for which DESI_TARGET bits are science targets'''
+    """Returns default mask for which DESI_TARGET bits are science targets"""
     sciencemask = 0
     sciencemask |= desi_mask["LRG"].mask
     sciencemask |= desi_mask["ELG"].mask
@@ -49,40 +50,45 @@ def get_sciencemask():
     sciencemask |= desi_mask["SECONDARY_ANY"].mask
     return sciencemask
 
+
 def get_stdmask():
-    '''Returns default mask for which DESI_TARGET bits are stdstar targets'''
+    """Returns default mask for which DESI_TARGET bits are stdstar targets"""
     stdmask = 0
     stdmask |= desi_mask["STD_FAINT"].mask
     stdmask |= desi_mask["STD_WD"].mask
     stdmask |= desi_mask["STD_BRIGHT"].mask
     return stdmask
 
+
 def get_skymask():
-    '''Returns default mask for which DESI_TARGET bits are sky targets'''
+    """Returns default mask for which DESI_TARGET bits are sky targets"""
     skymask = 0
     skymask |= desi_mask["SKY"].mask
     return skymask
 
+
 def get_safemask():
-    '''
+    """
     Returns default mask for which DESI_TARGET bits are backup/safe targets
 
     Note: these are targets of last resort; they are safe locations where
     we won't saturate the detector, but aren't good for anything else.
-    '''
+    """
     safemask = 0
     safemask |= desi_mask.BAD_SKY
     return safemask
 
+
 def get_excludemask():
-    '''
+    """
     Returns default DESI_TARGET mask for bits that should not be observed
-    '''
+    """
     excludemask = 0
-    #- Exclude BRIGHT_OBJECT and IN_BRIGHT_OBJECT, but not NEAR_BRIGHT_OBJECT
+    # Exclude BRIGHT_OBJECT and IN_BRIGHT_OBJECT, but not NEAR_BRIGHT_OBJECT
     excludemask |= desi_mask.BRIGHT_OBJECT
     excludemask |= desi_mask.IN_BRIGHT_OBJECT
     return excludemask
+
 
 def desi_target_type(desi_target, sciencemask=None, stdmask=None,
                      skymask=None, safemask=None, excludemask=None):
@@ -167,10 +173,9 @@ def append_target_table(tgs, tgdata, typeforce=None, typecol=None,
                 raise RuntimeError("FBATYPE column not found- specify typecol")
             d_type[:] = tgdata["FBATYPE"]
         else:
-            d_type[:] = desi_target_type(tgdata[typecol],
-                            sciencemask=sciencemask, stdmask=stdmask,
-                            skymask=skymask, safemask=safemask,
-                            excludemask=excludemask)
+            d_type[:] = desi_target_type(
+                tgdata[typecol], sciencemask=sciencemask, stdmask=stdmask,
+                skymask=skymask, safemask=safemask, excludemask=excludemask)
 
     if "OBSCONDITIONS" in tgdata.dtype.fields:
         d_obscond[:] = tgdata["OBSCONDITIONS"]

--- a/py/fiberassign/targets.py
+++ b/py/fiberassign/targets.py
@@ -36,50 +36,100 @@ def str_to_target_type(input):
         raise ValueError("unknown target type '{}'".format(input))
     return None
 
+def get_sciencemask():
+    '''Returns default mask for which DESI_TARGET bits are science targets'''
+    sciencemask = 0
+    sciencemask |= desi_mask["LRG"].mask
+    sciencemask |= desi_mask["ELG"].mask
+    sciencemask |= desi_mask["QSO"].mask
+    # Note: BAD_SKY are treated as science targets with priority == 0
+    sciencemask |= desi_mask["BAD_SKY"].mask
+    sciencemask |= desi_mask["BGS_ANY"].mask
+    sciencemask |= desi_mask["MWS_ANY"].mask
+    sciencemask |= desi_mask["SECONDARY_ANY"].mask
+    return sciencemask
+
+def get_stdmask():
+    '''Returns default mask for which DESI_TARGET bits are stdstar targets'''
+    stdmask = 0
+    stdmask |= desi_mask["STD_FAINT"].mask
+    stdmask |= desi_mask["STD_WD"].mask
+    stdmask |= desi_mask["STD_BRIGHT"].mask
+    return stdmask
+
+def get_skymask():
+    '''Returns default mask for which DESI_TARGET bits are sky targets'''
+    skymask = 0
+    skymask |= desi_mask["SKY"].mask
+    return skymask
+
+def get_safemask():
+    '''
+    Returns default mask for which DESI_TARGET bits are backup/safe targets
+
+    Note: these are targets of last resort; they are safe locations where
+    we won't saturate the detector, but aren't good for anything else.
+    '''
+    safemask = 0
+    safemask |= desi_mask.BAD_SKY
+    return safemask
+
+def get_excludemask():
+    '''
+    Returns default DESI_TARGET mask for bits that should not be observed
+    '''
+    excludemask = 0
+    #- Exclude BRIGHT_OBJECT and IN_BRIGHT_OBJECT, but not NEAR_BRIGHT_OBJECT
+    excludemask |= desi_mask.BRIGHT_OBJECT
+    excludemask |= desi_mask.IN_BRIGHT_OBJECT
+    return excludemask
 
 def desi_target_type(desi_target, sciencemask=None, stdmask=None,
-                     skymask=None, safemask=None):
+                     skymask=None, safemask=None, excludemask=None):
     """Determine fiber assign type from DESI_TARGET.
     """
     if sciencemask is None:
-        sciencemask = 0
-        sciencemask |= desi_mask["LRG"].mask
-        sciencemask |= desi_mask["ELG"].mask
-        sciencemask |= desi_mask["QSO"].mask
-        # Note: BAD_SKY are treated as science targets with priority == 0
-        sciencemask |= desi_mask["BAD_SKY"].mask
-        sciencemask |= desi_mask["BGS_ANY"].mask
-        sciencemask |= desi_mask["MWS_ANY"].mask
-        sciencemask |= desi_mask["SECONDARY_ANY"].mask
+        sciencemask = get_sciencemask()
 
     if stdmask is None:
-        stdmask = 0
-        stdmask |= desi_mask["STD_FAINT"].mask
-        stdmask |= desi_mask["STD_WD"].mask
-        stdmask |= desi_mask["STD_BRIGHT"].mask
+        stdmask = get_stdmask()
 
     if skymask is None:
-        skymask = 0
-        skymask |= desi_mask["SKY"].mask
+        skymask = get_skymask()
 
     if safemask is None:
-        safemask = 0
+        safemask = get_safemask()
 
-    ttype = 0
-    if desi_target & sciencemask != 0:
-        ttype |= TARGET_TYPE_SCIENCE
-    if desi_target & stdmask != 0:
-        ttype |= TARGET_TYPE_STANDARD
-    if desi_target & skymask != 0:
-        ttype |= TARGET_TYPE_SKY
-    if desi_target & safemask != 0:
-        ttype |= TARGET_TYPE_SAFE
+    if excludemask is None:
+        excludemask = get_excludemask()
+
+    if np.isscalar(desi_target):
+        ttype = 0
+        if desi_target & sciencemask != 0:
+            ttype |= TARGET_TYPE_SCIENCE
+        if desi_target & stdmask != 0:
+            ttype |= TARGET_TYPE_STANDARD
+        if desi_target & skymask != 0:
+            ttype |= TARGET_TYPE_SKY
+        if desi_target & safemask != 0:
+            ttype |= TARGET_TYPE_SAFE
+        if desi_target & excludemask != 0:
+            ttype = 0
+    else:
+        desi_target = np.asarray(desi_target)
+        ttype = np.zeros(len(desi_target), dtype=int)
+        ttype[desi_target & sciencemask != 0] |= TARGET_TYPE_SCIENCE
+        ttype[desi_target & stdmask != 0] |= TARGET_TYPE_STANDARD
+        ttype[desi_target & skymask != 0] |= TARGET_TYPE_SKY
+        ttype[desi_target & safemask != 0] |= TARGET_TYPE_SAFE
+        ttype[desi_target & excludemask != 0] = 0
+
     return ttype
 
 
 def append_target_table(tgs, tgdata, typeforce=None, typecol=None,
                         sciencemask=None, stdmask=None, skymask=None,
-                        safemask=None):
+                        safemask=None, excludemask=None):
     validtypes = [
         TARGET_TYPE_SCIENCE,
         TARGET_TYPE_SKY,
@@ -117,9 +167,10 @@ def append_target_table(tgs, tgdata, typeforce=None, typecol=None,
                 raise RuntimeError("FBATYPE column not found- specify typecol")
             d_type[:] = tgdata["FBATYPE"]
         else:
-            d_type[:] = [desi_target_type(x, sciencemask=sciencemask,
-                         stdmask=stdmask, skymask=skymask,
-                         safemask=safemask) for x in tgdata[typecol]]
+            d_type[:] = desi_target_type(tgdata[typecol],
+                            sciencemask=sciencemask, stdmask=stdmask,
+                            skymask=skymask, safemask=safemask,
+                            excludemask=excludemask)
 
     if "OBSCONDITIONS" in tgdata.dtype.fields:
         d_obscond[:] = tgdata["OBSCONDITIONS"]
@@ -151,7 +202,7 @@ def append_target_table(tgs, tgdata, typeforce=None, typecol=None,
 
 def load_target_file(tgs, tfile, typeforce=None, typecol="DESI_TARGET",
                      sciencemask=None, stdmask=None, skymask=None,
-                     safemask=None, rowbuffer=100000):
+                     safemask=None, excludemask=None, rowbuffer=100000):
     tm = Timer()
     tm.start()
 
@@ -176,7 +227,8 @@ def load_target_file(tgs, tfile, typeforce=None, typecol="DESI_TARGET",
                   .format(tfile, offset, offset+n-1))
         append_target_table(tgs, data, typeforce=typeforce, typecol=typecol,
                             sciencemask=sciencemask, stdmask=stdmask,
-                            skymask=skymask, safemask=safemask)
+                            skymask=skymask, safemask=safemask,
+                            excludemask=excludemask)
         offset += n
 
     tm.stop()

--- a/py/fiberassign/test/test_targets.py
+++ b/py/fiberassign/test/test_targets.py
@@ -6,12 +6,17 @@ import os
 
 import unittest
 
+import numpy as np
+
+from desitarget.targetmask import desi_mask
+
 from fiberassign.hardware import load_hardware
 
 from fiberassign.tiles import load_tiles
 
 from fiberassign.targets import (TARGET_TYPE_SCIENCE, TARGET_TYPE_SKY,
                                  TARGET_TYPE_STANDARD, load_target_file,
+                                 desi_target_type,
                                  Targets, TargetTree, TargetsAvailable,
                                  FibersAvailable)
 
@@ -58,3 +63,44 @@ class TestTargets(unittest.TestCase):
         favail = FibersAvailable(tgsavail)
 
         return
+
+    def test_target_type(self):
+        '''
+        test fiberassign.targets.desi_target_type()
+        '''
+        #- Array inputs
+        desi_target = [
+            desi_mask['ELG'].mask,
+            desi_mask['STD_FAINT'].mask,
+            desi_mask['SKY'].mask,
+            desi_mask['IN_BRIGHT_OBJECT'].mask,
+            ]
+        fbatype = np.array([
+            TARGET_TYPE_SCIENCE,
+            TARGET_TYPE_STANDARD,
+            TARGET_TYPE_SKY,
+            0
+            ])
+        result = desi_target_type(desi_target)
+        self.assertTrue(np.all(result == fbatype))
+
+        #- Scalar inputs
+        for i in range(len(desi_target)):
+            result = desi_target_type(desi_target[i])
+            self.assertEqual(result, fbatype[i])
+
+        #- Does excludemask work?
+        mask = desi_mask['ELG'].mask
+        result = desi_target_type(mask)
+        self.assertEqual(result, TARGET_TYPE_SCIENCE)
+        result = desi_target_type(mask, excludemask=mask)
+        self.assertEqual(result, 0)
+        result = desi_target_type([mask,mask], excludemask=mask)
+        self.assertTrue(not np.any(result))
+
+def test_suite():
+    """Allows testing of only this module with the command::
+
+        python setup.py test -m fiberassign.test.test_targets
+    """
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/fiberassign/test/test_targets.py
+++ b/py/fiberassign/test/test_targets.py
@@ -65,15 +65,15 @@ class TestTargets(unittest.TestCase):
         return
 
     def test_target_type(self):
-        '''
+        """
         test fiberassign.targets.desi_target_type()
-        '''
-        #- Array inputs
+        """
+        # Array inputs
         desi_target = [
-            desi_mask['ELG'].mask,
-            desi_mask['STD_FAINT'].mask,
-            desi_mask['SKY'].mask,
-            desi_mask['IN_BRIGHT_OBJECT'].mask,
+            desi_mask["ELG"].mask,
+            desi_mask["STD_FAINT"].mask,
+            desi_mask["SKY"].mask,
+            desi_mask["IN_BRIGHT_OBJECT"].mask,
             ]
         fbatype = np.array([
             TARGET_TYPE_SCIENCE,
@@ -84,19 +84,20 @@ class TestTargets(unittest.TestCase):
         result = desi_target_type(desi_target)
         self.assertTrue(np.all(result == fbatype))
 
-        #- Scalar inputs
+        # Scalar inputs
         for i in range(len(desi_target)):
             result = desi_target_type(desi_target[i])
             self.assertEqual(result, fbatype[i])
 
-        #- Does excludemask work?
-        mask = desi_mask['ELG'].mask
+        # Does excludemask work?
+        mask = desi_mask["ELG"].mask
         result = desi_target_type(mask)
         self.assertEqual(result, TARGET_TYPE_SCIENCE)
         result = desi_target_type(mask, excludemask=mask)
         self.assertEqual(result, 0)
-        result = desi_target_type([mask,mask], excludemask=mask)
+        result = desi_target_type([mask, mask], excludemask=mask)
         self.assertTrue(not np.any(result))
+
 
 def test_suite():
     """Allows testing of only this module with the command::


### PR DESCRIPTION
This PR allows the user to override sciencemask, stdmask, safemask, and skymask via `fba_run` command line arguments.  These can either be int or string, e.g.
```
fba_run ... --sciencemask 3
fba_run ... --sciencemask LRG,ELG
```

It also introduces an `excludemask`, which will exclude any targets that have bits matching that mask set.  The default is `BRIGHT_OBJECT` and `IN_BRIGHT_OBJECT`.  Targets with those bits set may be in the target files but should never be assigned a fiber.

Question: This PR changes the default safemask to `BAD_SKY` instead of 0.  I know that the concept of safe targets was deprecated (at my request) by just treating BAD_SKY targets as ultra low priority normal targets, but the code was left in place in case I changed my mind (which I probably have but I don't recall why...).  Will setting safemask != 0 mess that up?

Along the way this update also allows `fiberassign.targets.desi_target_type(desi_target)` to accept scalar or vector inputs instead of just scalars.

Note: this PR is in to the tsk_refactor branch, not the master branch.  It is filling in some features needed to provide a backwards compatible `fiberassign` script that wraps `fba_run` and `fba_merge` using the same syntax as current master `fiberassign`.