### PR TITLE
Enforce reproducibility of available tile / fibers

### DIFF
--- a/src/targets.cpp
+++ b/src/targets.cpp
@@ -566,6 +566,31 @@ fba::FibersAvailable::FibersAvailable(fba::TargetsAvailable::pshr tgsavail) {
         }
     }
 
+    // Sort the available tile / locations by tile order, since the
+    // original order will depend on thread concurrency.
+
+    auto tls = tgsavail->tiles();
+    auto torder = tls->order;
+    auto tids = tls->id;
+
+    fba::tile_loc_compare tlcomp;
+
+    std::vector < std::pair <int32_t, int32_t> > tdx;
+
+    for (auto & tgav : data) {
+        // int64_t tgid = tgav.first;
+        auto & av = tgav.second;
+        tdx.clear();
+        for (auto const & tf : av) {
+            tdx.push_back(std::make_pair(torder[tf.first], tf.second));
+        }
+        std::stable_sort(tdx.begin(), tdx.end(), tlcomp);
+        av.clear();
+        for (auto const & tf : tdx) {
+            av.push_back(std::make_pair(tids[tf.first], tf.second));
+        }
+    }
+
     tm.stop();
     tm.report("Computing tile / fibers available to all objects");
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -29,7 +29,11 @@ struct weight_compare {
     // Define this method here so that it is inline.
     bool operator() (weight_index const & lhs,
                      weight_index const & rhs) const {
-        return lhs.first > rhs.first;
+        if (lhs.first == rhs.first) {
+            return lhs.second < rhs.second;
+        } else {
+            return lhs.first > rhs.first;
+        }
     }
 };
 
@@ -37,10 +41,26 @@ struct weight_rcompare {
     // Define this method here so that it is inline.
     bool operator() (weight_index const & lhs,
                      weight_index const & rhs) const {
-        return lhs.first < rhs.first;
+        if (lhs.first == rhs.first) {
+            return lhs.second > rhs.second;
+        } else {
+            return lhs.first < rhs.first;
+        }
     }
 };
 
+typedef std::pair <int32_t, int32_t> tile_loc;
+
+struct tile_loc_compare {
+    bool operator() (tile_loc const & lhs,
+                     tile_loc const & rhs) const {
+        if (lhs.first == rhs.first) {
+            return lhs.second < rhs.second;
+        } else {
+            return lhs.first < rhs.first;
+        }
+    }
+};
 
 // These helpers are used by the header-only HTM tree and KD tree classes,
 // and we don't want to modify that code for now.


### PR DESCRIPTION
When collecting results of fibers available to each target, this raw output
will depend on the order of atomic updates from each thread.  Sort the
final result so that the list of available tile fibers is always the same,
regardless of the thread concurrency and runtime behavior.  Also add more
debugging statements.

Since this is a clear bug and a small fix, I'll self merge this shortly.