### PR TITLE
Apply per-petal standards limits when assigning science targets.

### DIFF
--- a/bin/fba_run
+++ b/bin/fba_run
@@ -242,33 +242,34 @@ def main():
     asgn = Assignment(tgs, tgsavail, favail)
 
     # First-pass assignment of science targets
-    asgn.assign_unused(TARGET_TYPE_SCIENCE)
+    asgn.assign_unused(TARGET_TYPE_SCIENCE, -1, "POS", -1, -1,
+                       args.standards_per_petal)
 
     # Redistribute science targets across available petals
-    asgn.redistribute_science()
+    asgn.redistribute_science(-1, -1, args.standards_per_petal)
 
-    # Assign standards, 10 per petal
-    asgn.assign_unused(TARGET_TYPE_STANDARD, args.standards_per_petal)
-    asgn.assign_force(TARGET_TYPE_STANDARD, args.standards_per_petal)
-
-    # Assign sky to unused fibers, up to 40 per petal
-    asgn.assign_unused(TARGET_TYPE_SKY, args.sky_per_petal)
-    asgn.assign_force(TARGET_TYPE_SKY, args.sky_per_petal)
-
-    # If there are any unassigned fibers, try to place them somewhere.
-    asgn.assign_unused(TARGET_TYPE_SCIENCE)
-    asgn.assign_unused(TARGET_TYPE_SKY)
-
-    # NOTE:  This was removed since we are treating BAD_SKY as science targets
-    # with very low priority.
+    # # Assign standards, 10 per petal
+    # asgn.assign_unused(TARGET_TYPE_STANDARD, args.standards_per_petal)
+    # asgn.assign_force(TARGET_TYPE_STANDARD, args.standards_per_petal)
     #
-    # # Assign safe location to unused fibers (no maximum).  There should
-    # # always be at least one safe location (i.e. "BAD_SKY") for each fiber.
-    # # So after this is run every fiber should be assigned to something.
-    # asgn.assign_unused(TARGET_TYPE_SAFE)
-
-    # Assign sky monitor fibers
-    asgn.assign_unused(TARGET_TYPE_SKY, -1, "ETC")
+    # # Assign sky to unused fibers, up to 40 per petal
+    # asgn.assign_unused(TARGET_TYPE_SKY, args.sky_per_petal)
+    # asgn.assign_force(TARGET_TYPE_SKY, args.sky_per_petal)
+    #
+    # # If there are any unassigned fibers, try to place them somewhere.
+    # asgn.assign_unused(TARGET_TYPE_SCIENCE)
+    # asgn.assign_unused(TARGET_TYPE_SKY)
+    #
+    # # NOTE:  This was removed since we are treating BAD_SKY as science targets
+    # # with very low priority.
+    # #
+    # # # Assign safe location to unused fibers (no maximum).  There should
+    # # # always be at least one safe location (i.e. "BAD_SKY") for each fiber.
+    # # # So after this is run every fiber should be assigned to something.
+    # # asgn.assign_unused(TARGET_TYPE_SAFE)
+    #
+    # # Assign sky monitor fibers
+    # asgn.assign_unused(TARGET_TYPE_SKY, -1, "ETC")
 
     gt.stop("total calculation")
     gt.start("total write output")

