### PR TITLE
Restore "safe" target type

### DIFF
--- a/py/fiberassign/assign.py
+++ b/py/fiberassign/assign.py
@@ -32,14 +32,9 @@ from ._version import __version__
 
 from .utils import Logger, Timer, default_mp_proc
 
-from .tiles import load_tiles
+from .targets import (TARGET_TYPE_SKY, desi_target_type)
 
-from .targets import (TARGET_TYPE_SCIENCE, TARGET_TYPE_SKY,
-                      TARGET_TYPE_STANDARD, TARGET_TYPE_SAFE,
-                      TargetTree, TargetsAvailable, FibersAvailable,
-                      load_target_file, desi_target_type)
-
-from .hardware import (load_hardware, FIBER_STATE_STUCK, FIBER_STATE_BROKEN)
+from .hardware import (FIBER_STATE_STUCK, FIBER_STATE_BROKEN)
 
 from ._internal import Assignment
 

--- a/py/fiberassign/qa.py
+++ b/py/fiberassign/qa.py
@@ -69,6 +69,7 @@ def qa_tile(hw, tile_id, tgs, tgprops, tile_assign, tile_avail):
     nscience = 0
     nstd = 0
     nsky = 0
+    nsafe = 0
     unassigned = list()
     objtypes = dict()
     for fid in fibers:
@@ -92,10 +93,13 @@ def qa_tile(hw, tile_id, tgs, tgprops, tile_assign, tile_avail):
             nstd += 1
         if tg.is_sky():
             nsky += 1
+        if tg.is_safe():
+            nsafe += 1
     props["assign_total"] = nassign
     props["assign_science"] = nscience
     props["assign_std"] = nstd
     props["assign_sky"] = nsky
+    props["assign_safe"] = nsafe
     for ot, cnt in objtypes.items():
         props["assign_obj_{}".format(ot)] = cnt
     props["unassigned"] = unassigned

--- a/py/fiberassign/scripts/assign.py
+++ b/py/fiberassign/scripts/assign.py
@@ -314,13 +314,10 @@ def run_assign_full(args):
     asgn.assign_unused(TARGET_TYPE_STANDARD)
     asgn.assign_unused(TARGET_TYPE_SKY)
 
-    # NOTE:  This was removed since we are treating BAD_SKY as science targets
-    # with very low priority.
-    #
-    # # Assign safe location to unused fibers (no maximum).  There should
-    # # always be at least one safe location (i.e. "BAD_SKY") for each fiber.
-    # # So after this is run every fiber should be assigned to something.
-    # asgn.assign_unused(TARGET_TYPE_SAFE)
+    # Assign safe location to unused fibers (no maximum).  There should
+    # always be at least one safe location (i.e. "BAD_SKY") for each fiber.
+    # So after this is run every fiber should be assigned to something.
+    asgn.assign_unused(TARGET_TYPE_SAFE)
 
     # Assign sky monitor fibers
     asgn.assign_unused(TARGET_TYPE_SKY, -1, "ETC")
@@ -408,14 +405,11 @@ def run_assign_bytile(args):
         asgn.assign_unused(TARGET_TYPE_STANDARD, -1, "POS", tile_id, tile_id)
         asgn.assign_unused(TARGET_TYPE_SKY, -1, "POS", tile_id, tile_id)
 
-        # NOTE:  This was removed since we are treating BAD_SKY as science
-        # targets with very low priority.
-        #
-        # # Assign safe location to unused fibers (no maximum).  There should
-        # # always be at least one safe location (i.e. "BAD_SKY") for each
-        # # fiber.  So after this is run every fiber should be assigned to
-        # # something.
-        # asgn.assign_unused(TARGET_TYPE_SAFE)
+        # Assign safe location to unused fibers (no maximum).  There should
+        # always be at least one safe location (i.e. "BAD_SKY") for each
+        # fiber.  So after this is run every fiber should be assigned to
+        # something.
+        asgn.assign_unused(TARGET_TYPE_SAFE)
 
         # Assign sky monitor fibers
         asgn.assign_unused(TARGET_TYPE_SKY, -1, "ETC", tile_id, tile_id)

--- a/py/fiberassign/scripts/assign.py
+++ b/py/fiberassign/scripts/assign.py
@@ -303,13 +303,16 @@ def run_assign_full(args):
 
     # Assign standards, up to some limit
     asgn.assign_unused(TARGET_TYPE_STANDARD, args.standards_per_petal)
