### PR TITLE
support NUMOBS_INIT and PRIORITY_INIT

### DIFF
--- a/py/fiberassign/targets.py
+++ b/py/fiberassign/targets.py
@@ -185,11 +185,15 @@ def append_target_table(tgs, tgdata, typeforce=None, typecol=None,
 
     if "NUMOBS_MORE" in tgdata.dtype.fields:
         d_nobs[:] = tgdata["NUMOBS_MORE"]
+    elif "NUMOBS_INIT" in tgdata.dtype.fields:
+        d_nobs[:] = tgdata["NUMOBS_INIT"]
     else:
         d_nobs[:] = np.zeros(nrows, dtype=np.int32)
 
     if "PRIORITY" in tgdata.dtype.fields:
         d_prior[:] = tgdata["PRIORITY"]
+    elif "PRIORITY_INIT" in tgdata.dtype.fields:
+        d_prior[:] = tgdata["PRIORITY_INIT"]
     else:
         d_prior[:] = np.zeros(nrows, dtype=np.int32)
 


### PR DESCRIPTION
Now that that input target files have `NUMOBS_INIT` and `PRIORITY_INIT` columns, it is a bit of a hassle to have to convert those to the MTL format with `NUMOBS_MORE` and `PRIORITY` columns before being able to run fiber assignment.  This PR updates `fiberassign.targets.append_target_table` so that it will use `NUMOBS_MORE` and `PRIORITY` if they exist (i.e. no changes when running with MTL files), but it will also fall back to using `NUMOBS_INIT` and `PRIORITY_INIT` if they don't, thus enabling `fba_run` to work on raw target files without pre-processing them through `desitarget.mtl.make_mtl` first.  This will make it more convenient to run fiber assignment on target lists for CMX and SV, where we won't be updating `NUMOBS_MORE` and `PRIORITY` based upon prior observations and redshift fits.

I acknowledge that this is beyond the baseline for the minimalist refactor requirement of "prioritize backwards compatibility while still being correct", but the increase of usefulness seemed worth the extra 4 lines of code.