--- a/src/_pyfiberassign.cpp
+++ b/src/_pyfiberassign.cpp
@@ -565,15 +565,18 @@ PYBIND11_MODULE(_internal, m) {
         .def("tile_fiber_target", &fba::Assignment::tile_fiber_target,
             py::return_value_policy::reference_internal)
         .def("assign_unused", &fba::Assignment::assign_unused,
-             py::arg("tgtype")=TARGET_TYPE_SCIENCE, py::arg("max_per_petal")=-1,
+             py::arg("tgtype")=TARGET_TYPE_SCIENCE,
+             py::arg("max_per_petal")=-1,
              py::arg("pos_type")=std::string("POS"),
-             py::arg("start_tile")=-1, py::arg("stop_tile")=-1)
+             py::arg("start_tile")=-1, py::arg("stop_tile")=-1,
+             py::arg("max_standards_petal")=-1)
         .def("assign_force", &fba::Assignment::assign_force,
              py::arg("tgtype")=TARGET_TYPE_SCIENCE,
              py::arg("required_per_petal")=0,
              py::arg("start_tile")=-1, py::arg("stop_tile")=-1)
         .def("redistribute_science", &fba::Assignment::redistribute_science,
-             py::arg("start_tile")=-1, py::arg("stop_tile")=-1);
+             py::arg("start_tile")=-1, py::arg("stop_tile")=-1,
+             py::arg("max_standards_petal")=-1);
 
 
 }

--- a/src/assign.h
+++ b/src/assign.h
@@ -32,13 +32,15 @@ class Assignment : public std::enable_shared_from_this <Assignment> {
 
         void assign_unused(uint8_t tgtype, int32_t max_per_petal = -1,
                            std::string const & pos_type = std::string("POS"),
-                           int32_t start_tile = -1, int32_t stop_tile = -1);
+                           int32_t start_tile = -1, int32_t stop_tile = -1,
+                           int32_t max_standards_petal = -1);
 
         void assign_force(uint8_t tgtype, int32_t required_per_petal = 0,
                           int32_t start_tile = -1, int32_t stop_tile = -1);
 
         void redistribute_science(int32_t start_tile = -1,
-                                  int32_t stop_tile = -1);
+                                  int32_t stop_tile = -1,
+                                  int32_t max_standards_petal = -1);
 
         Hardware::pshr hardware() const;
 
@@ -97,6 +99,7 @@ class Assignment : public std::enable_shared_from_this <Assignment> {
         void reassign_science_target(int32_t tstart, int32_t tstop,
             int32_t tile, int32_t fiber, int64_t target, bool balance_petals,
             std::map <int32_t, std::map <int32_t, bool> > const & done,
+            int32_t max_standards_petal,
             int32_t & best_tile, int32_t & best_fiber) const;
 
         // The number of assigned fibers per tile and spectrograph (petal)


### PR DESCRIPTION
This PR is against the tsk_refactor branch and should NOT be merged as-is.  This is a demonstration of changes needed to account for per-petal standard limits when assigning science targets.

Essentially a new argument is added to the assign_unused and redistribute_science methods.  This argument is the maximum standards per petal limit to use when assigning things that are both standards and science targets.  This is a follow up the discussion in #165, where I mentioned that greater than 10 standards were being assigned per petal in some cases during the assignment of science targets (i.e. prior to any intentional assignment of standards).

It is not clear to me that this new behavior is desired, but here is a comparison.  First the existing code in tsk_refactor running on the dr7.1 "lite" dataset, looking at petal one of the last tile (45660).  First plot is the initial assignment of science targets.  Second plot is after the redistribution step.

[fiberassign_45660_science.pdf](https://github.com/desihub/fiberassign/files/2849893/fiberassign_45660_science.pdf)
[fiberassign_45660_science-redist.pdf](https://github.com/desihub/fiberassign/files/2849894/fiberassign_45660_science-redist.pdf)

Next we have the same data from this branch:

[fiberassign_45660_science.pdf](https://github.com/desihub/fiberassign/files/2849896/fiberassign_45660_science.pdf)
[fiberassign_45660_science-redist.pdf](https://github.com/desihub/fiberassign/files/2849897/fiberassign_45660_science-redist.pdf)

Recall that this is before any intentional assignment of standards.  The green targets are "dual" science and standards.  Note that in the code from this branch, only a maximum of 10 per petal of these dual targets are assigned during the assignment of science targets.

If these changes are desired, I will un-comment the remaining steps in fba_run, and also change the function signature of the Assignment class methods to take kwargs (since passing in "-1" is clunky).  Feedback welcome.