### PR TITLE
allow fiberassign --stdstar duplicates with --mtl

### DIFF
--- a/bin/fiberassign
+++ b/bin/fiberassign
@@ -5,7 +5,7 @@ Wrapper script for fba_run and fba_merge to provide script API compatibility
 with the legacy branch of fiberassign.
 """
 
-import argparse
+import argparse, os, sys, tempfile
 
 import fiberassign
 
@@ -43,8 +43,33 @@ parser.add_argument("--surveytiles",
 parser.add_argument("--outdir",
                     help="output directory (default = ./)", default="./")
 
+parser.add_argument("--sciencemask", required=False,
+                    default=None,
+                    help="Default DESI_TARGET mask to use for science "
+                         "targets")
+
+# DEPRECATED; use --stdmask instead
 parser.add_argument("--starmask",
-                    help="integer mask defining standard stars")
+                    help="DEPRECATED: use --stdmask instead")
+
+parser.add_argument("--stdmask", required=False,
+                    default=None,
+                    help="Default DESI_TARGET mask to use for stdstar "
+                         "targets")
+
+parser.add_argument("--skymask", required=False,
+                    default=None,
+                    help="Default DESI_TARGET mask to use for sky targets")
+
+parser.add_argument("--safemask", required=False,
+                    default=None,
+                    help="Default DESI_TARGET mask to use for safe "
+                    "backup targets")
+
+parser.add_argument("--excludemask", required=False,
+                    default=None,
+                    help="Default DESI_TARGET mask to exclude from "
+                    "any assignments")
 
 parser.add_argument("--rundate", help="run date [YYYY-MM-DD]")
 
@@ -67,54 +92,90 @@ parser.add_argument("--version", help="Print code version and exit",
 args = parser.parse_args()
 log = Logger.get()
 
+#- Check if standards are already in MTL
+tempdir = None
+if args.stdstar:
+    import fitsio
+    import numpy as np
+    science_targets = fitsio.read(args.mtl, 'MTL', columns=['TARGETID',])
+    stdstars, stdhdr = fitsio.read(args.stdstar, header=True)
+    ii = np.in1d(stdstars['TARGETID'], science_targets['TARGETID'])
+    if np.all(ii):
+        #- All standards are already in MTL; just drop this file
+        log.warning('All standards are already in MTL; ignoring {}'.format(
+            args.stdstar))
+        args.stdstar = None
+    else:
+        #- Keep only the standards that aren't in MTL
+        stdstars = stdstars[~ii]
+        log.info("Keeping {} standards that aren't already in MTL".format(
+            len(stdstars)))
+
+        tempdir = tempfile.mkdtemp()
+        args.stdstar = os.path.join(tempdir, 'standards.fits')
+        fitsio.write(args.stdstar, stdstars, header=stdhdr, extname='STD')
+
 # ------
 # - fba_run
 
-opts = {
-    "targets": [args.mtl, args.sky, args.stdstar],
-    "dir": args.outdir,
-    "standards_per_petal": args.nstarpetal,
-    "sky_per_petal": args.nskypetal
-}
-
-# Completely optional; only propagate if specified
-if args.fibstatusfile is not None:
-    opts["status"] = args.fibstatusfile
-
-if args.footprint is not None:
-    opts["footprint"] = args.footprint
-
-if args.positioners is not None:
-    opts["positioners"] = args.positioners
-
-if args.surveytiles is not None:
-    opts["tiles"] = args.surveytiles
+#- reformat fiberassign options into fba_run and fba_merge options,
+#- which changed some of the option names
 
 if args.starmask is not None:
-    opts["stdmask"] = args.starmask
+    log.warning('--starmask is deprecated; please use --stdmask instead')
+    if args.stdmask is None:
+        args.stdmask = args.starmask
 
-if args.rundate is not None:
-    opts["rundate"] = args.rundate
+#- mtl, sky, stdstar -> targets
+opts = args.__dict__.copy()
+opts['targets'] = [args.mtl, args.sky]
+if args.stdstar is not None:
+    opts["targets"].append(args.stdstar)
 
-if args.gfafile is not None:
-    opts["gfafile"] = args.gfafile
+#- other options that were renamed
+opts['dir'] = args.outdir
+opts['status'] = args.fibstatusfile
+opts['tiles'] = args.surveytiles
+opts['standards_per_petal'] = args.nstarpetal
+opts['sky_per_petal'] = args.nskypetal
 
-if args.overwrite:
-    opts["overwrite"] = True
+#- remove keys for options that were renamed
+for key in ['mtl', 'sky', 'stdstar', 'outdir', 'fibstatusfile', 'surveytiles',
+            'nstarpetal', 'nskypetal', 'starmask']:
+    if key in opts:
+        del opts[key]
 
 optlist = option_list(opts)
 assign_args = parse_assign(optlist)
+
 run_assign_full(assign_args)
 
 # ------
 # - fba_merge_results
 
-opts = {
-    "targets": [args.mtl, args.sky, args.stdstar],
-    "dir": args.outdir,
-    "out": args.outdir
-}
+#- mtl, sky, stdstar -> targets
+opts = args.__dict__.copy()
+opts['targets'] = [args.mtl, args.sky]
+if args.stdstar is not None:
+    opts["targets"].append(args.stdstar)
+
+#- other options that were renamed
+opts['dir'] = args.outdir
+opts['out'] = args.outdir
+
+#- remove keys for options that were renamed or not used by fba_merge_results
+for key in ['mtl', 'sky', 'stdstar', 'outdir', 'fibstatusfile', 'surveytiles',
+            'nstarpetal', 'nskypetal', 'starmask', 'footprint', 'overwrite']:
+    if key in opts:
+        del opts[key]
 
 optlist = option_list(opts)
 merge_args = parse_merge(optlist)
 run_merge(merge_args)
+
+#- Cleanup (CAREFUL! only cleanup if contents exactly match expectations)
+if tempdir and \
+   tempdir == os.path.dirname(args.stdstar) and \
+   os.listdir(tempdir) == [args.stdstar,]:
+        os.remove(stdstar)
+        os.removedirs(tempdir)

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,7 +6,8 @@ fiberassign change log
 1.0.2 (unreleased)
 ------------------
 
-* No changes yet.
+* Gracefully allow fiberassign --stdstar to have duplicates with --mtl
+* Expose fba_run --sciencemask, --stdmask, etc. to fiberassign too
 
 1.0.1 (2019-05-13)
 ------------------

--- a/py/fiberassign/assign.py
+++ b/py/fiberassign/assign.py
@@ -954,8 +954,8 @@ def merge_results_tile(out_dtype, copy_fba, params):
 
     # Determine the rows of the assignment that are for science and sky
     # monitor positioners.
-    science_rows = np.where(fiber_data["DEVICE_TYPE"] == b"POS")[0]
-    sky_rows = np.where(fiber_data["DEVICE_TYPE"] == b"ETC")[0]
+    science_rows = np.where(fiber_data["DEVICE_TYPE"].astype(str) == "POS")[0]
+    sky_rows = np.where(fiber_data["DEVICE_TYPE"].astype(str) == "ETC")[0]
 
     # Construct output recarray
     outdata = np.zeros(len(fiber_data), dtype=out_dtype)

--- a/py/fiberassign/assign.py
+++ b/py/fiberassign/assign.py
@@ -266,7 +266,7 @@ def write_assignment_fits_tile(asgn, fulltarget, overwrite, params):
         log.debug("Write:  copying assignment data for tile {}"
                   .format(tile_id))
 
-        fdata = np.empty(nfiber, dtype=assign_dtype)
+        fdata = np.zeros(nfiber, dtype=assign_dtype)
         fdata["FIBER"] = fibers
 
         # For unassigned fibers, we give each fiber a unique negative
@@ -282,10 +282,10 @@ def write_assignment_fits_tile(asgn, fulltarget, overwrite, params):
         assigned_invalid = np.where(assigned_tgids < 0)[0]
 
         # Buffers for X/Y/RA/DEC
-        assigned_tgx = np.empty(nfiber, dtype=np.float64)
-        assigned_tgy = np.empty(nfiber, dtype=np.float64)
-        assigned_tgra = np.empty(nfiber, dtype=np.float64)
-        assigned_tgdec = np.empty(nfiber, dtype=np.float64)
+        assigned_tgx = np.full(nfiber, 9999.9, dtype=np.float64)
+        assigned_tgy = np.full(nfiber, 9999.9, dtype=np.float64)
+        assigned_tgra = np.full(nfiber, 9999.9, dtype=np.float64)
+        assigned_tgdec = np.full(nfiber, 9999.9, dtype=np.float64)
         assigned_tgbits = np.zeros(nfiber, dtype=np.int64)
         assigned_tgtype = np.zeros(nfiber, dtype=np.uint8)
 
@@ -384,7 +384,7 @@ def write_assignment_fits_tile(asgn, fulltarget, overwrite, params):
         log.debug("Write:  writing target data for tile {}"
                   .format(tile_id))
 
-        fdata = np.empty(ntarget, dtype=targets_dtype)
+        fdata = np.zeros(ntarget, dtype=targets_dtype)
         fdata["TARGETID"] = tgids
         fdata["TARGET_RA"] = tg_ra
         fdata["TARGET_DEC"] = tg_dec
@@ -411,7 +411,7 @@ def write_assignment_fits_tile(asgn, fulltarget, overwrite, params):
         log.debug("Write:  writing avail data for tile {}"
                   .format(tile_id))
 
-        fdata = np.empty(navail, dtype=avail_dtype)
+        fdata = np.zeros(navail, dtype=avail_dtype)
         off = 0
         for fid in sorted(avail.keys()):
             for tg in avail[fid]:
@@ -856,7 +856,7 @@ def merge_results_tile(out_dtype, copy_fba, params):
     # Extract just these targets from the full set of catalogs
 
     tile_targets_dtype = np.dtype(out_dtype.fields)
-    tile_targets = np.empty(len(tile_tgids), dtype=tile_targets_dtype)
+    tile_targets = np.zeros(len(tile_tgids), dtype=tile_targets_dtype)
 
     # Copy original data
 

--- a/py/fiberassign/hardware.py
+++ b/py/fiberassign/hardware.py
@@ -51,8 +51,8 @@ def load_hardware(fiberpos_file=None, gfa_file=None, rundate=None,
     log.info("Reading fiber positions from {}".format(fiberpos_file))
 
     fpdata = fitsio.read(fiberpos_file, ext=1)
-    pos_rows = np.where(fpdata["DEVICE_TYPE"] == b"POS")[0]
-    etc_rows = np.where(fpdata["DEVICE_TYPE"] == b"ETC")[0]
+    pos_rows = np.where(fpdata["DEVICE_TYPE"].astype(str) == "POS")[0]
+    etc_rows = np.where(fpdata["DEVICE_TYPE"].astype(str) == "ETC")[0]
     keep_rows = np.unique(np.concatenate((pos_rows, etc_rows)))
 
     nfiber = len(keep_rows)

--- a/py/fiberassign/hardware.py
+++ b/py/fiberassign/hardware.py
@@ -58,7 +58,7 @@ def load_hardware(fiberpos_file=None, gfa_file=None, rundate=None,
     nfiber = len(keep_rows)
     log.debug("  fiber position table keeping {} rows".format(nfiber))
 
-    device_type = np.empty(nfiber, dtype="a8")
+    device_type = np.full(nfiber, "OOPSBUG", dtype="a8")
     device_type[:] = fpdata["DEVICE_TYPE"][keep_rows]
 
     # For non-science positioners, no fiber ID is assigned in the positioner
@@ -75,8 +75,7 @@ def load_hardware(fiberpos_file=None, gfa_file=None, rundate=None,
                                 location[missing_fiber]]
 
     # Read the status file...
-    status = np.empty(nfiber, dtype=np.int32)
-    status[:] = FIBER_STATE_OK
+    status = np.full(nfiber, FIBER_STATE_OK, dtype=np.int32)
 
     if status_file is not None:
         runtime = None

--- a/py/fiberassign/qa.py
+++ b/py/fiberassign/qa.py
@@ -130,7 +130,7 @@ def qa_tile_file(hw, params):
     tgs, tgprops = qa_parse_table(header, targets_data)
 
     # Only do QA on positioners.
-    pos_rows = np.where(fiber_data["DEVICE_TYPE"] == b"POS")[0]
+    pos_rows = np.where(fiber_data["DEVICE_TYPE"].astype(str) == "POS")[0]
 
     # Target assignment
     tassign = {x["FIBER"]: x["TARGETID"] for x in fiber_data[pos_rows]

--- a/py/fiberassign/test/test_assign.py
+++ b/py/fiberassign/test/test_assign.py
@@ -136,6 +136,7 @@ class TestAssign(unittest.TestCase):
                                   "basic_tile-{:06d}.fits".format(tid))
             inhead, fiber_data, targets_data, avail_data, gfa_targets = \
                 read_assignment_fits_tile((tid, infile))
+
             for fid, tgid, tgra, tgdec in zip(
                     fiber_data["FIBER"],
                     fiber_data["TARGETID"],
@@ -394,3 +395,10 @@ class TestAssign(unittest.TestCase):
             self.assertEqual(400, props["assign_sky"])
 
         return
+
+def test_suite():
+    """Allows testing of only this module with the command::
+
+        python setup.py test -m <modulename>
+    """
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/fiberassign/test/test_hardware.py
+++ b/py/fiberassign/test/test_hardware.py
@@ -60,3 +60,10 @@ class TestHardware(unittest.TestCase):
         tm.stop()
         tm.report("check_collisions_thetaphi 100 configurations")
         return
+
+def test_suite():
+    """Allows testing of only this module with the command::
+
+        python setup.py test -m <modulename>
+    """
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/fiberassign/test/test_tiles.py
+++ b/py/fiberassign/test/test_tiles.py
@@ -34,3 +34,9 @@ class TestTiles(unittest.TestCase):
             self.assertEqual(tls.order[st], indx)
             indx += 1
         return
+def test_suite():
+    """Allows testing of only this module with the command::
+
+        python setup.py test -m <modulename>
+    """
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/fiberassign/test/test_vis.py
+++ b/py/fiberassign/test/test_vis.py
@@ -86,3 +86,10 @@ class TestVis(unittest.TestCase):
             plt.savefig(outfile)
             plt.close()
         return
+
+def test_suite():
+    """Allows testing of only this module with the command::
+
+        python setup.py test -m <modulename>
+    """
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/fiberassign/vis.py
+++ b/py/fiberassign/vis.py
@@ -135,8 +135,8 @@ def plot_tile_targets_props(hw, tile_ra, tile_dec, tgs, avail_tgid=None):
     if avail_tgid is None:
         avail_tgid = tgs.ids()
     # print("  DBG:  avail_tgid len = ", len(avail_tgid), flush=True)
-    ra = np.empty(len(avail_tgid), dtype=np.float64)
-    dec = np.empty(len(avail_tgid), dtype=np.float64)
+    ra = np.full(len(avail_tgid), 9999.9, dtype=np.float64)
+    dec = np.full(len(avail_tgid), 9999.9, dtype=np.float64)
     color = list()
     for idx, tgid in enumerate(avail_tgid):
         tg = tgs.get(tgid)
@@ -153,8 +153,8 @@ def plot_tile_targets_props(hw, tile_ra, tile_dec, tgs, avail_tgid=None):
 
 def plot_available(ax, targetprops, selected, linewidth=0.1):
     mwidth = 5.0 * linewidth
-    xdata = np.empty(len(selected), dtype=np.float64)
-    ydata = np.empty(len(selected), dtype=np.float64)
+    xdata = np.full(len(selected), 9999.9, dtype=np.float64)
+    ydata = np.full(len(selected), 9999.9, dtype=np.float64)
     color = list()
     for idx, tgid in enumerate(selected):
         xdata[idx] = targetprops[tgid]["xy"][0]


### PR DESCRIPTION
This PR fixes #198 by allowing fiberassign to have duplicate targets in the `--stdstar` file and the `--mtl`.  It also exposures the fba_run options `--sciencemask`, `--stdmask`, etc. to fiberassign.

Background: Legacy `fiberassign` allowed duplicate std/mtl targets and it worked due to how it did internal bookkeeping.  The refactored `fba_run` does not allow duplicate targets, but that broke some of the ways we had been using it.

This PR: If all `--stdstar` targets are already in MTL, it just ignores the file.  If it has some unique targets, those are filtered out and written to a separate temporary file before passing on to `fba_run`.  This allows users to continue to use `fiberassign` in the same manner as before, without worrying about std/mtl duplicates.