### PR TITLE
If no sky targets are available for ETC fibers, assign safe targets.

### DIFF
--- a/py/fiberassign/assign.py
+++ b/py/fiberassign/assign.py
@@ -32,7 +32,7 @@ from ._version import __version__
 
 from .utils import Logger, Timer, default_mp_proc
 
-from .targets import (TARGET_TYPE_SKY, desi_target_type)
+from .targets import (TARGET_TYPE_SKY, TARGET_TYPE_SAFE, desi_target_type)
 
 from .hardware import (FIBER_STATE_STUCK, FIBER_STATE_BROKEN)
 
@@ -371,6 +371,9 @@ def write_assignment_fits_tile(asgn, fulltarget, overwrite, params):
                     for x in fibers]
         fstatus |= [4 if (fstate[x] & FIBER_STATE_BROKEN) else 0
                     for x in fibers]
+        fstatus[assigned_valid] |= \
+            [8 if (tg_type[x] & TARGET_TYPE_SAFE) else 0
+             for x in target_rows]
         fdata["FIBERSTATUS"] = fstatus
 
         # tm.stop()

--- a/py/fiberassign/scripts/assign.py
+++ b/py/fiberassign/scripts/assign.py
@@ -324,6 +324,7 @@ def run_assign_full(args):
 
     # Assign sky monitor fibers
     asgn.assign_unused(TARGET_TYPE_SKY, -1, "ETC")
+    asgn.assign_unused(TARGET_TYPE_SAFE, -1, "ETC")
 
     gt.stop("run_assign_full calculation")
     gt.start("run_assign_full write output")
@@ -421,6 +422,7 @@ def run_assign_bytile(args):
 
         # Assign sky monitor fibers
         asgn.assign_unused(TARGET_TYPE_SKY, -1, "ETC", tile_id, tile_id)
+        asgn.assign_unused(TARGET_TYPE_SAFE, -1, "ETC", tile_id, tile_id)
 
     gt.stop("run_assign_bytile calculation")
     gt.start("run_assign_bytile write output")

--- a/src/_pyfiberassign.cpp
+++ b/src/_pyfiberassign.cpp
@@ -43,6 +43,7 @@ PYBIND11_MODULE(_internal, m) {
     m.attr("FIBER_STATE_OK") = py::int_(FIBER_STATE_OK);
     m.attr("FIBER_STATE_STUCK") = py::int_(FIBER_STATE_STUCK);
     m.attr("FIBER_STATE_BROKEN") = py::int_(FIBER_STATE_BROKEN);
+    m.attr("FIBER_STATE_SAFE") = py::int_(FIBER_STATE_SAFE);
 
     py::class_ <fba::Timer, fba::Timer::pshr > (m, "Timer", R"(
         Simple timer class.

--- a/src/hardware.h
+++ b/src/hardware.h
@@ -24,6 +24,7 @@ namespace fiberassign {
 #define FIBER_STATE_OK 0
 #define FIBER_STATE_STUCK 1
 #define FIBER_STATE_BROKEN 2
+#define FIBER_STATE_SAFE 4
 
 
 class Hardware : public std::enable_shared_from_this <Hardware> {


### PR DESCRIPTION
For both normal positioners and ETC fibers, if assigned to a safe target, set the fourth bit (value=8) of FIBERSTATUS.  This change addresses #190, and downstream codes can check FIBERSTATUS to see which fibers are assigned to BAD_SKY or other "safe" (but undesirable) targets.