-    asgn.assign_force(TARGET_TYPE_STANDARD, args.standards_per_petal)
 
     # Assign sky to unused fibers, up to some limit
     asgn.assign_unused(TARGET_TYPE_SKY, args.sky_per_petal)
+
+    # Force assignment if needed
+    asgn.assign_force(TARGET_TYPE_STANDARD, args.standards_per_petal)
     asgn.assign_force(TARGET_TYPE_SKY, args.sky_per_petal)
 
     # If there are any unassigned fibers, try to place them somewhere.
+    # Assigning science again is a no-op, but...
     asgn.assign_unused(TARGET_TYPE_SCIENCE)
     asgn.assign_unused(TARGET_TYPE_STANDARD)
     asgn.assign_unused(TARGET_TYPE_SKY)
@@ -393,15 +396,20 @@ def run_assign_bytile(args):
         # Assign standards, up to some limit
         asgn.assign_unused(TARGET_TYPE_STANDARD, args.standards_per_petal,
                            "POS", tile_id, tile_id)
-        asgn.assign_force(TARGET_TYPE_STANDARD, args.standards_per_petal,
-                          tile_id, tile_id)
 
         # Assign sky to unused fibers, up to some limit
         asgn.assign_unused(TARGET_TYPE_SKY, args.sky_per_petal, "POS",
                            tile_id, tile_id)
+
+        # Force assignment if needed
+        asgn.assign_force(TARGET_TYPE_STANDARD, args.standards_per_petal,
+                          tile_id, tile_id)
         asgn.assign_force(TARGET_TYPE_SKY, args.sky_per_petal,
                           tile_id, tile_id)
 
+        # If there are any unassigned fibers, try to place them somewhere.
+        # Assigning science again is a no-op, but...
+        asgn.assign_unused(TARGET_TYPE_SCIENCE, -1, "POS", tile_id, tile_id)
         asgn.assign_unused(TARGET_TYPE_STANDARD, -1, "POS", tile_id, tile_id)
         asgn.assign_unused(TARGET_TYPE_SKY, -1, "POS", tile_id, tile_id)
 

--- a/py/fiberassign/targets.py
+++ b/py/fiberassign/targets.py
@@ -44,8 +44,6 @@ def get_sciencemask():
     sciencemask |= desi_mask["LRG"].mask
     sciencemask |= desi_mask["ELG"].mask
     sciencemask |= desi_mask["QSO"].mask
-    # Note: BAD_SKY are treated as science targets with priority == 0
-    sciencemask |= desi_mask["BAD_SKY"].mask
     sciencemask |= desi_mask["BGS_ANY"].mask
     sciencemask |= desi_mask["MWS_ANY"].mask
     sciencemask |= desi_mask["SECONDARY_ANY"].mask
@@ -77,7 +75,7 @@ def get_safemask():
     we won't saturate the detector, but aren't good for anything else.
     """
     safemask = 0
-    safemask |= desi_mask.BAD_SKY
+    safemask |= desi_mask["BAD_SKY"].mask
     return safemask
 
 

--- a/src/assign.cpp
+++ b/src/assign.cpp
@@ -1430,12 +1430,12 @@ int64_t fba::Assignment::find_best(fba::Hardware const * hw,
                 }
             }
         } else {
-            // We are working with either standards or skies.  We base our
-            // comparison on both priority and subpriority.  Normal standards
-            // and skies will have priority == 0, so this reduces to a
-            // comparison on subpriority.  Objects that are both a standard
-            // and a science target will always "win", since their priority
-            // is non-zero.  Change this behavior here if desired.
+            // We are working with either standards, skies or safe.  We base
+            // our comparison on both priority and subpriority.  Normal
+            // standards and skies will have priority == 0, so this reduces
+            // to a comparison on subpriority.  Objects that are both a
+            // standard and a science target will always "win", since their
+            // priority is non-zero.  Change this behavior here if desired.
             double bestweight = static_cast <double> (best_priority)
                 + best_subpriority;
             double newweight = static_cast <double> (tg.priority)


### PR DESCRIPTION
This restores the previous handling of BAD_SKY as a separate target type (a.k.a. safe).  This target type is assigned at the very end.  Running the dr7.1-lite dataset actually only had one safe target assigned (plot below).  The rest of the unassigned fibers were simply off the edge of the footprint.  This closes #175 and also should close #187.
![dr7 1-lite_045623](https://user-images.githubusercontent.com/84221/53923065-b40c7f00-402b-11e9-8a1e-e67a9044262e.png)

