### PR TITLE
Use LOCATION instead of FIBER

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,13 +6,16 @@ fiberassign change log
 1.0.3 (unreleased)
 ------------------
 
-* No changes yet.
+* Fix an issue with reproducibility of the ordering of available tile-fibers
+  for each target (PR `#203`_).
+
+.. _`#203`: https://github.com/desihub/fiberassign/pull/203
 
 1.0.2 (2019-05-30)
 ------------------
 
 * PR `#202`_:
-  
+
   * Gracefully allow fiberassign --stdstar to have duplicates with --mtl
   * Expose fba_run --sciencemask, --stdmask, etc. to fiberassign too
   * support fitsio 1.0.x

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -21,171 +21,171 @@ I made some plots::
        --dir "out_fiberassign_2018-11-24T11:09:48"
 
 I opened one resulting image (fiberassign_001148.pdf) and zoomed into one
-petal.  I noticed that fiber 2233 was assigned to a standard.  Let's look at
-the details of how this fiber was assigned::
+petal.  I noticed that device location 2233 was assigned to a standard.  Let's
+look at the details of how this device was assigned::
 
-    %> export DESI_DEBUG_FIBER=2233
+    %> export DESI_DEBUG_LOCATION=2233
     %> fba_run --targets mtl.fits standards-dark.fits sky.fits
 
 The log showed that there were several targets available to this fiber on tile
 1148::
 
-    DEBUG: targets avail:  tile 1148, fiber 2233 append ID \
+    DEBUG: targets avail:  tile 1148, loc 2233 append ID \
         288230398599630147 (type=1), total priority 3200.07
-    DEBUG: targets avail:  tile 1148, fiber 2233 append ID \
+    DEBUG: targets avail:  tile 1148, loc 2233 append ID \
         288230398599629415 (type=1), total priority 3000.91
-    DEBUG: targets avail:  tile 1148, fiber 2233 append ID \
+    DEBUG: targets avail:  tile 1148, loc 2233 append ID \
         288230398599629372 (type=1), total priority 3000.24
-    DEBUG: targets avail:  tile 1148, fiber 2233 append ID \
+    DEBUG: targets avail:  tile 1148, loc 2233 append ID \
         288230398599627959 (type=1), total priority 2000.04
-    DEBUG: targets avail:  tile 1148, fiber 2233 append ID \
+    DEBUG: targets avail:  tile 1148, loc 2233 append ID \
         288230398599631299 (type=3), total priority 1500.79
-    DEBUG: targets avail:  tile 1148, fiber 2233 append ID \
+    DEBUG: targets avail:  tile 1148, loc 2233 append ID \
         288230398599631166 (type=1), total priority 1500.1
-    DEBUG: targets avail:  tile 1148, fiber 2233 append ID \
+    DEBUG: targets avail:  tile 1148, loc 2233 append ID \
         288230398599632448 (type=4), total priority 0.293402
-    DEBUG: targets avail:  tile 1148, fiber 2233 append ID \
+    DEBUG: targets avail:  tile 1148, loc 2233 append ID \
         288230398599632236 (type=4), total priority 0.179244
 
 Looking at the target type (which are the 4 categories of target used
 internally in fiberassign, defined in targets.py / targets.h), we see that
 there are 2 sky targets, 5 science targets, and one target which is both a
-science target and a standard.  Later, during the assignment of unused fibers
-to science targets, we see::
+science target and a standard.  Later, during the assignment of unused
+locations to science targets, we see::
 
-    DEBUG: assign unused science: tile 1148, petal 4 fiber 2233 \
+    DEBUG: assign unused science: tile 1148, petal 4 loc 2233 \
         available target 288230398599630147, subpriority 0.0692912
-    DEBUG: assign unused science: tile 1148, petal 4 fiber 2233 \
+    DEBUG: assign unused science: tile 1148, petal 4 loc 2233 \
         available target 288230398599629415, subpriority 0.914937
-    DEBUG: assign unused science: tile 1148, petal 4 fiber 2233 \
+    DEBUG: assign unused science: tile 1148, petal 4 loc 2233 \
         available target 288230398599629372, subpriority 0.241329
-    DEBUG: assign unused science: tile 1148, petal 4 fiber 2233 \
+    DEBUG: assign unused science: tile 1148, petal 4 loc 2233 \
         available target 288230398599627959, subpriority 0.0415658
-    DEBUG: assign unused science: tile 1148, petal 4 fiber 2233 \
+    DEBUG: assign unused science: tile 1148, petal 4 loc 2233 \
         available target 288230398599631299, subpriority 0.786657
-    DEBUG: assign unused science: tile 1148, petal 4 fiber 2233 \
+    DEBUG: assign unused science: tile 1148, petal 4 loc 2233 \
         available target 288230398599631166, subpriority 0.0962114
-    DEBUG: assign unused science: tile 1148, petal 4 fiber 2233 \
+    DEBUG: assign unused science: tile 1148, petal 4 loc 2233 \
         available target 288230398599632448 is wrong type (4)
-    DEBUG: assign unused science: tile 1148, petal 4 fiber 2233 \
+    DEBUG: assign unused science: tile 1148, petal 4 loc 2233 \
         available target 288230398599632236 is wrong type (4)
-    DEBUG: find_best: tile 1148, fiber 2233, target \
+    DEBUG: find_best: tile 1148, loc 2233, target \
         288230398599630147, type 1 accept with priority = 3200, \
         subpriority = 0.0692912, obs_remain = 2
-    DEBUG: find_best: tile 1148, fiber 2233, target \
+    DEBUG: find_best: tile 1148, loc 2233, target \
         288230398599630147, type 1 SELECTED
-    DEBUG: assign unused science: tile 1148, petal 4 fiber 2233 \
+    DEBUG: assign unused science: tile 1148, petal 4 loc 2233 \
         found best object 288230398599630147
 
 So it skipped over the two sky targets and selected a high-priority science
 target.  Later, during the redistribution step, we see::
 
-    DEBUG: reassign: tile 1148, fiber 2233, target \
+    DEBUG: reassign: tile 1148, loc 2233, target \
         288230398599630147 considering for swap...
-    DEBUG: reassign: tile 1148, fiber 2233, target \
+    DEBUG: reassign: tile 1148, loc 2233, target \
         288230398599630147 considering tile indices 0 to 16070
-    DEBUG: reassign: tile 1148, fiber 2233, target \
+    DEBUG: reassign: tile 1148, loc 2233, target \
         288230398599630147 avail T/F 1148,2233 already assigned
-    DEBUG: reassign: tile 1148, fiber 2233, target \
+    DEBUG: reassign: tile 1148, loc 2233, target \
         288230398599630147 avail T/F 6926,175 already assigned
-    DEBUG: reassign: tile 1148, fiber 2233, target \
+    DEBUG: reassign: tile 1148, loc 2233, target \
         288230398599630147 avail T/F 12688,968 already assigned
-    DEBUG: reassign: tile 1148, fiber 2233, target \
+    DEBUG: reassign: tile 1148, loc 2233, target \
         288230398599630147 avail T/F 12688,991 already assigned
-    DEBUG: reassign: tile 1148, fiber 2233, target \
+    DEBUG: reassign: tile 1148, loc 2233, target \
         288230398599630147 avail T/F 12689,2561 already assigned
-    DEBUG: reassign: tile 1148, fiber 2233, target \
+    DEBUG: reassign: tile 1148, loc 2233, target \
         288230398599630147 avail T/F 12689,2587 already assigned
-    DEBUG: redist: tile 1148, fiber 2233, target \
+    DEBUG: redist: tile 1148, loc 2233, target \
         288230398599630147 keeping assignment
 
-So the science target initially assigned to this fiber had no other unassigned
-available tile / fibers for potential swapping.  Further in the assignment
-process, we see that a standard was found available to this fiber.  Here is the
-log snippet from this step::
+So the science target initially assigned to this location had no other
+unassigned available tile / locations for potential swapping.  Further in the
+assignment process, we see that a standard was found available to this
+location.  Here is the log snippet from this step::
 
     DEBUG: assign force standard: tile 1148, petal 4, \
-        fiber 2233, found object 288230398599631299 \
+        loc 2233, found object 288230398599631299 \
         with weight 1500.79
     DEBUG: assign force standard: tile 1148, petal 4, \
         class 1500, object 288230398599631299, subpriority \
-        1500.79, available fiber 2233 at target \
+        1500.79, available loc 2233 at target \
         288230398599630147 is wrong class (3200)
     DEBUG: assign force standard: tile 1148, petal 4, \
         class 1600, object 288230398599631299, subpriority \
-        1500.79, available fiber 2233 at target \
+        1500.79, available loc 2233 at target \
         288230398599630147 is wrong class (3200)
     DEBUG: assign force standard: tile 1148, petal 4, \
         class 2000, object 288230398599631299, subpriority \
-        1500.79, available fiber 2233 at target \
+        1500.79, available loc 2233 at target \
         288230398599630147 is wrong class (3200)
     DEBUG: assign force standard: tile 1148, petal 4, \
         class 2100, object 288230398599631299, subpriority \
-        1500.79, available fiber 2233 at target \
+        1500.79, available loc 2233 at target \
         288230398599630147 is wrong class (3200)
     DEBUG: assign force standard: tile 1148, petal 4, \
         class 3000, object 288230398599631299, subpriority \
-        1500.79, available fiber 2233 at target \
+        1500.79, available loc 2233 at target \
         288230398599630147 is wrong class (3200)
     DEBUG: assign force standard: tile 1148, petal 4, \
         class 3200, object 288230398599631299, subpriority \
-        1500.79, available fiber 2233 bumping science \
+        1500.79, available loc 2233 bumping science \
         target 288230398599630147
-    DEBUG: reassign: tile 1148, fiber 2233, target \
+    DEBUG: reassign: tile 1148, loc 2233, target \
         288230398599630147 considering for swap...
-    DEBUG: reassign: tile 1148, fiber 2233, target \
+    DEBUG: reassign: tile 1148, loc 2233, target \
         288230398599630147 considering tile indices 0 to 16070
-    DEBUG: reassign: tile 1148, fiber 2233, target \
+    DEBUG: reassign: tile 1148, loc 2233, target \
         288230398599630147 avail T/F 1148,2233 already assigned
-    DEBUG: reassign: tile 1148, fiber 2233, target \
+    DEBUG: reassign: tile 1148, loc 2233, target \
         288230398599630147 avail T/F 6926,175 already assigned
-    DEBUG: reassign: tile 1148, fiber 2233, target \
+    DEBUG: reassign: tile 1148, loc 2233, target \
         288230398599630147 avail T/F 12688,968 already assigned
-    DEBUG: reassign: tile 1148, fiber 2233, target \
+    DEBUG: reassign: tile 1148, loc 2233, target \
         288230398599630147 avail T/F 12688,991 already assigned
-    DEBUG: reassign: tile 1148, fiber 2233, target \
+    DEBUG: reassign: tile 1148, loc 2233, target \
         288230398599630147 avail T/F 12689,2561 already assigned
-    DEBUG: reassign: tile 1148, fiber 2233, target \
+    DEBUG: reassign: tile 1148, loc 2233, target \
         288230398599630147 avail T/F 12689,2587 not OK to assign
 
 What happened here is that a standard was found to replace the low-priority
-science target assigned to fiber 2233.  The existing science target was tested
-for other available tile / fibers, but all but one of those fibers were already
-assigned, and that one remaining fiber would produce a collision.  During the
-forced assignment of sky fibers, this is what happens to this fiber::
+science target assigned to location 2233.  The existing science target was tested
+for other available tile / locations, but all but one of those locations were already
+assigned, and that one remaining device would produce a collision.  During the
+forced assignment of sky targets, this is what happens to this location::
 
-    DEBUG: assign force sky: tile 1148, petal 4, fiber 2233, \
+    DEBUG: assign force sky: tile 1148, petal 4, loc 2233, \
         found object 288230398599632448 with weight 0.293402
-    DEBUG: assign force sky: tile 1148, petal 4, fiber 2233, \
+    DEBUG: assign force sky: tile 1148, petal 4, loc 2233, \
         found object 288230398599632236 with weight 0.179244
     DEBUG: assign force sky: tile 1148, petal 4, class 1500, \
         object 288230398599632448, subpriority 0.293402, \
-        available fiber 2233 at science target \
+        available loc 2233 at science target \
         288230398599631299 is also a standard- skipping
     DEBUG: assign force sky: tile 1148, petal 4, class 1500, \
         object 288230398599632236, subpriority 0.179244, \
-        available fiber 2233 at science target \
+        available loc 2233 at science target \
         288230398599631299 is also a standard- skipping
     DEBUG: assign force sky: tile 1148, petal 4, class 1600, \
         object 288230398599632448, subpriority 0.293402, available \
-        fiber 2233 at target 288230398599631299 is wrong class (1500)
+        loc 2233 at target 288230398599631299 is wrong class (1500)
     DEBUG: assign force sky: tile 1148, petal 4, class 1600, \
         object 288230398599632236, subpriority 0.179244, available \
-        fiber 2233 at target 288230398599631299 is wrong class (1500)
+        loc 2233 at target 288230398599631299 is wrong class (1500)
     DEBUG: assign force sky: tile 1148, petal 4, class 2000, \
         object 288230398599632448, subpriority 0.293402, available \
-        fiber 2233 at target 288230398599631299 is wrong class (1500)
+        loc 2233 at target 288230398599631299 is wrong class (1500)
     DEBUG: assign force sky: tile 1148, petal 4, class 2000, \
         object 288230398599632236, subpriority 0.179244, available \
-        fiber 2233 at target 288230398599631299 is wrong class (1500)
+        loc 2233 at target 288230398599631299 is wrong class (1500)
     DEBUG: assign force sky: tile 1148, petal 4, class 2100, \
         object 288230398599632448, subpriority 0.293402, available \
-        fiber 2233 at target 288230398599631299 is wrong class (1500)
+        loc 2233 at target 288230398599631299 is wrong class (1500)
     DEBUG: assign force sky: tile 1148, petal 4, class 2100, \
         object 288230398599632236, subpriority 0.179244, available \
-        fiber 2233 at target 288230398599631299 is wrong class (1500)
+        loc 2233 at target 288230398599631299 is wrong class (1500)
 
-So for this fiber, the existing assignment was recognized as both a science
+So for this device, the existing assignment was recognized as both a science
 target and a standard, and was therefore not considered for bumping to place a
 sky target.
 
@@ -211,7 +211,7 @@ variables::
     %> export \
        targetdir=/project/projectdirs/desi/datachallenge/reference_runs/18.11/targets
 
-Now run the fiber assignment using the default footprint tiling from
+Now run the assignment using the default footprint tiling from
 desimodel::
 
     %> time fba_run \
@@ -257,7 +257,7 @@ variables::
     %> export \
        targetdir=/project/projectdirs/desi/target/fiberassign/dr7.1/0.10.3-dark
 
-Now run the fiber assignment.  This will use about half of the RAM on a cori
+Now run the assignment.  This will use about half of the RAM on a cori
 haswell compute node and take about an hour- but half of that time is
 writing the output files (something to work on)::
 

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -187,14 +187,14 @@ After loading all the data, we usually want to index these targets in a hierarch
 .. autoclass:: fiberassign.targets.TargetTree
     :members:
 
-Given a hardware model, our set of tiles, and this tree structure, we can now compute the target IDs available to every fiber on every tile.  This is done with the `TargetsAvailable` class:
+Given a hardware model, our set of tiles, and this tree structure, we can now compute the target IDs available to every device location on every tile.  This is done with the `TargetsAvailable` class:
 
 .. autoclass:: fiberassign.targets.TargetsAvailable
     :members:
 
-We can also compute the inverse quantity:  the tile-fiber combinations that can reach each target ID.  This is done with the `FibersAvailable` class:
+We can also compute the inverse quantity:  the tile-location combinations that can reach each target ID.  This is done with the `LocationsAvailable` class:
 
-.. autoclass:: fiberassign.targets.FibersAvailable
+.. autoclass:: fiberassign.targets.LocationsAvailable
     :members:
 
 
@@ -207,7 +207,7 @@ Assigning Targets to Unused Fibers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When assigning a particular class of target ("science", "standard", or "sky")
-to unused fibers, the same technique (and code) is used.
+to unused locations, the same technique (and code) is used.
 
 .. todo:: Algorithm discussion here, once relevant github issues and their associated changes are done.
 
@@ -227,9 +227,9 @@ For each petal, we do the following pseudocode::
 
     for each science target priority "P" (lowest to highest)
         for each object (standard or sky) in total priority from high to low
-            if object is reachable by fibers on targets with priority "P"
-                remove target and place fiber on object
-                re-assign target to unused fiber on future tile if possible
+            if object is reachable by devices on targets with priority "P"
+                remove target and place positioner on object
+                re-assign target to unused location on future tile if possible
                 if enough objects on this petal
                     break
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -107,14 +107,14 @@ variables that can be set to dump even more details about the internal
 assignment process.  Examples::
 
     %> export DESI_DEBUG_TARGET=123456789
-    %> export DESI_DEBUG_FIBER=4321
+    %> export DESI_DEBUG_LOCATION=4321
     %> export DESI_DEBUG_TILE=1111
 
 These options are combined with a logical OR and any combination of tile,
 fiber, or target specified will have all possible info logged.
 
 .. warning::
-    Use of these "extra" debug variables will have a large impact on code
+    Use of these "extra" debug variables will have a HUGE impact on code
     performance.  Do not use in large production runs.
 
 

--- a/py/fiberassign/assign.py
+++ b/py/fiberassign/assign.py
@@ -334,12 +334,16 @@ def write_assignment_fits_tile(asgn, fulltarget, overwrite, params):
         fdata["DESIGN_S"] = assigned_s
 
         fibers = dict(hw.loc_fiber)
+        etcloc = sorted([x for x, y in fibers.items() if y < 0])
+        fakefibers = {y: (5000 + x) for x, y in enumerate(etcloc)}
+        fullfibers = fibers
+        fullfibers.update(fakefibers)
         device = dict(hw.loc_device)
         petal = dict(hw.loc_petal)
         device_type = dict(hw.loc_device_type)
 
         fdata["FIBER"] = np.array(
-            [fibers[x] for x in locs]).astype(np.int32)
+            [fullfibers[x] for x in locs]).astype(np.int32)
         fdata["DEVICE_LOC"] = np.array(
             [device[x] for x in locs]).astype(np.int32)
         fdata["PETAL_LOC"] = np.array(

--- a/py/fiberassign/assign.py
+++ b/py/fiberassign/assign.py
@@ -45,14 +45,14 @@ from ._internal import Assignment
 # internally to fiber assignment without duplicating information:
 #
 # FASSIGN
-# - Per-fiber information, including assignment.  Sorted by fiber ID.
+# - Per-location information, including assignment.  Sorted by location.
 #
 # FTARGETS
 # - All available targets and their properties relevant to assignment.  Sorted
 #   by target ID.
 #
 # FAVAIL
-# - Target IDs available to each fiber.  Sorted by fiber ID and then target ID.
+# - Target IDs available to each location.  Sorted by loc and then target ID.
 #
 
 results_assign_columns = OrderedDict([
@@ -87,6 +87,7 @@ results_targets_columns = OrderedDict([
 ])
 
 results_avail_columns = OrderedDict([
+    ("LOCATION", "i4"),
     ("FIBER", "i4"),
     ("TARGETID", "i8")
 ])
@@ -141,14 +142,14 @@ def write_assignment_fits_tile(asgn, fulltarget, overwrite, params):
     # Hardware properties
     hw = asgn.hardware()
 
-    # Targets available for all tile / fibers
+    # Targets available for all tile / locs
     tgsavail = asgn.targets_avail()
 
     # Target properties
     tgs = asgn.targets()
 
     # Data for this tile
-    tdata = asgn.tile_fiber_target(tile_id)
+    tdata = asgn.tile_location_target(tile_id)
     avail = tgsavail.tile_data(tile_id)
 
     # The recarray dtypes
@@ -163,8 +164,8 @@ def write_assignment_fits_tile(asgn, fulltarget, overwrite, params):
     # tm.clear()
     # tm.start()
 
-    fibers = np.array(hw.fiber_id)
-    nfiber = len(fibers)
+    locs = np.array(hw.locations)
+    nloc = len(locs)
 
     # Compute the total list of targets
     navail = np.sum([len(avail[x]) for x in avail.keys()])
@@ -266,34 +267,34 @@ def write_assignment_fits_tile(asgn, fulltarget, overwrite, params):
         log.debug("Write:  copying assignment data for tile {}"
                   .format(tile_id))
 
-        fdata = np.zeros(nfiber, dtype=assign_dtype)
-        fdata["FIBER"] = fibers
+        fdata = np.zeros(nloc, dtype=assign_dtype)
+        fdata["LOCATION"] = locs
 
-        # For unassigned fibers, we give each fiber a unique negative
-        # number based on the tile and fiber.
-        unassign_offset = tile_id * nfiber
+        # For unassigned fibers, we give each location a unique negative
+        # number based on the tile and loc.
+        unassign_offset = tile_id * nloc
         assigned_tgids = np.array([tdata[x] if x in tdata.keys()
                                   else -(unassign_offset + x)
-                                  for x in fibers], dtype=np.int64)
+                                  for x in locs], dtype=np.int64)
         fdata["TARGETID"] = assigned_tgids
 
-        # Rows containing assigned fibers
+        # Rows containing assigned locations
         assigned_valid = np.where(assigned_tgids >= 0)[0]
         assigned_invalid = np.where(assigned_tgids < 0)[0]
 
         # Buffers for X/Y/RA/DEC
-        assigned_tgx = np.full(nfiber, 9999.9, dtype=np.float64)
-        assigned_tgy = np.full(nfiber, 9999.9, dtype=np.float64)
-        assigned_tgra = np.full(nfiber, 9999.9, dtype=np.float64)
-        assigned_tgdec = np.full(nfiber, 9999.9, dtype=np.float64)
-        assigned_tgbits = np.zeros(nfiber, dtype=np.int64)
-        assigned_tgtype = np.zeros(nfiber, dtype=np.uint8)
+        assigned_tgx = np.full(nloc, 9999.9, dtype=np.float64)
+        assigned_tgy = np.full(nloc, 9999.9, dtype=np.float64)
+        assigned_tgra = np.full(nloc, 9999.9, dtype=np.float64)
+        assigned_tgdec = np.full(nloc, 9999.9, dtype=np.float64)
+        assigned_tgbits = np.zeros(nloc, dtype=np.int64)
+        assigned_tgtype = np.zeros(nloc, dtype=np.uint8)
 
         if (len(assigned_invalid) > 0):
-            # Fill our unassigned fiber X/Y coordinates with the central
+            # Fill our unassigned location X/Y coordinates with the central
             # positioner locations.  Then convert these to RA/DEC.
-            empty_fibers = fibers[assigned_invalid]
-            fpos_xy_mm = dict(hw.fiber_pos_xy_mm)
+            empty_fibers = locs[assigned_invalid]
+            fpos_xy_mm = dict(hw.loc_pos_xy_mm)
             empty_x = np.array(
                 [fpos_xy_mm[f][0] for f in empty_fibers], dtype=np.float64)
             empty_y = np.array(
@@ -332,34 +333,34 @@ def write_assignment_fits_tile(asgn, fulltarget, overwrite, params):
         fdata["DESIGN_Q"] = assigned_q
         fdata["DESIGN_S"] = assigned_s
 
-        location = dict(hw.fiber_location)
-        device = dict(hw.fiber_device)
-        petal = dict(hw.fiber_petal)
-        device_type = dict(hw.fiber_device_type)
+        fibers = dict(hw.loc_fiber)
+        device = dict(hw.loc_device)
+        petal = dict(hw.loc_petal)
+        device_type = dict(hw.loc_device_type)
 
-        fdata["LOCATION"] = np.array(
-            [location[x] for x in fibers]).astype(np.int32)
+        fdata["FIBER"] = np.array(
+            [fibers[x] for x in locs]).astype(np.int32)
         fdata["DEVICE_LOC"] = np.array(
-            [device[x] for x in fibers]).astype(np.int32)
+            [device[x] for x in locs]).astype(np.int32)
         fdata["PETAL_LOC"] = np.array(
-            [petal[x] for x in fibers]).astype(np.int16)
+            [petal[x] for x in locs]).astype(np.int16)
         fdata["DEVICE_TYPE"] = np.array(
-            [device_type[x] for x in fibers]).astype(np.dtype("a3"))
+            [device_type[x] for x in locs]).astype(np.dtype("a3"))
 
         # This hard-coded value copied from the original code...
-        lambda_ref = np.ones(nfiber, dtype=np.float32) * 5400.0
+        lambda_ref = np.ones(nloc, dtype=np.float32) * 5400.0
         fdata["LAMBDA_REF"] = lambda_ref
 
         # Fiber status
         fstate = dict(hw.state)
-        fstatus = np.zeros(nfiber, dtype=np.int32)
+        fstatus = np.zeros(nloc, dtype=np.int32)
         # Set unused bit
         fstatus |= [0 if x in tdata.keys() else 1 for x in fibers]
         # Set stuck / broken bits
         fstatus |= [2 if (fstate[x] & FIBER_STATE_STUCK) else 0
-                    for x in fibers]
+                    for x in locs]
         fstatus |= [4 if (fstate[x] & FIBER_STATE_BROKEN) else 0
-                    for x in fibers]
+                    for x in locs]
         fstatus[assigned_valid] |= \
             [8 if (tg_type[x] & TARGET_TYPE_SAFE) else 0
              for x in target_rows]
@@ -413,9 +414,9 @@ def write_assignment_fits_tile(asgn, fulltarget, overwrite, params):
 
         fdata = np.zeros(navail, dtype=avail_dtype)
         off = 0
-        for fid in sorted(avail.keys()):
-            for tg in avail[fid]:
-                fdata[off] = (fid, tg)
+        for lid in sorted(avail.keys()):
+            for tg in avail[lid]:
+                fdata[off] = (lid, fibers[lid], tg)
                 off += 1
 
         # tm.stop()
@@ -449,7 +450,7 @@ def write_assignment_fits(tiles, asgn, out_dir=".", out_prefix="fiberassign_",
 
     For each tile, all available targets (not only the assigned targets) and
     their properties are written to the first HDU.  The second HDU contains
-    one row for every fiber and target available to that fiber.
+    one row for every location and target available to that location.
 
     Args:
         tiles (Tiles):  The Tiles object containing the properties of each
@@ -529,23 +530,23 @@ def write_assignment_ascii(tiles, asgn, out_dir=".", out_prefix="fiberassign_",
     tgs = asgn.targets()
 
     for t in tileids:
-        tdata = asgn.tile_fiber_target(t)
-        nfiber = len(tdata)
+        tdata = asgn.tile_location_target(t)
+        nloc = len(tdata)
         tfile = result_path(t, dir=out_dir, prefix=out_prefix,
                             create=True, split=split_dir)
-        if nfiber > 0:
+        if nloc > 0:
             log.debug("Writing tile {}".format(t))
             with open(tfile, "w") as f:
                 f.write("# TILE_RA = {}\n".format(tilera[tileorder[t]]))
                 f.write("# TILE_DEC = {}\n".format(tiledec[tileorder[t]]))
                 f.write("#\n")
-                f.write("# FIBER  TARGETID  RA  DEC  PRIORITY  "
+                f.write("# LOCATION  TARGETID  RA  DEC  PRIORITY  "
                         "SUBPRIORITY  OBSCONDITIONS  NUMOBS_MORE  FBATYPE\n")
-                for fid in sorted(tdata.keys()):
-                    tgid = tdata[fid]
+                for lid in sorted(tdata.keys()):
+                    tgid = tdata[lid]
                     tg = tgs.get(tgid)
                     f.write("{:d} {:d} {:.6f} {:.6f}\n"
-                            .format(fid, tgid, tg.ra, tg.dec, tg.priority,
+                            .format(lid, tgid, tg.ra, tg.dec, tg.priority,
                                     tg.subpriority, tg.obscond, tg.obsremain,
                                     tg.type))
     return
@@ -559,18 +560,18 @@ def avail_table_to_dict(avail_data):
             (for example).
 
     Returns:
-        (dict):  A dictionary of numpy arrays, one per fiber, containing the
-            available target IDs for the fiber.
+        (dict):  A dictionary of numpy arrays, one per location, containing the
+            available target IDs for the location.
 
     """
     avail_target = avail_data["TARGETID"]
-    avail_fiber = avail_data["FIBER"]
+    avail_loc = avail_data["LOCATION"]
     avail = dict()
-    for fid, tgid in zip(avail_fiber, avail_target):
-        if fid in avail:
-            avail[fid].append(tgid)
+    for lid, tgid in zip(avail_loc, avail_target):
+        if lid in avail:
+            avail[lid].append(tgid)
         else:
-            avail[fid] = list([tgid])
+            avail[lid] = list([tgid])
     avail = {f: np.array(av) for f, av in avail.items()}
     return avail
 
@@ -636,7 +637,7 @@ def read_assignment_fits_tile(params):
                 fiber_data[col][npos:] = "ETC"
             elif col == "FIBER":
                 fiber_data[col][0:npos] = fbassign[col]
-                fiber_data[col][npos:] = 5000 + fbsky[col]
+                fiber_data[col][npos:] = -1
             else:
                 fiber_data[col][0:npos] = fbassign[col]
                 if col in fbsky.dtype.names:
@@ -1091,11 +1092,11 @@ def merge_results_tile(out_dtype, copy_fba, params):
                                 in merged_potential_columns.items()])
     potential = np.zeros(len(avail_data), dtype=potential_dtype)
 
-    fiberloc = {x: y for x, y in
-                zip(fiber_data["FIBER"], fiber_data["LOCATION"])}
-    potential["FIBER"] = avail_data["FIBER"]
+    locfiber = {x: y for x, y in
+                zip(fiber_data["LOCATION"], fiber_data["FIBER"])}
+    potential["LOCATION"] = avail_data["LOCATION"]
     potential["TARGETID"] = avail_data["TARGETID"]
-    potential["LOCATION"] = [fiberloc[x] for x in avail_data["FIBER"]]
+    potential["FIBER"] = [locfiber[x] for x in avail_data["LOCATION"]]
     fd.write(potential, header=inhead, extname="POTENTIAL_ASSIGNMENTS")
 
     # Now copy the original HDUs

--- a/py/fiberassign/qa.py
+++ b/py/fiberassign/qa.py
@@ -75,7 +75,7 @@ def qa_tile(hw, tile_id, tgs, tgprops, tile_assign, tile_avail):
     # props["tile_ra"] = tiles.ra[tile_idx]
     # props["tile_dec"] = tiles.dec[tile_idx]
     # props["tile_obscond"] = tiles.obscond[tile_idx]
-    fibers = np.array(hw.device_fibers("POS"))
+    locs = np.array(hw.device_locations("POS"))
     nassign = 0
     nscience = 0
     nstd = 0
@@ -83,13 +83,13 @@ def qa_tile(hw, tile_id, tgs, tgprops, tile_assign, tile_avail):
     nsafe = 0
     unassigned = list()
     objtypes = dict()
-    for fid in fibers:
-        if fid not in tile_assign:
-            unassigned.append(int(fid))
+    for lid in locs:
+        if lid not in tile_assign:
+            unassigned.append(int(lid))
             continue
-        tgid = tile_assign[fid]
+        tgid = tile_assign[lid]
         if tgid < 0:
-            unassigned.append(int(fid))
+            unassigned.append(int(lid))
             continue
         nassign += 1
         tg = tgs.get(tgid)

--- a/py/fiberassign/qa.py
+++ b/py/fiberassign/qa.py
@@ -133,8 +133,8 @@ def qa_tile_file(hw, params):
     pos_rows = np.where(fiber_data["DEVICE_TYPE"].astype(str) == "POS")[0]
 
     # Target assignment
-    tassign = {x["FIBER"]: x["TARGETID"] for x in fiber_data[pos_rows]
-               if (x["FIBER"] >= 0)}
+    tassign = {x["LOCATION"]: x["TARGETID"] for x in fiber_data[pos_rows]
+               if (x["LOCATION"] >= 0)}
 
     tavail = avail_table_to_dict(avail_data)
 

--- a/py/fiberassign/scripts/assign.py
+++ b/py/fiberassign/scripts/assign.py
@@ -26,7 +26,7 @@ from ..gfa import get_gfa_targets
 from ..targets import (str_to_target_type, TARGET_TYPE_SCIENCE,
                        TARGET_TYPE_SKY, TARGET_TYPE_STANDARD,
                        TARGET_TYPE_SAFE, Targets, TargetsAvailable,
-                       TargetTree, FibersAvailable,
+                       TargetTree, LocationsAvailable,
                        load_target_file)
 
 from ..assign import (Assignment, write_assignment_fits,
@@ -309,7 +309,7 @@ def run_assign_full(args):
     del tree
 
     # Compute the fibers on all tiles available for each target and sky
-    favail = FibersAvailable(tgsavail)
+    favail = LocationsAvailable(tgsavail)
 
     # Create assignment object
     asgn = Assignment(tgs, tgsavail, favail)

--- a/py/fiberassign/targets.py
+++ b/py/fiberassign/targets.py
@@ -29,7 +29,7 @@ from .utils import Logger, Timer
 from ._internal import (TARGET_TYPE_SCIENCE, TARGET_TYPE_SKY,
                         TARGET_TYPE_STANDARD, TARGET_TYPE_SAFE,
                         Target, Targets, TargetTree, TargetsAvailable,
-                        FibersAvailable)
+                        LocationsAvailable)
 
 
 def str_to_target_type(input):

--- a/py/fiberassign/test/test_assign.py
+++ b/py/fiberassign/test/test_assign.py
@@ -22,7 +22,7 @@ from fiberassign.tiles import load_tiles
 from fiberassign.targets import (TARGET_TYPE_SCIENCE, TARGET_TYPE_SKY,
                                  TARGET_TYPE_STANDARD, TARGET_TYPE_SAFE,
                                  Targets, TargetsAvailable, TargetTree,
-                                 FibersAvailable, load_target_file)
+                                 LocationsAvailable, load_target_file)
 
 from fiberassign.assign import (Assignment, write_assignment_fits,
                                 write_assignment_ascii, merge_results,
@@ -82,7 +82,7 @@ class TestAssign(unittest.TestCase):
         del tree
 
         # Compute the fibers on all tiles available for each target
-        favail = FibersAvailable(tgsavail)
+        favail = LocationsAvailable(tgsavail)
 
         # First pass assignment
         asgn = Assignment(tgs, tgsavail, favail)
@@ -129,7 +129,7 @@ class TestAssign(unittest.TestCase):
         # Here we test reading with the standard reading function
 
         for tid in tile_ids:
-            tdata = asgn.tile_fiber_target(tid)
+            tdata = asgn.tile_location_target(tid)
             avail = tgsavail.tile_data(tid)
             # Check basic format
             infile = os.path.join(test_dir,
@@ -289,7 +289,7 @@ class TestAssign(unittest.TestCase):
         del tree
 
         # Compute the fibers on all tiles available for each target
-        favail = FibersAvailable(tgsavail)
+        favail = LocationsAvailable(tgsavail)
 
         # Create assignment object
         asgn = Assignment(tgs, tgsavail, favail)

--- a/py/fiberassign/test/test_assign.py
+++ b/py/fiberassign/test/test_assign.py
@@ -137,13 +137,13 @@ class TestAssign(unittest.TestCase):
             inhead, fiber_data, targets_data, avail_data, gfa_targets = \
                 read_assignment_fits_tile((tid, infile))
 
-            for fid, tgid, tgra, tgdec in zip(
-                    fiber_data["FIBER"],
+            for lid, tgid, tgra, tgdec in zip(
+                    fiber_data["LOCATION"],
                     fiber_data["TARGETID"],
                     fiber_data["TARGET_RA"],
                     fiber_data["TARGET_DEC"]):
                 if tgid >= 0:
-                    self.assertEqual(tgid, tdata[fid])
+                    self.assertEqual(tgid, tdata[lid])
                     props = tgs.get(tgid)
                     self.assertEqual(tgra, props.ra)
                     self.assertEqual(tgdec, props.dec)
@@ -153,13 +153,13 @@ class TestAssign(unittest.TestCase):
                                   "full_tile-{:06d}.fits".format(tid))
             inhead, fiber_data, targets_data, avail_data, gfa_targets = \
                 read_assignment_fits_tile((tid, infile))
-            for fid, tgid, tgra, tgdec in zip(
-                    fiber_data["FIBER"],
+            for lid, tgid, tgra, tgdec in zip(
+                    fiber_data["LOCATION"],
                     fiber_data["TARGETID"],
                     fiber_data["TARGET_RA"],
                     fiber_data["TARGET_DEC"]):
                 if tgid >= 0:
-                    self.assertEqual(tgid, tdata[fid])
+                    self.assertEqual(tgid, tdata[lid])
                     props = tgs.get(tgid)
                     self.assertEqual(tgra, props.ra)
                     self.assertEqual(tgdec, props.dec)
@@ -168,7 +168,7 @@ class TestAssign(unittest.TestCase):
         # target data.
 
         for tid in tile_ids:
-            tdata = asgn.tile_fiber_target(tid)
+            tdata = asgn.tile_location_target(tid)
             avail = tgsavail.tile_data(tid)
             # Check basic format
             infile = os.path.join(test_dir,
@@ -176,8 +176,8 @@ class TestAssign(unittest.TestCase):
             fdata = fitsio.FITS(infile, "r")
             fassign = fdata["FIBERASSIGN"].read()
             ftargets = fdata["TARGETS"].read()
-            for fid, tgid, tgra, tgdec, tgsub, tgprior, tgobs in zip(
-                    fassign["FIBER"],
+            for lid, tgid, tgra, tgdec, tgsub, tgprior, tgobs in zip(
+                    fassign["LOCATION"],
                     fassign["TARGETID"],
                     fassign["TARGET_RA"],
                     fassign["TARGET_DEC"],
@@ -185,7 +185,7 @@ class TestAssign(unittest.TestCase):
                     fassign["PRIORITY"],
                     fassign["OBSCONDITIONS"]):
                 if tgid >= 0:
-                    self.assertEqual(tgid, tdata[fid])
+                    self.assertEqual(tgid, tdata[lid])
                     props = tgs.get(tgid)
                     self.assertEqual(tgra, props.ra)
                     self.assertEqual(tgdec, props.dec)
@@ -212,8 +212,8 @@ class TestAssign(unittest.TestCase):
             fdata = fitsio.FITS(infile, "r")
             fassign = fdata["FIBERASSIGN"].read()
             ftargets = fdata["TARGETS"].read()
-            for fid, tgid, tgra, tgdec, tgsub, tgprior, tgobs in zip(
-                    fassign["FIBER"],
+            for lid, tgid, tgra, tgdec, tgsub, tgprior, tgobs in zip(
+                    fassign["LOCATION"],
                     fassign["TARGETID"],
                     fassign["TARGET_RA"],
                     fassign["TARGET_DEC"],
@@ -221,7 +221,7 @@ class TestAssign(unittest.TestCase):
                     fassign["PRIORITY"],
                     fassign["OBSCONDITIONS"]):
                 if tgid >= 0:
-                    self.assertEqual(tgid, tdata[fid])
+                    self.assertEqual(tgid, tdata[lid])
                     props = tgs.get(tgid)
                     self.assertEqual(tgra, props.ra)
                     self.assertEqual(tgdec, props.dec)

--- a/py/fiberassign/test/test_hardware.py
+++ b/py/fiberassign/test/test_hardware.py
@@ -26,8 +26,8 @@ class TestHardware(unittest.TestCase):
 
     def test_collision_xy(self):
         hw = load_hardware()
-        center_mm = hw.fiber_pos_xy_mm
-        fiber_id = hw.fiber_id
+        center_mm = hw.loc_pos_xy_mm
+        locs = hw.locations
         nrot = 100
         rotrad = 0.5
         rotincr = 2 * np.pi / nrot
@@ -37,15 +37,15 @@ class TestHardware(unittest.TestCase):
             xoff = rotrad * np.cos(rot * rotincr)
             yoff = rotrad * np.sin(rot * rotincr)
             xy = [(center_mm[p][0] + xoff, center_mm[p][1] + yoff)
-                  for p in fiber_id]
-            result = hw.check_collisions_xy(fiber_id, xy, 0)
+                  for p in locs]
+            result = hw.check_collisions_xy(locs, xy, 0)
         tm.stop()
         tm.report("check_collisions_xy 100 configurations")
         return
 
     def test_collision_thetaphi(self):
         hw = load_hardware()
-        fiber_id = hw.fiber_id
+        locs = hw.locations
         ntheta = 10
         nphi = 10
         thetaincr = 2 * np.pi / ntheta
@@ -54,9 +54,9 @@ class TestHardware(unittest.TestCase):
         tm.start()
         for thetarot in range(ntheta):
             for phirot in range(nphi):
-                theta = [thetarot * thetaincr for x in fiber_id]
-                phi = [phirot * phiincr for x in fiber_id]
-                result = hw.check_collisions_thetaphi(fiber_id, theta, phi, 0)
+                theta = [thetarot * thetaincr for x in locs]
+                phi = [phirot * phiincr for x in locs]
+                result = hw.check_collisions_thetaphi(locs, theta, phi, 0)
         tm.stop()
         tm.report("check_collisions_thetaphi 100 configurations")
         return

--- a/py/fiberassign/test/test_targets.py
+++ b/py/fiberassign/test/test_targets.py
@@ -21,7 +21,7 @@ from fiberassign.targets import (TARGET_TYPE_SCIENCE, TARGET_TYPE_SKY,
                                  default_main_safemask,
                                  default_main_excludemask,
                                  Targets, TargetTree, TargetsAvailable,
-                                 FibersAvailable)
+                                 LocationsAvailable)
 
 from .simulate import (test_subdir_create, sim_tiles, sim_targets)
 
@@ -63,7 +63,7 @@ class TestTargets(unittest.TestCase):
         del tree
 
         # Compute the fibers on all tiles available for each target
-        favail = FibersAvailable(tgsavail)
+        favail = LocationsAvailable(tgsavail)
 
         return
 

--- a/py/fiberassign/test/test_vis.py
+++ b/py/fiberassign/test/test_vis.py
@@ -28,8 +28,8 @@ class TestVis(unittest.TestCase):
         test_dir = test_subdir_create("vis_test_plotpos")
         hw = load_hardware()
         patrol_mm = hw.patrol_mm
-        fiber_id = hw.fiber_id
-        center_mm = hw.fiber_pos_xy_mm
+        locs = hw.locations
+        center_mm = hw.loc_pos_xy_mm
 
         # Plot data range in mm
         width = 1.2 * (2.0 * patrol_mm)
@@ -44,36 +44,36 @@ class TestVis(unittest.TestCase):
         fontpt = int(0.75 * fontpix)
 
         # Plot the first fiber in a variety of positions
-        fid = fiber_id[0]
+        lid = locs[0]
         nincr = 8
         configincr = 2.0 * np.pi / nincr
 
-        center = center_mm[fid]
+        center = center_mm[lid]
 
         for configindx, (configrad, col) in \
                 enumerate(zip([0.5*patrol_mm, patrol_mm], ["r", "b"])):
             fig = plt.figure(figsize=(xfigsize, yfigsize), dpi=figdpi)
             ax = fig.add_subplot(1, 1, 1)
             ax.set_aspect("equal")
-            cb, fh = hw.fiber_position(fid, center_mm[fid])
-            plot_positioner(ax, patrol_mm, fid, center, cb, fh, color="k")
+            cb, fh = hw.loc_position(lid, center_mm[lid])
+            plot_positioner(ax, patrol_mm, lid, center, cb, fh, color="k")
             for inc in range(nincr):
                 ang = inc * configincr
-                xoff = configrad * np.cos(ang) + center_mm[fid][0]
-                yoff = configrad * np.sin(ang) + center_mm[fid][1]
-                cb, fh = hw.fiber_position(fid, (xoff, yoff))
-                plot_positioner(ax, patrol_mm, fid, center, cb, fh, color=col)
+                xoff = configrad * np.cos(ang) + center_mm[lid][0]
+                yoff = configrad * np.sin(ang) + center_mm[lid][1]
+                cb, fh = hw.loc_position(lid, (xoff, yoff))
+                plot_positioner(ax, patrol_mm, lid, center, cb, fh, color=col)
                 xend = xoff
                 yend = yoff
-                ax.plot([center_mm[fid][0], xend], [center_mm[fid][1], yend],
+                ax.plot([center_mm[lid][0], xend], [center_mm[lid][1], yend],
                         color="k", linewidth="0.5")
                 ax.text(xend, yend, "{}".format(inc),
                         color='k', fontsize=fontpt,
                         horizontalalignment='center',
                         verticalalignment='center',
                         bbox=dict(fc='w', ec='none', pad=1, alpha=1.0))
-            pxcent = center_mm[fid][0]
-            pycent = center_mm[fid][1]
+            pxcent = center_mm[lid][0]
+            pycent = center_mm[lid][1]
             half_width = 0.5 * width
             half_height = 0.5 * height
             ax.set_xlabel("Millimeters", fontsize="large")

--- a/src/_pyfiberassign.cpp
+++ b/src/_pyfiberassign.cpp
@@ -1,4 +1,3 @@
-
 #include <string>
 #include <sstream>
 
@@ -433,21 +432,21 @@ PYBIND11_MODULE(_internal, m) {
         Class representing the hardware configuration of the telescope.
 
         Args:
-            fiber (array):  int32 array of fiber IDs.
-            petal (array):  int32 array of petal index.
-            spectro (array):  int32 array of spectrograph index.
             location (array):  int32 array of location.
-            slit (array):  int32 array of slit number.
+            petal (array):  int32 array of petal index.
+            device (array):  int32 array of device number.
             slitblock (array):  int32 array of slitblock.
             blockfiber (array):  int32 array of blockfiber.
-            device (array):  int32 array of device number.
+            spectro (array):  int32 array of spectrograph index.
+            fiber (array):  int32 array of fiber IDs.
+            slit (array):  int32 array of slit number.
             device_type (list):  List of strings of device types
                 (e.g. POS, ETC).
-            x (array):  array of fiber X coordinate centers in mm.
-            y (array):  array of fiber Y coordinate centers in mm.
-            z (array):  array of fiber Z coordinate centers in mm.
-            q (array):  array fiber Q coordinate centers in degrees.
-            s (array):  array fiber S coordinate centers in mm.
+            x (array):  location X coordinate centers in mm.
+            y (array):  location Y coordinate centers in mm.
+            z (array):  location Z coordinate centers in mm.
+            q (array):  location Q coordinate centers in degrees.
+            s (array):  location S coordinate centers in mm.
             status (array):  array of integers containing the fiber status.
 
         )")
@@ -466,68 +465,68 @@ PYBIND11_MODULE(_internal, m) {
             std::vector <double> const &,
             std::vector <double> const &,
             std::vector <double> const &,
-            std::vector <int32_t> const & > (), py::arg("fiber"),
-            py::arg("peta"), py::arg("spectro"), py::arg("location"),
-            py::arg("slit"), py::arg("slitblock"), py::arg("blockfiber"),
-            py::arg("device"), py::arg("device_type"), py::arg("x"),
+            std::vector <int32_t> const &> (), py::arg("location"),
+            py::arg("petal"), py::arg("device"), py::arg("slitblock"),
+            py::arg("blockfiber"), py::arg("spectro"), py::arg("fiber"),
+            py::arg("slit"), py::arg("device_type"), py::arg("x"),
             py::arg("y"), py::arg("z"), py::arg("q"), py::arg("s"),
             py::arg("status")
         )
-        .def_readonly("nfiber", &fba::Hardware::nfiber, R"(
-            The number of fibers (including POS and ETC devices).
+        .def_readonly("nloc", &fba::Hardware::nloc, R"(
+            The number of device locations.
         )")
         .def_readonly("npetal", &fba::Hardware::npetal, R"(
             The number of petals.
         )")
         .def_readonly("nfiber_petal", &fba::Hardware::nfiber_petal, R"(
-            The number of fibers per petal.
+            The number of science positioners (device type POS) per petal.
         )")
         .def_readonly("focalplane_radius_deg",
                       &fba::Hardware::focalplane_radius_deg, R"(
                           The focalplane radius in degrees.
                       )")
-        .def_readonly("fiber_id", &fba::Hardware::fiber_id, R"(
-            Vector of fiber IDs.
+        .def_readonly("locations", &fba::Hardware::locations, R"(
+            Vector of locations.
         )")
-        .def_readonly("fiber_petal", &fba::Hardware::fiber_petal, R"(
-            Dictionary of the petal for each fiber ID.
+        .def_readonly("loc_petal", &fba::Hardware::loc_petal, R"(
+            Dictionary of the petal for each location.
         )")
-        .def_readonly("petal_fibers", &fba::Hardware::petal_fibers, R"(
-            Dictionary of the fiber IDs for each petal.
+        .def_readonly("petal_locations", &fba::Hardware::petal_locations, R"(
+            Dictionary of the locations for each petal.
         )")
-        .def_readonly("fiber_pos_xy_mm", &fba::Hardware::fiber_pos_xy_mm, R"(
-            Dictionary of (X, Y) position tuples for each fiber ID.
+        .def_readonly("loc_pos_xy_mm", &fba::Hardware::loc_pos_xy_mm, R"(
+            Dictionary of central (X, Y) position tuples for each location.
         )")
-        .def_readonly("fiber_pos_z_mm", &fba::Hardware::fiber_pos_z_mm, R"(
-            Dictionary of Z values for each fiber ID.
+        .def_readonly("loc_pos_z_mm", &fba::Hardware::loc_pos_z_mm, R"(
+            Dictionary of central Z values for each location.
         )")
-        .def_readonly("fiber_pos_q_deg", &fba::Hardware::fiber_pos_q_deg, R"(
-            Dictionary of Q values for each fiber ID.
+        .def_readonly("loc_pos_q_deg", &fba::Hardware::loc_pos_q_deg, R"(
+            Dictionary of central Q values for each location.
         )")
-        .def_readonly("fiber_pos_s_mm", &fba::Hardware::fiber_pos_s_mm, R"(
-            Dictionary of S values for each fiber ID.
+        .def_readonly("loc_pos_s_mm", &fba::Hardware::loc_pos_s_mm, R"(
+            Dictionary of central S values for each location.
         )")
-        .def_readonly("fiber_device", &fba::Hardware::fiber_device, R"(
-            Dictionary of device ID for each fiber ID
+        .def_readonly("loc_device", &fba::Hardware::loc_device, R"(
+            Dictionary of device ID for each location
         )")
-        .def_readonly("fiber_device_type",
-                      &fba::Hardware::fiber_device_type, R"(
-            Dictionary of device type (POS or ETC) for each fiber ID.
+        .def_readonly("loc_device_type",
+                      &fba::Hardware::loc_device_type, R"(
+            Dictionary of device type (POS or ETC) for each location.
         )")
-        .def_readonly("fiber_location", &fba::Hardware::fiber_location, R"(
-            Dictionary of location values for each fiber ID.
+        .def_readonly("loc_fiber", &fba::Hardware::loc_fiber, R"(
+            Dictionary of fiber values for each location.
         )")
-        .def_readonly("fiber_spectro", &fba::Hardware::fiber_spectro, R"(
-            Dictionary of spectrograph index for each fiber ID.
+        .def_readonly("loc_spectro", &fba::Hardware::loc_spectro, R"(
+            Dictionary of spectrograph index for each location.
         )")
-        .def_readonly("fiber_slit", &fba::Hardware::fiber_slit, R"(
-            Dictionary of slit values for each fiber ID.
+        .def_readonly("loc_slit", &fba::Hardware::loc_slit, R"(
+            Dictionary of slit values for each location.
         )")
-        .def_readonly("fiber_slitblock", &fba::Hardware::fiber_slitblock, R"(
-            Dictionary of slitblock values for each fiber ID.
+        .def_readonly("loc_slitblock", &fba::Hardware::loc_slitblock, R"(
+            Dictionary of slitblock values for each location.
         )")
-        .def_readonly("fiber_blockfiber", &fba::Hardware::fiber_blockfiber, R"(
-            Dictionary of blockfiber values for each fiber ID.
+        .def_readonly("loc_blockfiber", &fba::Hardware::loc_blockfiber, R"(
+            Dictionary of blockfiber values for each location.
         )")
         .def_readonly("patrol_mm", &fba::Hardware::patrol_mm, R"(
             Constant patrol radius, soon will be a dictionary...
@@ -541,20 +540,20 @@ PYBIND11_MODULE(_internal, m) {
         )")
         .def_readonly("neighbor_radius_mm",
                       &fba::Hardware::neighbor_radius_mm, R"(
-            Radius for considering fibers as neighbors.
+            Radius for considering locations as neighbors.
         )")
         .def_readonly("positioner_range", &fba::Hardware::positioner_range, R"(
             Constant positioner range, soon will be a dictionary...
         )")
         .def_readonly("state", &fba::Hardware::state, R"(
-            Dictionary of fiber state for each fiber ID.
+            Dictionary of fiber state for each location.
         )")
         .def_readonly("neighbors", &fba::Hardware::neighbors, R"(
-            Dictionary of neighbor IDs for each fiber ID.
+            Dictionary of neighbor IDs for each location.
         )")
-        .def("device_fibers", &fba::Hardware::device_fibers,
+        .def("device_locations", &fba::Hardware::device_locations,
             py::arg("type"), R"(
-            Dictionary of fiber IDs for each device type (POS or ETC).
+            Dictionary of locations for each device type (POS or ETC).
         )")
         .def("radec2xy", &fba::Hardware::radec2xy, py::arg("tilera"),
             py::arg("tiledec"), py::arg("ra"), py::arg("dec"), R"(
@@ -643,11 +642,11 @@ PYBIND11_MODULE(_internal, m) {
                 (list): list of (RA, DEC) tuples.
 
         )")
-        .def("fiber_position", &fba::Hardware::fiber_position, py::arg("id"),
+        .def("loc_position", &fba::Hardware::loc_position, py::arg("id"),
             py::arg("xy"), R"(
             Move a positioner to a given location.
 
-            This takes the specified fiber ID and computes the shapes of
+            This takes the specified location and computes the shapes of
             the central body and fiber holder when the fiber is moved to
             a given (X, Y) position.  The returned tuple contains the
             (central body, fiber holder) as independent Shape objects.
@@ -660,106 +659,107 @@ PYBIND11_MODULE(_internal, m) {
                 (tuple): the shapes representing the positioner.
 
         )")
-        .def("fiber_position_multi", &fba::Hardware::fiber_position_multi,
+        .def("loc_position_multi", &fba::Hardware::loc_position_multi,
             py::arg("id"), py::arg("xy"), py::arg("threads"), R"(
             Move positioners to given locations.
 
-            This takes the specified fiber IDs and computes the shapes of
+            This takes the specified locations and computes the shapes of
             the central body and fiber holder when each fiber is moved to
             a given (X, Y) position.  The returned list of tuples contains
             the (central body, fiber holder) as 2 Shape objects for each
-            fiber ID.
+            location.
 
             Args:
-                id (list): List of (int) fiber IDs.
+                id (list): List of (int) locations.
                 xy (list): List of (X, Y) tuples at which to place each fiber.
                 threads (int): If <= 0 use maximum threads,
                     else use this number.
 
             Returns:
-                (list): One tuple for each fiber ID with positioner shapes.
+                (list): One tuple for each location with positioner shapes.
 
         )")
         .def("check_collisions_xy", &fba::Hardware::check_collisions_xy,
             py::arg("id"), py::arg("xy"), py::arg("threads"), R"(
             Check for collisions.
 
-            This takes the specified fiber IDs and computes the shapes of
+            This takes the specified locations and computes the shapes of
             the central body and fiber holder when each fiber is moved to
             a given (X, Y) position.  It then tests for collisions between
-            these shapes among the fiber IDs specified.  The returned list
+            these shapes among the locations specified.  The returned list
             of bools is True whenever the corresponding fiber had a collision
             and False otherwise.
 
             Args:
-                id (list): List of (int) fiber IDs.
+                id (list): List of (int) locations.
                 xy (list): List of (X, Y) tuples at which to place each fiber.
                 threads (int): If <= 0 use maximum threads,
                     else use this number.
 
             Returns:
-                (list): A boolean value for each fiber ID.
+                (list): A boolean value for each location.
 
         )")
         .def("check_collisions_thetaphi",
              &fba::Hardware::check_collisions_thetaphi, py::arg("id"), py::arg("theta"), py::arg("phi"), py::arg("threads"), R"(
              Check for collisions.
 
-             This takes the specified fiber IDs and computes the shapes of
+             This takes the specified locations and computes the shapes of
              the central body and fiber holder when each fiber is moved to
              a given (theta, phi) orientation.  It then tests for collisions
-             between these shapes among the fiber IDs specified.  The returned
+             between these shapes among the locations specified.  The returned
              list of bools is True whenever the corresponding fiber had a
              collision and False otherwise.
 
              Args:
-                 id (array): List of (int) fiber IDs.
+                 id (array): List of (int) locations.
                  theta (array): Theta angle for each positioner.
                  phi (array): Phi angle for each positioner.
                  threads (int): If <= 0 use maximum threads,
                      else use this number.
 
              Returns:
-                 (list): A boolean value for each fiber ID.
+                 (list): A boolean value for each location.
 
          )")
         .def(py::pickle(
             [](fba::Hardware const & p) { // __getstate__
-                int32_t nfiber = p.fiber_id.size();
-                std::vector <int32_t> fid(nfiber);
-                std::vector <int32_t> petal(nfiber);
-                std::vector <int32_t> spectro(nfiber);
-                std::vector <int32_t> location(nfiber);
-                std::vector <int32_t> slit(nfiber);
-                std::vector <int32_t> slitblock(nfiber);
-                std::vector <int32_t> blockfiber(nfiber);
-                std::vector <int32_t> device(nfiber);
-                std::vector <std::string> device_type(nfiber);
-                std::vector <double> x_mm(nfiber);
-                std::vector <double> y_mm(nfiber);
-                std::vector <double> z_mm(nfiber);
-                std::vector <double> q_deg(nfiber);
-                std::vector <double> s_mm(nfiber);
-                std::vector <int32_t> status(nfiber);
-                for (int32_t i = 0; i < nfiber; ++i) {
-                    fid[i] = p.fiber_id.at(i);
-                    petal[i] = p.fiber_petal.at(fid[i]);
-                    spectro[i] = p.fiber_spectro.at(fid[i]);
-                    location[i] = p.fiber_location.at(fid[i]);
-                    slit[i] = p.fiber_slit.at(fid[i]);
-                    slitblock[i] = p.fiber_slitblock.at(fid[i]);
-                    blockfiber[i] = p.fiber_blockfiber.at(fid[i]);
-                    device[i] = p.fiber_device.at(fid[i]);
-                    device_type[i] = p.fiber_device_type.at(fid[i]);
-                    x_mm[i] = p.fiber_pos_xy_mm.at(fid[i]).first;
-                    y_mm[i] = p.fiber_pos_xy_mm.at(fid[i]).second;
-                    z_mm[i] = p.fiber_pos_z_mm.at(fid[i]);
-                    q_deg[i] = p.fiber_pos_q_deg.at(fid[i]);
-                    s_mm[i] = p.fiber_pos_s_mm.at(fid[i]);
-                    status[i] = p.state.at(fid[i]);
+                int32_t nloc = p.locations.size();
+                std::vector <int32_t> lid(nloc);
+                std::vector <int32_t> petal(nloc);
+                std::vector <int32_t> spectro(nloc);
+                std::vector <int32_t> fiber(nloc);
+                std::vector <int32_t> slit(nloc);
+                std::vector <int32_t> slitblock(nloc);
+                std::vector <int32_t> blockfiber(nloc);
+                std::vector <int32_t> device(nloc);
+                std::vector <std::string> device_type(nloc);
+                std::vector <double> x_mm(nloc);
+                std::vector <double> y_mm(nloc);
+                std::vector <double> z_mm(nloc);
+                std::vector <double> q_deg(nloc);
+                std::vector <double> s_mm(nloc);
+                std::vector <int32_t> status(nloc);
+                for (int32_t i = 0; i < nloc; ++i) {
+                    lid[i] = p.locations.at(i);
+                    petal[i] = p.loc_petal.at(lid[i]);
+                    spectro[i] = p.loc_spectro.at(lid[i]);
+                    fiber[i] = p.loc_fiber.at(lid[i]);
+                    slit[i] = p.loc_slit.at(lid[i]);
+                    slitblock[i] = p.loc_slitblock.at(lid[i]);
+                    blockfiber[i] = p.loc_blockfiber.at(lid[i]);
+                    device[i] = p.loc_device.at(lid[i]);
+                    device_type[i] = p.loc_device_type.at(lid[i]);
+                    x_mm[i] = p.loc_pos_xy_mm.at(lid[i]).first;
+                    y_mm[i] = p.loc_pos_xy_mm.at(lid[i]).second;
+                    z_mm[i] = p.loc_pos_z_mm.at(lid[i]);
+                    q_deg[i] = p.loc_pos_q_deg.at(lid[i]);
+                    s_mm[i] = p.loc_pos_s_mm.at(lid[i]);
+                    status[i] = p.state.at(lid[i]);
                 }
-                return py::make_tuple(fid, petal, spectro, location, slit,
-                    slitblock, blockfiber, device, device_type, x_mm, y_mm, z_mm, q_deg,
+                return py::make_tuple(
+                    lid, petal, device, slitblock, blockfiber, spectro, fiber,
+                    slit, device_type, x_mm, y_mm, z_mm, q_deg,
                     s_mm, status);
             },
             [](py::tuple t) { // __setstate__
@@ -1011,10 +1011,10 @@ PYBIND11_MODULE(_internal, m) {
 
     py::class_ <fba::TargetsAvailable, fba::TargetsAvailable::pshr > (m,
         "TargetsAvailable", R"(
-        Class representing the objects reachable by each fiber of each tile.
+        Class representing the objects reachable by each location of each tile.
 
         This data structure makes it convenient and efficient to get the list
-        of target IDs available to a given fiber for a given tile.
+        of target IDs available to a given location for a given tile.
 
         Args:
             hw (Hardware):  The hardware model.
@@ -1038,64 +1038,67 @@ PYBIND11_MODULE(_internal, m) {
             Return the targets available for a given tile.
 
             This returns a copy of the internal C++ available targets for a
-            given tile ID.  The returned data is a dictionary with the fiber
-            ID as the key and the value is an array of target IDs available to
-            the fiber.
+            given tile ID.  The returned data is a dictionary with the
+            location as the key and the value is an array of target IDs
+            available to the location.
 
             Args:
                 tile (int): The tile ID.
 
             Returns:
-                (dict): Dictionary of available targets for each fiber ID.
+                (dict): Dictionary of available targets for each location.
 
         )");
 
 
-    py::class_ <fba::FibersAvailable, fba::FibersAvailable::pshr > (m,
-        "FibersAvailable", R"(
-        Class representing the tile/fibers reachable by each target.
+    py::class_ <fba::LocationsAvailable, fba::LocationsAvailable::pshr > (m,
+        "LocationsAvailable", R"(
+        Class representing the tile/location reachable by each target.
 
         This data structure makes it convenient and efficient to get the list
-        of tile / fiber pairs that can reach a given target.
+        of tile / location pairs that can reach a given target.
 
         Args:
-            tgsavail (TargetsAvailable):  the targets available to each fiber.
+            tgsavail (TargetsAvailable):  the targets available to each
+                location.
 
         )")
         .def(py::init < fba::TargetsAvailable::pshr > (), py::arg("tgsavail"))
-        .def("target_data", &fba::FibersAvailable::target_data,
+        .def("target_data", &fba::LocationsAvailable::target_data,
             py::arg("target"), R"(
-            Return the tile/fiber pairs that can reach a target.
+            Return the tile/loc pairs that can reach a target.
 
             This returns a copy of the internal C++ data.  The return value
-            is a list of tuples containing the (tile ID, fiber ID) pairs that
+            is a list of tuples containing the (tile ID, location) pairs that
             can reach the specified target ID.
 
             Args:
                 target (int): The target ID.
 
             Returns:
-                (list): List of (tile, fiber) tuples.
+                (list): List of (tile, loc) tuples.
 
         )");
 
 
     py::class_ <fba::Assignment, fba::Assignment::pshr > (m,
         "Assignment", R"(
-        Class representing the current assignment of all fibers.
+        Class representing the current assignment of all locations.
 
-        This data structure stores the current fiber assignment and
+        This data structure stores the current location assignment and
         provides methods for manipulating that assignment
 
         Args:
             tgs (Targets):  the targets.
-            tgsavail (TargetsAvailable):  the targets available to each fiber.
-            favail (FibersAvailable):  the fibers available to each target.
+            tgsavail (TargetsAvailable):  the targets available to each
+                location.
+            locavail (LocationsAvailable):  the locations available to each
+                target.
 
         )")
         .def(py::init < fba::Targets::pshr, fba::TargetsAvailable::pshr,
-             fba::FibersAvailable::pshr > (), py::arg("tgs"),
-             py::arg("tgsavail"), py::arg("favail")
+             fba::LocationsAvailable::pshr > (), py::arg("tgs"),
+             py::arg("tgsavail"), py::arg("locavail")
          )
         .def("targets", &fba::Assignment::targets, R"(
             Return a handle to the Targets object used.
@@ -1109,27 +1112,27 @@ PYBIND11_MODULE(_internal, m) {
         .def("targets_avail", &fba::Assignment::targets_avail, R"(
             Return a handle to the TargetsAvailable object used.
         )")
-        .def("fibers_avail", &fba::Assignment::fibers_avail, R"(
-            Return a handle to the FibersAvailable object used.
+        .def("locations_avail", &fba::Assignment::locations_avail, R"(
+            Return a handle to the LocationsAvailable object used.
         )")
         .def("tiles_assigned", &fba::Assignment::tiles_assigned, R"(
             Return an array of currently assigned tile IDs.
         )")
-        .def("tile_fiber_target", &fba::Assignment::tile_fiber_target,
+        .def("tile_location_target", &fba::Assignment::tile_location_target,
             py::return_value_policy::reference_internal, py::arg("tile"), R"(
             Return the assignment for a given tile.
 
             This returns a copy of the internal C++ target assignment for a
-            given tile ID.  The returned data is a dictionary with the fiber
-            ID as the key and the value is the assigned target ID.  **Only
-            assigned fibers are stored**.  Unassigned fiber IDs do not exist
-            in this dictionary.
+            given tile ID.  The returned data is a dictionary with the
+            location as the key and the value is the assigned target ID.
+            **Only assigned locations are stored**.  Unassigned locations do
+            not exist in this dictionary.
 
             Args:
                 tile (int): The tile ID.
 
             Returns:
-                (dict): Dictionary of assigned target for each fiber ID.
+                (dict): Dictionary of assigned target for each location.
 
         )")
         .def("assign_unused", &fba::Assignment::assign_unused,
@@ -1137,10 +1140,10 @@ PYBIND11_MODULE(_internal, m) {
              py::arg("max_per_petal")=-1,
              py::arg("pos_type")=std::string("POS"),
              py::arg("start_tile")=-1, py::arg("stop_tile")=-1, R"(
-            Assign targets to unused fibers.
+            Assign targets to unused locations.
 
             This will attempt to assign targets of the specified type to
-            unused fibers on devices of the specified type.
+            unused locations with devices of the specified type.
 
             Args:
                 tgtype (int): The target type to assign, which must be one
@@ -1162,7 +1165,7 @@ PYBIND11_MODULE(_internal, m) {
              py::arg("tgtype")=TARGET_TYPE_SCIENCE,
              py::arg("required_per_petal")=0,
              py::arg("start_tile")=-1, py::arg("stop_tile")=-1, R"(
-            Force assignment of targets to unused fibers.
+            Force assignment of targets to unused locations.
 
             This function will "bump" science targets (starting with lowest
             priority) in order to place the required number of targets of the
@@ -1187,7 +1190,7 @@ PYBIND11_MODULE(_internal, m) {
             Redistribute science targets to future tiles.
 
             This function attempts to load balance the science targets per
-            petal by moving science target to future available tile/fiber
+            petal by moving science target to future available tile/loc
             placements that lie on petals with fewer total science targets.
 
             Args:

--- a/src/assign.cpp
+++ b/src/assign.cpp
@@ -14,7 +14,7 @@ namespace fbg = fiberassign::geom;
 
 fba::Assignment::Assignment(fba::Targets::pshr tgs,
                             fba::TargetsAvailable::pshr tgsavail,
-                            fba::FibersAvailable::pshr favail) {
+                            fba::LocationsAvailable::pshr locavail) {
     fba::Timer tm;
     tm.start();
 
@@ -30,7 +30,7 @@ fba::Assignment::Assignment(fba::Targets::pshr tgs,
 
     tgs_ = tgs;
     tgsavail_ = tgsavail;
-    favail_ = favail;
+    locavail_ = locavail;
 
     // Get the hardware and tile configuration
     tiles_ = tgsavail_->tiles();
@@ -61,8 +61,8 @@ fba::Assignment::Assignment(fba::Targets::pshr tgs,
         }
     }
 
-    fiber_target.clear();
-    target_fiber.clear();
+    loc_target.clear();
+    target_loc.clear();
 
     auto const * ptiles = tiles_.get();
     auto const * phw = hw_.get();
@@ -105,15 +105,15 @@ fba::Assignment::Assignment(fba::Targets::pshr tgs,
 
 std::vector <int32_t> fba::Assignment::tiles_assigned() const {
     std::vector <int32_t> ret;
-    for (auto const & it : fiber_target) {
+    for (auto const & it : loc_target) {
         ret.push_back(it.first);
     }
     return ret;
 }
 
 
-std::map <int32_t, int64_t> const & fba::Assignment::tile_fiber_target(int32_t tile) const {
-    return fiber_target.at(tile);
+std::map <int32_t, int64_t> const & fba::Assignment::tile_location_target(int32_t tile) const {
+    return loc_target.at(tile);
 }
 
 
@@ -182,12 +182,12 @@ void fba::Assignment::assign_unused(uint8_t tgtype, int32_t max_per_petal,
 
     std::string tgstr = fba::target_string(tgtype);
 
-    // Select fiber IDs based on positioner type
-    auto fiber_id = hw_->device_fibers(pos_type);
+    // Select locations based on positioner type
+    auto loc = hw_->device_locations(pos_type);
     logmsg.str("");
     logmsg << "assign unused " << tgstr << ":  considering "
-        << fiber_id.size()
-        << " fibers of positioner type \"" << pos_type << "\"";
+        << loc.size()
+        << " locations of positioner type \"" << pos_type << "\"";
     logger.info(logmsg.str().c_str());
 
     gtmname.str("");
@@ -213,14 +213,14 @@ void fba::Assignment::assign_unused(uint8_t tgtype, int32_t max_per_petal,
     auto const & tavail = tgsavail_->data;
     auto const & tgsdata = tgs_->data;
 
-    fba::weight_compare fiber_comp;
+    fba::weight_compare loc_comp;
 
     // This container stores the position in focalplane
     // coordinates of the available targets on a tile.
     //std::map <int64_t, std::pair <double, double> > target_xy;
 
     // This is the specific list of available targets for a single
-    // tile / fiber, after selecting by target type, etc.
+    // tile / location, after selecting by target type, etc.
     std::vector <int64_t> targets_avail;
 
     for (int32_t t = tstart; t <= tstop; ++t) {
@@ -250,26 +250,26 @@ void fba::Assignment::assign_unused(uint8_t tgtype, int32_t max_per_petal,
         auto const & tfavail = tavail.at(tile_id);
         auto const & target_xy = tile_target_xy.at(tile_id);
 
-        // The order in which the fibers should be assigned, based
-        // on the maximum priority of each fiber's available targets of the
+        // The order in which the locations should be assigned, based
+        // on the maximum priority of each location's available targets of the
         // specified type.
-        std::vector <weight_index> fiber_priority;
+        std::vector <weight_index> loc_priority;
 
         gtmname.str("");
-        gtmname << "unused " << tgstr << ": fiber order";
+        gtmname << "unused " << tgstr << ": location order";
         gtm.start(gtmname.str());
 
-        for (auto const & fid : fiber_id) {
-            if (tfavail.count(fid) == 0) {
-                // No targets available for this fiber
+        for (auto const & lid : loc) {
+            if (tfavail.count(lid) == 0) {
+                // No targets available for this location
                 continue;
             }
-            // Targets available for this fiber.  These are already
+            // Targets available for this location.  These are already
             // sorted by priority + subpriority.
-            auto const & avail = tfavail.at(fid);
+            auto const & avail = tfavail.at(lid);
 
             if (avail.size() == 0) {
-                // No targets available for this fiber.
+                // No targets available for this location.
                 continue;
             }
 
@@ -293,77 +293,77 @@ void fba::Assignment::assign_unused(uint8_t tgtype, int32_t max_per_petal,
                 double totpriority = static_cast <double> (tg.priority)
                     + tg.subpriority;
 
-                fiber_priority.push_back(std::make_pair(totpriority, fid));
+                loc_priority.push_back(std::make_pair(totpriority, lid));
                 break;
             }
         }
 
-        std::stable_sort(fiber_priority.begin(), fiber_priority.end(),
-                         fiber_comp);
+        std::stable_sort(loc_priority.begin(), loc_priority.end(),
+                         loc_comp);
         gtm.stop(gtmname.str());
 
         gtmname.str("");
-        gtmname << "unused " << tgstr << ": assign fibers";
+        gtmname << "unused " << tgstr << ": assign locations";
         gtm.start(gtmname.str());
 
-        for (auto const & fpr : fiber_priority) {
-            // The fiber ID.
-            int32_t fid = fpr.second;
+        for (auto const & fpr : loc_priority) {
+            // The location.
+            int32_t lid = fpr.second;
             // The petal
-            int32_t p = hw_->fiber_petal[fid];
+            int32_t p = hw_->loc_petal[lid];
 
             if (nassign_petal[tgtype][tile_id][p] >= max_per_petal) {
                 // Already have enough objects on this petal
                 if (extra_log) {
                     logmsg.str("");
                     logmsg << "assign unused " << tgstr << ": tile " << tile_id
-                        << ", petal " << p << " fiber " << fid << " has "
+                        << ", petal " << p << " location " << lid << " has "
                         << nassign_petal[tgtype][tile_id][p]
                         << " (>= " << max_per_petal << ")";
-                    logger.debug_tfg(tile_id, fid, -1, logmsg.str().c_str());
+                    logger.debug_tfg(tile_id, lid, -1, logmsg.str().c_str());
                 }
                 continue;
             }
 
-            if (fiber_target[tile_id].count(fid) > 0) {
+            if (loc_target[tile_id].count(lid) > 0) {
                 // Fiber is currently assigned, skip it.
                 if (extra_log) {
                     logmsg.str("");
                     logmsg << "assign unused " << tgstr << ": tile " << tile_id
-                        << ", petal " << p << " fiber " << fid
+                        << ", petal " << p << " location " << lid
                         << " is already assigned";
-                    logger.debug_tfg(tile_id, fid, -1, logmsg.str().c_str());
+                    logger.debug_tfg(tile_id, lid, -1, logmsg.str().c_str());
                 }
                 continue;
             }
 
-            // Examine available targets for this fiber.  These are already
+            // Examine available targets for this location.  These are already
             // sorted in priority / subpriority order.  Attempt to assign
             // any standards we can.
 
-            if (tfavail.count(fid) == 0) {
-                // No targets available for this fiber
+            if (tfavail.count(lid) == 0) {
+                // No targets available for this location
                 if (extra_log) {
                     logmsg.str("");
                     logmsg << "assign unused " << tgstr << ": tile " << tile_id
-                        << ", petal " << p << " fiber " << fid
+                        << ", petal " << p << " location " << lid
                         << " has no available targets";
-                    logger.debug_tfg(tile_id, fid, -1, logmsg.str().c_str());
+                    logger.debug_tfg(tile_id, lid, -1, logmsg.str().c_str());
                 }
                 continue;
             }
 
-            // All targets available for this fiber.
-            auto const & avail = tfavail.at(fid);
+            // All targets available for this location.
+            auto const & avail = tfavail.at(lid);
 
             if (avail.size() == 0) {
-                // No targets available for this fiber.
+                // No targets available for this location.
                 if (extra_log) {
                     logmsg.str("");
                     logmsg << "assign unused " << tgstr << ": tile " << tile_id
-                        << ", petal " << p << " fiber " << fid
+                        << ", petal " << p << " location " << lid
                         << " has no available targets";
-                    logger.debug_tfg(tile_id, fid, -1, logmsg.str().c_str());
+                    logger.debug_tfg(tile_id, lid, -1, logmsg.str().c_str());
                 }
                 continue;
             }
@@ -383,10 +383,10 @@ void fba::Assignment::assign_unused(uint8_t tgtype, int32_t max_per_petal,
                     if (extra_log) {
                         logmsg.str("");
                         logmsg << "assign unused " << tgstr << ": tile " << tile_id
-                            << ", petal " << p << " fiber " << fid
+                            << ", petal " << p << " location " << lid
                             << " available target " << tgid
                             << " is wrong type (" << (int)tg.type << ")";
-                        logger.debug_tfg(tile_id, fid, tgid,
+                        logger.debug_tfg(tile_id, lid, tgid,
                                          logmsg.str().c_str());
                     }
                     continue;
@@ -394,11 +394,11 @@ void fba::Assignment::assign_unused(uint8_t tgtype, int32_t max_per_petal,
                 if (extra_log) {
                     logmsg.str("");
                     logmsg << "assign unused " << tgstr << ": tile " << tile_id
-                        << ", petal " << p << " fiber " << fid
+                        << ", petal " << p << " location " << lid
                         << " available target " << tgid
                         << ", priority " << tg.priority << ", subpriority "
                         << tg.subpriority;
-                    logger.debug_tfg(tile_id, fid, tgid,
+                    logger.debug_tfg(tile_id, lid, tgid,
                                      logmsg.str().c_str());
                 }
                 targets_avail.push_back(tgid);
@@ -408,26 +408,26 @@ void fba::Assignment::assign_unused(uint8_t tgtype, int32_t max_per_petal,
 
             if (targets_avail.size() > 0) {
                 int64_t target = find_best(hw_.get(), tgs_.get(), tile_id,
-                                           fid, tgtype, target_xy, targets_avail);
+                                           lid, tgtype, target_xy, targets_avail);
                 if (target >= 0) {
                     if (extra_log) {
                         logmsg.str("");
                         logmsg << "assign unused " << tgstr << ": tile " << tile_id
-                            << ", petal " << p << " fiber " << fid
+                            << ", petal " << p << " location " << lid
                             << " found best object " << target;
-                        logger.debug_tfg(tile_id, fid, target,
+                        logger.debug_tfg(tile_id, lid, target,
                                          logmsg.str().c_str());
                     }
-                    assign_tilefiber(hw_.get(), tgs_.get(), tile_id,
-                                     fid, target, tgtype);
+                    assign_tileloc(hw_.get(), tgs_.get(), tile_id,
+                                     lid, target, tgtype);
                 }
             } else {
                 if (extra_log) {
                     logmsg.str("");
                     logmsg << "assign unused " << tgstr << ": tile " << tile_id
-                        << ", petal " << p << " fiber " << fid
+                        << ", petal " << p << " location " << lid
                         << " no available targets of correct type";
-                    logger.debug_tfg(tile_id, fid, -1,
+                    logger.debug_tfg(tile_id, lid, -1,
                                      logmsg.str().c_str());
                 }
             }
@@ -442,16 +442,26 @@ void fba::Assignment::assign_unused(uint8_t tgtype, int32_t max_per_petal,
 
     logmsg.str("");
     if (max_per_petal > 1000000) {
-        logmsg << "Assign " << tgstr << " targets to unused fibers";
+        logmsg << "Assign " << tgstr << " targets to unused locations";
     } else {
         logmsg << "Assign up to " << max_per_petal << " " << tgstr
-            << " targets to unused fibers";
+            << " targets to unused locations";
     }
     tm.stop();
     tm.report(logmsg.str().c_str());
 
     return;
 }
+
+
+typedef std::pair <int32_t, int32_t> fiber_loc;
+
+struct fiber_loc_compare {
+    bool operator() (fiber_loc const & lhs,
+                     fiber_loc const & rhs) const {
+        return lhs.first < rhs.first;
+    }
+};
 
 
 void fba::Assignment::redistribute_science(int32_t start_tile,
@@ -470,8 +480,8 @@ void fba::Assignment::redistribute_science(int32_t start_tile,
     gtmname << "redistribute science: total";
     gtm.start(gtmname.str());
 
-    // Select fiber IDs based on positioner type
-    auto fiber_id = hw_->device_fibers("POS");
+    // Select locations based on positioner type
+    auto loc = hw_->device_locations("POS");
 
     // Determine our range of tiles
     int32_t tstart;
@@ -484,7 +494,7 @@ void fba::Assignment::redistribute_science(int32_t start_tile,
         << stop_tile << " (index " << tstop << ")";
     logger.info(logmsg.str().c_str());
 
-    // This is going to be used to track whether a tile / fiber combination has
+    // This is going to be used to track whether a tile / loc combination has
     // already been considered.
     std::map <int32_t, std::map <int32_t, bool> > done;
     for (int32_t t = tstart; t <= tstop; ++t) {
@@ -493,6 +503,17 @@ void fba::Assignment::redistribute_science(int32_t start_tile,
     }
 
     std::vector <int64_t> targets_avail;
+
+    // This structure is only used in order to reproduce the previous
+    // erroneous behavior of looping in fiber ID order.
+    auto loc_fiber = hw_->loc_fiber;
+    std::vector <std::pair <int32_t, int32_t> > fiber_and_loc;
+    for (auto const & lid : loc) {
+        fiber_and_loc.push_back(std::make_pair(loc_fiber[lid], lid));
+    }
+
+    fiber_loc_compare flcomp;
+    std::stable_sort(fiber_and_loc.begin(), fiber_and_loc.end(), flcomp);
 
     for (int32_t t = tstart; t <= tstop; ++t) {
         int32_t tile_id = tiles_->id[t];
@@ -512,73 +533,85 @@ void fba::Assignment::redistribute_science(int32_t start_tile,
         auto const & tfavail = tgsavail_->data.at(tile_id);
         auto const & target_xy = tile_target_xy.at(tile_id);
 
-        for (auto const & fid : fiber_id) {
-            if (fiber_target[tile_id].count(fid) == 0) {
-                // This tile / fiber combination is unassigned.
+        // FIXME:  This loop order should be changed to be based on target
+        // priority (see https://github.com/desihub/fiberassign/issues/179).
+        // Here we loop over FIBER ID rather than location to be consistent
+        // with the existing code prior to the fiber --> location swap
+        // throughout the code base.
+
+        for (auto const & flid : fiber_and_loc) {
+            auto fid = flid.first;
+            auto lid = flid.second;
+            if (loc_target[tile_id].count(lid) == 0) {
+                // This tile / location combination is unassigned.
                 if (extra_log) {
                     logmsg.str("");
-                    logmsg << "redist: tile " << tile_id << ", fiber "
-                        << fid << " unassigned- skipping";
-                    logger.debug_tfg(tile_id, fid, -1, logmsg.str().c_str());
+                    logmsg << "redist: tile " << tile_id << ", location "
+                        << lid << " (fiber " << fid << ")"
+                        << " unassigned- skipping";
+                    logger.debug_tfg(tile_id, lid, -1, logmsg.str().c_str());
                 }
                 continue;
             }
 
-            if ((done[tile_id].count(fid) > 0) && done[tile_id].at(fid)) {
-                // Already considered or swapped this fiber.
+            if ((done[tile_id].count(lid) > 0) && done[tile_id].at(lid)) {
+                // Already considered or swapped this location.
                 if (extra_log) {
                     logmsg.str("");
-                    logmsg << "redist: tile " << tile_id << ", fiber "
-                        << fid << " already considered- skipping";
-                    logger.debug_tfg(tile_id, fid, -1, logmsg.str().c_str());
+                    logmsg << "redist: tile " << tile_id << ", location "
+                        << lid << " (fiber " << fid << ")"
+                        << " already considered- skipping";
+                    logger.debug_tfg(tile_id, lid, -1, logmsg.str().c_str());
                 }
                 continue;
             }
 
             // Get the current target.
-            int64_t tgid = fiber_target[tile_id].at(fid);
+            int64_t tgid = loc_target[tile_id].at(lid);
             auto const & tg = tgs_->data.at(tgid);
             if ( ! tg.is_science()) {
                 // Only consider science targets.
                 if (extra_log) {
                     logmsg.str("");
-                    logmsg << "redist: tile " << tile_id << ", fiber "
-                        << fid << ", target " << tgid
+                    logmsg << "redist: tile " << tile_id << ", location "
+                        << lid << " (fiber " << fid << ")"
+                        << ", target " << tgid
                         << " not a science target- skipping";
-                    logger.debug_tfg(tile_id, fid, tgid, logmsg.str().c_str());
+                    logger.debug_tfg(tile_id, lid, tgid, logmsg.str().c_str());
                 }
                 continue;
             }
 
             // Find any better assignment.
             int32_t best_tile;
-            int32_t best_fiber;
+            int32_t best_loc;
 
-            reassign_science_target(tstart, tstop, tile_id, fid, tgid, true,
-                                    done, best_tile, best_fiber);
+            reassign_science_target(tstart, tstop, tile_id, lid, tgid, true,
+                                    done, best_tile, best_loc);
 
-            // Mark this current tile / fiber as done
-            done[tile_id][fid] = true;
+            // Mark this current tile / loc as done
+            done[tile_id][lid] = true;
 
-            if ((best_tile != tile_id) || (best_fiber != fid)) {
+            if ((best_tile != tile_id) || (best_loc != lid)) {
                 // We have a better possible assignment- change it.
                 if (extra_log) {
                     logmsg.str("");
-                    logmsg << "redist: tile " << tile_id << ", fiber "
-                        << fid << ", target " << tgid
+                    logmsg << "redist: tile " << tile_id << ", location "
+                        << lid << " (fiber " << fid << ")"
+                        << ", target " << tgid
                         << " swapping to T/F " << best_tile << ","
-                        << best_fiber;
-                    logger.debug_tfg(tile_id, fid, tgid, logmsg.str().c_str());
+                        << best_loc;
+                    logger.debug_tfg(tile_id, lid, tgid, logmsg.str().c_str());
                 }
-                unassign_tilefiber(hw_.get(), tgs_.get(), tile_id, fid,
+                unassign_tileloc(hw_.get(), tgs_.get(), tile_id, lid,
                                    TARGET_TYPE_SCIENCE);
-                assign_tilefiber(hw_.get(), tgs_.get(), best_tile,
-                                 best_fiber, tgid, TARGET_TYPE_SCIENCE);
+                assign_tileloc(hw_.get(), tgs_.get(), best_tile,
+                                 best_loc, tgid, TARGET_TYPE_SCIENCE);
                 // Mark the new assignment as done.
-                done[best_tile][best_fiber] = true;
+                done[best_tile][best_loc] = true;
 
-                // All targets available for this fiber.
-                auto const & avail = tfavail.at(fid);
+                // All targets available for this location.
+                auto const & avail = tfavail.at(lid);
 
                 if (avail.size() > 0) {
                     // Find available targets of the desired type
@@ -593,28 +626,30 @@ void fba::Assignment::redistribute_science(int32_t start_tile,
                     // Assign the best object that is not already assigned.
                     if (targets_avail.size() > 0) {
                         int64_t newtarget = find_best(hw_.get(), tgs_.get(),
-                                                      tile_id, fid,
+                                                      tile_id, lid,
                                                       TARGET_TYPE_SCIENCE, target_xy,
                                                       targets_avail);
                         if (newtarget >= 0) {
                             if (extra_log) {
                                 logmsg.str("");
                                 logmsg << "redist: tile " << tile_id
-                                    << " fiber " << fid
+                                    << " location " << lid
+                                    << " (fiber " << fid << ")"
                                     << " reassigned to " << newtarget;
-                                logger.debug_tfg(tile_id, fid, newtarget,
+                                logger.debug_tfg(tile_id, lid, newtarget,
                                                  logmsg.str().c_str());
                             }
-                            assign_tilefiber(hw_.get(), tgs_.get(), tile_id,
-                                             fid, newtarget,
+                            assign_tileloc(hw_.get(), tgs_.get(), tile_id,
+                                             lid, newtarget,
                                              TARGET_TYPE_SCIENCE);
                         } else {
                             if (extra_log) {
                                 logmsg.str("");
                                 logmsg << "redist: tile " << tile_id
-                                    << " fiber " << fid
+                                    << " location " << lid
+                                    << " (fiber " << fid << ")"
                                     << " no science targets available ";
-                                logger.debug_tfg(tile_id, fid, newtarget,
+                                logger.debug_tfg(tile_id, lid, newtarget,
                                                  logmsg.str().c_str());
                             }
                         }
@@ -623,10 +658,11 @@ void fba::Assignment::redistribute_science(int32_t start_tile,
             } else {
                 if (extra_log) {
                     logmsg.str("");
-                    logmsg << "redist: tile " << tile_id << ", fiber "
-                        << fid << ", target " << tgid
+                    logmsg << "redist: tile " << tile_id << ", location "
+                        << lid << " (fiber " << fid << ")"
+                        << ", target " << tgid
                         << " keeping assignment";
-                    logger.debug_tfg(tile_id, fid, tgid, logmsg.str().c_str());
+                    logger.debug_tfg(tile_id, lid, tgid, logmsg.str().c_str());
                 }
             }
         }
@@ -654,11 +690,11 @@ struct target_compare {
     }
 };
 
-typedef std::pair <double, int32_t> weight_fiber;
+typedef std::pair <double, int32_t> weight_loc;
 
-struct fiber_compare {
-    bool operator() (weight_fiber const & lhs,
-                     weight_fiber const & rhs) const {
+struct loc_compare {
+    bool operator() (weight_loc const & lhs,
+                     weight_loc const & rhs) const {
         return lhs.first < rhs.first;
     }
 };
@@ -683,7 +719,7 @@ void fba::Assignment::assign_force(uint8_t tgtype, int32_t required_per_petal,
     gtm.start(gtmname.str());
 
     int32_t npetal = hw_->npetal;
-    auto fiber_id = hw_->device_fibers("POS");
+    auto loc = hw_->device_locations("POS");
 
     // Determine our range of tiles
     int32_t tstart;
@@ -698,7 +734,7 @@ void fba::Assignment::assign_force(uint8_t tgtype, int32_t required_per_petal,
 
     auto const & tgsdata = tgs_->data;
 
-    // This is going to be used to track whether a tile / fiber combination has
+    // This is going to be used to track whether a tile / loc combination has
     // already been considered.
     std::map <int32_t, std::map <int32_t, bool> > done;
     for (int32_t t = tstart; t <= tstop; ++t) {
@@ -710,18 +746,18 @@ void fba::Assignment::assign_force(uint8_t tgtype, int32_t required_per_petal,
     auto const & tgclasses = tgs_->science_classes;
 
     // This is the specific list of available targets for a single
-    // tile / fiber, after selecting by target type, etc.
+    // tile / loc, after selecting by target type, etc.
     std::vector <int64_t> targets_avail;
 
     // vector of priority-weighted objects on one petal
     std::vector <weight_target> petal_obj;
 
-    // The fibers on one petal, of each priority class, that can reach
+    // The locs on one petal, of each priority class, that can reach
     // each object.
-    std::vector <weight_fiber> can_replace;
+    std::vector <weight_loc> can_replace;
 
     target_compare tcompare;
-    fiber_compare fcompare;
+    loc_compare fcompare;
 
     for (int32_t t = tstart; t <= tstop; ++t) {
         int32_t tile_id = tiles_->id[t];
@@ -774,22 +810,22 @@ void fba::Assignment::assign_force(uint8_t tgtype, int32_t required_per_petal,
             // are sorted by total priority of the standard/sky.
             petal_obj.clear();
 
-            // Get the fibers for this petal which are science positioners.
-            std::vector <int32_t> petal_fibers;
-            for (auto const & fid : fiber_id) {
-                if (hw_->fiber_petal.at(fid) == p) {
-                    petal_fibers.push_back(fid);
+            // Get the locations for this petal which are science positioners.
+            std::vector <int32_t> petal_locations;
+            for (auto const & lid : loc) {
+                if (hw_->loc_petal.at(lid) == p) {
+                    petal_locations.push_back(lid);
                 }
             }
 
-            for (auto const & fid : petal_fibers) {
-                if (tfavail.count(fid) == 0) {
-                    // No targets available for this fiber
+            for (auto const & lid : petal_locations) {
+                if (tfavail.count(lid) == 0) {
+                    // No targets available for this location
                     continue;
                 }
 
-                // Targets available for this fiber.
-                auto const & avail = tfavail.at(fid);
+                // Targets available for this location.
+                auto const & avail = tfavail.at(lid);
 
                 if (avail.size() == 0) {
                     continue;
@@ -810,10 +846,10 @@ void fba::Assignment::assign_force(uint8_t tgtype, int32_t required_per_petal,
                     if (extra_log) {
                         logmsg.str("");
                         logmsg << "assign force " << tgstr << ": tile "
-                            << tile_id << ", petal " << p << ", fiber "
-                            << fid << ", found object " << tgid
+                            << tile_id << ", petal " << p << ", location "
+                            << lid << ", found object " << tgid
                             << " with weight " << av_weight;
-                        logger.debug_tfg(tile_id, fid, tgid,
+                        logger.debug_tfg(tile_id, lid, tgid,
                                          logmsg.str().c_str());
                     }
                 }
@@ -840,28 +876,28 @@ void fba::Assignment::assign_force(uint8_t tgtype, int32_t required_per_petal,
                     // target ID for this object
                     int64_t id = ps.second;
 
-                    // Find all fibers on this petal which can reach
+                    // Find all locations on this petal which can reach
                     // this target and are occupied by a science target of
                     // the correct target class.  Sort these by increasing
                     // subpriority.
                     can_replace.clear();
-                    for (auto const & tf : favail_->data[id]) {
-                        int32_t fid = tf.second;
+                    for (auto const & tf : locavail_->data[id]) {
+                        int32_t lid = tf.second;
                         if (tf.first != tile_id) {
                             // Not this tile
                             continue;
                         }
-                        if (hw_->fiber_petal[fid] != p) {
+                        if (hw_->loc_petal[lid] != p) {
                             // Not this petal
                             continue;
                         }
-                        // Is this fiber currently assigned to a target of the
+                        // Is this loc currently assigned to a target of the
                         // correct target class?
-                        if (fiber_target[tile_id].count(fid) == 0) {
+                        if (loc_target[tile_id].count(lid) == 0) {
                             // Fiber not assigned
                             continue;
                         }
-                        auto & cur = tgsdata.at(fiber_target[tile_id].at(fid));
+                        auto & cur = tgsdata.at(loc_target[tile_id].at(lid));
                         if (! cur.is_science()) {
                             // The currently assigned target is not a science
                             // target.
@@ -876,11 +912,11 @@ void fba::Assignment::assign_force(uint8_t tgtype, int32_t required_per_petal,
                                     << tile_id << ", petal " << p
                                     << ", class " << tc << ", object " << id
                                     << ", total priority " << ps.first
-                                    << ", available fiber " << fid
+                                    << ", available loc " << lid
                                     << " at target " << cur.id
                                     << " is wrong class (" << cur.priority
                                     << ")";
-                                logger.debug_tfg(tile_id, fid, id,
+                                logger.debug_tfg(tile_id, lid, id,
                                                  logmsg.str().c_str());
                             }
                             continue;
@@ -901,10 +937,10 @@ void fba::Assignment::assign_force(uint8_t tgtype, int32_t required_per_petal,
                                     << tile_id << ", petal " << p
                                     << ", class " << tc << ", object " << id
                                     << ", total priority " << ps.first
-                                    << ", available fiber " << fid
+                                    << ", available loc " << lid
                                     << " at science target " << cur.id
                                     << " is also a standard- skipping";
-                                logger.debug_tfg(tile_id, fid, id,
+                                logger.debug_tfg(tile_id, lid, id,
                                                  logmsg.str().c_str());
                             }
                             continue;
@@ -923,7 +959,7 @@ void fba::Assignment::assign_force(uint8_t tgtype, int32_t required_per_petal,
                                              logmsg.str().c_str());
                         }
                         can_replace.push_back(
-                            std::make_pair(cur.subpriority, fid));
+                            std::make_pair(cur.subpriority, lid));
                     }
 
                     std::stable_sort(can_replace.begin(), can_replace.end(),
@@ -946,71 +982,71 @@ void fba::Assignment::assign_force(uint8_t tgtype, int32_t required_per_petal,
                     }
 
                     for (auto const & av : can_replace) {
-                        int32_t fid = av.second;
-                        if ((done[tile_id].count(fid) > 0)
-                            && done[tile_id].at(fid)) {
-                            // Already considered this tile/fiber
+                        int32_t lid = av.second;
+                        if ((done[tile_id].count(lid) > 0)
+                            && done[tile_id].at(lid)) {
+                            // Already considered this tile/loc
                             if (extra_log) {
                                 logmsg.str("");
                                 logmsg << "assign force " << tgstr << ": tile "
                                     << tile_id << ", petal " << p
                                     << ", class " << tc << ", object " << id
                                     << ", total priority " << ps.first
-                                    << ", available fiber " << fid
+                                    << ", available loc " << lid
                                     << " already bumped";
-                                logger.debug_tfg(tile_id, fid, id,
+                                logger.debug_tfg(tile_id, lid, id,
                                                  logmsg.str().c_str());
                             }
                             continue;
                         }
 
-                        int64_t curtg = fiber_target[tile_id].at(fid);
+                        int64_t curtg = loc_target[tile_id].at(lid);
 
-                        if (ok_to_assign(hw_.get(), tile_id, fid,
+                        if (ok_to_assign(hw_.get(), tile_id, lid,
                                          id, target_xy)) {
-                            // We can swap this fiber.
+                            // We can swap this location.
                             if (extra_log) {
                                 logmsg.str("");
                                 logmsg << "assign force " << tgstr << ": tile "
                                     << tile_id << ", petal " << p
                                     << ", class " << tc << ", object " << id
                                     << ", total priority " << ps.first
-                                    << ", available fiber " << fid
+                                    << ", available loc " << lid
                                     << " bumping science target " << curtg;
                                 // Log for target doing the bumping
-                                logger.debug_tfg(tile_id, fid, id,
+                                logger.debug_tfg(tile_id, lid, id,
                                                  logmsg.str().c_str());
                                 // Also log for target getting bumped
-                                logger.debug_tfg(tile_id, fid, curtg,
+                                logger.debug_tfg(tile_id, lid, curtg,
                                                  logmsg.str().c_str());
                             }
                             // Attempt to re-assign this science target to
-                            // a later tile / fiber.
+                            // a later tile / loc.
                             int32_t best_tile;
-                            int32_t best_fiber;
+                            int32_t best_loc;
                             reassign_science_target(tstart, tstop, tile_id,
-                                                    fid, curtg, false,
+                                                    lid, curtg, false,
                                                     done, best_tile,
-                                                    best_fiber);
+                                                    best_loc);
 
                             // Assign object.
-                            unassign_tilefiber(hw_.get(), tgs_.get(),
-                                               tile_id, fid,
+                            unassign_tileloc(hw_.get(), tgs_.get(),
+                                               tile_id, lid,
                                                TARGET_TYPE_SCIENCE);
-                            assign_tilefiber(hw_.get(), tgs_.get(),
-                                             tile_id, fid, id, tgtype);
+                            assign_tileloc(hw_.get(), tgs_.get(),
+                                             tile_id, lid, id, tgtype);
 
-                            // Mark current tile / fiber as done
-                            done[tile_id][fid] = true;
+                            // Mark current tile / loc as done
+                            done[tile_id][lid] = true;
 
                             // Move science target to new location if possible
                             if ((best_tile != tile_id)
-                                && (best_fiber != fid)) {
-                                assign_tilefiber(hw_.get(), tgs_.get(),
-                                                 best_tile, best_fiber,
+                                && (best_loc != lid)) {
+                                assign_tileloc(hw_.get(), tgs_.get(),
+                                                 best_tile, best_loc,
                                                  curtg, TARGET_TYPE_SCIENCE);
                                 // Mark this new location as done
-                                done[best_tile][best_fiber] = true;
+                                done[best_tile][best_loc] = true;
                                 if (extra_log) {
                                     logmsg.str("");
                                     logmsg << "assign force " << tgstr
@@ -1018,15 +1054,15 @@ void fba::Assignment::assign_force(uint8_t tgtype, int32_t required_per_petal,
                                         << ", petal " << p
                                         << ", class " << tc << ", object " << id
                                         << ", total priority " << ps.first
-                                        << ", available fiber " << fid
+                                        << ", available loc " << lid
                                         << " bumped target " << curtg
                                         << " reassigned to " << best_tile
-                                        << "," << best_fiber;
+                                        << "," << best_loc;
                                     // Log for target doing the bumping
-                                    logger.debug_tfg(tile_id, fid, id,
+                                    logger.debug_tfg(tile_id, lid, id,
                                                      logmsg.str().c_str());
                                     // Also log for target getting bumped
-                                    logger.debug_tfg(tile_id, fid, curtg,
+                                    logger.debug_tfg(tile_id, lid, curtg,
                                                      logmsg.str().c_str());
                                 }
                             }
@@ -1039,9 +1075,9 @@ void fba::Assignment::assign_force(uint8_t tgtype, int32_t required_per_petal,
                                     << ", petal " << p
                                     << ", class " << tc << ", object " << id
                                     << ", total priority " << ps.first
-                                    << ", available fiber " << fid
+                                    << ", available loc " << lid
                                     << " not ok to assign";
-                                logger.debug_tfg(tile_id, fid, id,
+                                logger.debug_tfg(tile_id, lid, id,
                                                  logmsg.str().c_str());
                             }
                         }
@@ -1098,121 +1134,121 @@ void fba::Assignment::assign_force(uint8_t tgtype, int32_t required_per_petal,
 
 
 void fba::Assignment::reassign_science_target(int32_t tstart, int32_t tstop,
-    int32_t tile, int32_t fiber, int64_t target, bool balance_petals,
+    int32_t tile, int32_t loc, int64_t target, bool balance_petals,
     std::map <int32_t, std::map <int32_t, bool> > const & done,
-    int32_t & best_tile, int32_t & best_fiber) const {
+    int32_t & best_tile, int32_t & best_loc) const {
 
     fba::Logger & logger = fba::Logger::get();
     std::ostringstream logmsg;
     bool extra_log = logger.extra_debug();
 
-    // Get the number of unused fibers on this current petal.
-    int32_t petal = hw_->fiber_petal.at(fiber);
+    // Get the number of unused locations on this current petal.
+    int32_t petal = hw_->loc_petal.at(loc);
     int32_t passign = nassign_petal.at(TARGET_TYPE_SCIENCE).at(tile).at(petal);
 
-    // Vector of available tile / fiber pairs which have a fiber that is a
+    // Vector of available tile / loc pairs which have a loc that is a
     // science positioner.
-    auto const & availtfall = favail_->data.at(target);
+    auto const & availtfall = locavail_->data.at(target);
     std::vector < std::pair <int32_t, int32_t> > availtf;
     std::string pos_str("POS");
     for (auto const & av : availtfall) {
-        if (pos_str.compare(hw_->fiber_device_type.at(av.second)) == 0) {
+        if (pos_str.compare(hw_->loc_device_type.at(av.second)) == 0) {
             availtf.push_back(av);
         }
     }
 
     best_tile = tile;
-    best_fiber = fiber;
+    best_loc = loc;
     int32_t best_passign = passign;
 
     if (extra_log) {
         logmsg.str("");
-        logmsg << "reassign: tile " << tile << ", fiber "
-            << fiber << ", target " << target
+        logmsg << "reassign: tile " << tile << ", location "
+            << loc << ", target " << target
             << " considering for swap...";
-        logger.debug_tfg(tile, fiber, target, logmsg.str().c_str());
+        logger.debug_tfg(tile, loc, target, logmsg.str().c_str());
 
         logmsg.str("");
-        logmsg << "reassign: tile " << tile << ", fiber "
-            << fiber << ", target " << target << " considering tile indices "
+        logmsg << "reassign: tile " << tile << ", location "
+            << loc << ", target " << target << " considering tile indices "
             << tstart << " to " << tstop;
-        logger.debug_tfg(tile, fiber, target, logmsg.str().c_str());
+        logger.debug_tfg(tile, loc, target, logmsg.str().c_str());
     }
 
     for (auto const & av : availtf) {
-        // The available tile fiber pair
+        // The available tile loc pair
         int32_t av_tile = av.first;
-        int32_t av_fiber = av.second;
+        int32_t av_loc = av.second;
 
         if (nassign_tile.at(TARGET_TYPE_SCIENCE).at(av_tile) == 0) {
-            // This available tile / fiber is on a tile with
+            // This available tile / loc is on a tile with
             // nothing assigned.  Skip it.
             if (extra_log) {
                 logmsg.str("");
-                logmsg << "reassign: tile " << tile << ", fiber "
-                    << fiber << ", target " << target
+                logmsg << "reassign: tile " << tile << ", location "
+                    << loc << ", target " << target
                     << " available tile " << av_tile
                     << " has nothing assigned- skipping";
-                logger.debug_tfg(tile, fiber, target, logmsg.str().c_str());
+                logger.debug_tfg(tile, loc, target, logmsg.str().c_str());
             }
             continue;
         }
 
         if ((done.count(av_tile) > 0)
-            && (done.at(av_tile).count(av_fiber) > 0)
-            && done.at(av_tile).at(av_fiber)) {
-            // Already considered or swapped this available tile/fiber.
+            && (done.at(av_tile).count(av_loc) > 0)
+            && done.at(av_tile).at(av_loc)) {
+            // Already considered or swapped this available tile/loc.
             if (extra_log) {
                 logmsg.str("");
-                logmsg << "reassign: tile " << tile << ", fiber "
-                    << fiber << ", target " << target
-                    << " avail T/F " << av_tile << "," << av_fiber
+                logmsg << "reassign: tile " << tile << ", loc "
+                    << loc << ", target " << target
+                    << " avail T/F " << av_tile << "," << av_loc
                     << " already considered or swapped";
-                logger.debug_tfg(tile, fiber, target, logmsg.str().c_str());
+                logger.debug_tfg(tile, loc, target, logmsg.str().c_str());
             }
             continue;
         }
 
-        if (fiber_target.at(av_tile).count(av_fiber) > 0) {
-            // This available tile / fiber is already assigned.
+        if (loc_target.at(av_tile).count(av_loc) > 0) {
+            // This available tile / loc is already assigned.
             if (extra_log) {
                 logmsg.str("");
-                logmsg << "reassign: tile " << tile << ", fiber "
-                    << fiber << ", target " << target
-                    << " avail T/F " << av_tile << "," << av_fiber
+                logmsg << "reassign: tile " << tile << ", loc "
+                    << loc << ", target " << target
+                    << " avail T/F " << av_tile << "," << av_loc
                     << " already assigned";
-                logger.debug_tfg(tile, fiber, target, logmsg.str().c_str());
+                logger.debug_tfg(tile, loc, target, logmsg.str().c_str());
             }
             continue;
         }
 
-        if (target_fiber.at(target).count(av_tile) > 0) {
-            // We have already assigned a fiber on this tile to this
+        if (target_loc.at(target).count(av_tile) > 0) {
+            // We have already assigned a location on this tile to this
             // target.
             if (extra_log) {
                 logmsg.str("");
-                logmsg << "reassign: tile " << tile << ", fiber "
-                    << fiber << ", target " << target
+                logmsg << "reassign: tile " << tile << ", loc "
+                    << loc << ", target " << target
                     << " already assigned on available tile " << av_tile;
-                logger.debug_tfg(tile, fiber, target, logmsg.str().c_str());
+                logger.debug_tfg(tile, loc, target, logmsg.str().c_str());
             }
             continue;
         }
 
-        int32_t av_petal = hw_->fiber_petal.at(av_fiber);
+        int32_t av_petal = hw_->loc_petal.at(av_loc);
         int32_t av_tile_indx = tiles_->order.at(av_tile);
 
         if (av_tile_indx < tstart) {
-            // The tile containing this alternate tile/fiber is before
+            // The tile containing this alternate tile/loc is before
             // the start of the tiles we are considering.
             if (extra_log) {
                 logmsg.str("");
-                logmsg << "reassign: tile " << tile << ", fiber "
-                    << fiber << ", target " << target
+                logmsg << "reassign: tile " << tile << ", loc "
+                    << loc << ", target " << target
                     << " available tile " << av_tile
                     << " at index " << av_tile_indx
                     << " is prior to tile start (" << tstart << ")";
-                logger.debug_tfg(tile, fiber, target, logmsg.str().c_str());
+                logger.debug_tfg(tile, loc, target, logmsg.str().c_str());
             }
             continue;
         }
@@ -1220,65 +1256,68 @@ void fba::Assignment::reassign_science_target(int32_t tstart, int32_t tstop,
         // Projected target locations on the available tile.
         auto const & av_target_xy = tile_target_xy.at(av_tile);
 
-        if ( ! ok_to_assign(hw_.get(), av_tile, av_fiber, target,
+        if ( ! ok_to_assign(hw_.get(), av_tile, av_loc, target,
                             av_target_xy)) {
             // There must be a collision or some other problem.
             if (extra_log) {
                 logmsg.str("");
-                logmsg << "reassign: tile " << tile << ", fiber "
-                    << fiber << ", target " << target
-                    << " avail T/F " << av_tile << "," << av_fiber
+                logmsg << "reassign: tile " << tile << ", loc "
+                    << loc << ", target " << target
+                    << " avail T/F " << av_tile << "," << av_loc
                     << " not OK to assign";
-                logger.debug_tfg(tile, fiber, target, logmsg.str().c_str());
+                logger.debug_tfg(tile, loc, target, logmsg.str().c_str());
             }
             continue;
         }
 
-        // Compare the number of assigned fibers on the petal of this
-        // available tile/fiber to the current best one.
+        // Compare the number of assigned locations on the petal of this
+        // available tile/loc to the current best one.
         int32_t av_passign =
             nassign_petal.at(TARGET_TYPE_SCIENCE).at(av_tile).at(av_petal);
 
-        // At this point we know we have a new tile / fiber where we can place
+        // At this point we know we have a new tile / loc where we can place
         // this target.  If we are balancing the number of targets per petal,
-        // check if this new tile / fiber is a better placement.  If we are not
-        // balancing, then we just take this first available tile / fiber and
+        // check if this new tile / loc is a better placement.  If we are not
+        // balancing, then we just take this first available tile / loc and
         // return.
 
         if (balance_petals) {
+            // NOTE:  we really are using the number POS fibers per petal for
+            // this max- since we are not including ETC locations in this
+            // check.
             if ((av_passign < hw_->nfiber_petal) &&
             (av_passign < best_passign)) {
-                // There are some unassigned fibers on this available petal,
+                // There are some unassigned locs on this available petal,
                 // and the number of unassigned is greater than the original
-                // tile/fiber.
+                // tile/loc.
                 if (extra_log) {
                     logmsg.str("");
-                    logmsg << "reassign: tile " << tile << ", fiber "
-                        << fiber << ", target " << target
-                        << " avail T/F " << av_tile << "," << av_fiber
-                        << " has fewer assigned fibers in its petal ("
+                    logmsg << "reassign: tile " << tile << ", loc "
+                        << loc << ", target " << target
+                        << " avail T/F " << av_tile << "," << av_loc
+                        << " has fewer assigned locs in its petal ("
                         << av_passign << " vs "
                         << best_passign << "): new best";
-                    logger.debug_tfg(tile, fiber, target, logmsg.str().c_str());
+                    logger.debug_tfg(tile, loc, target, logmsg.str().c_str());
                 }
                 best_tile = av_tile;
-                best_fiber = av_fiber;
+                best_loc = av_loc;
                 best_passign = av_passign;
             } else {
                 if (extra_log) {
                     logmsg.str("");
-                    logmsg << "reassign: tile " << tile << ", fiber "
-                        << fiber << ", target " << target
-                        << " avail T/F " << av_tile << "," << av_fiber
-                        << " has more assigned fibers in its petal ("
+                    logmsg << "reassign: tile " << tile << ", loc "
+                        << loc << ", target " << target
+                        << " avail T/F " << av_tile << "," << av_loc
+                        << " has more assigned locs in its petal ("
                         << av_passign << " vs "
                         << best_passign << "): skipping";
-                    logger.debug_tfg(tile, fiber, target, logmsg.str().c_str());
+                    logger.debug_tfg(tile, loc, target, logmsg.str().c_str());
                 }
             }
         } else {
             best_tile = av_tile;
-            best_fiber = av_fiber;
+            best_loc = av_loc;
             break;
         }
     }
@@ -1288,7 +1327,7 @@ void fba::Assignment::reassign_science_target(int32_t tstart, int32_t tstop,
 
 
 bool fba::Assignment::ok_to_assign (fba::Hardware const * hw, int32_t tile,
-    int32_t fiber, int64_t target,
+    int32_t loc, int64_t target,
     std::map <int64_t, std::pair <double, double> > const & target_xy
     ) const {
 
@@ -1296,36 +1335,36 @@ bool fba::Assignment::ok_to_assign (fba::Hardware const * hw, int32_t tile,
     std::ostringstream logmsg;
     bool extra_log = logger.extra_debug();
 
-    // Is the fiber stuck or broken?
-    if (hw->state.at(fiber) != FIBER_STATE_OK) {
+    // Is the location stuck or broken?
+    if (hw->state.at(loc) != FIBER_STATE_OK) {
         if (extra_log) {
             logmsg.str("");
-            logmsg << "ok_to_assign: tile " << tile << ", fiber "
-                << fiber << " not OK";
-            logger.debug_tfg(tile, fiber, target, logmsg.str().c_str());
+            logmsg << "ok_to_assign: tile " << tile << ", loc "
+                << loc << " not OK";
+            logger.debug_tfg(tile, loc, target, logmsg.str().c_str());
         }
         return false;
     }
 
-    if (fiber_target.count(tile) == 0) {
+    if (loc_target.count(tile) == 0) {
         // This is the first assignment on the tile, so definitely ok
         // to assign!
         if (extra_log) {
             logmsg.str("");
             logmsg << "ok_to_assign: tile " << tile
                 << " first assignment (definitely OK)";
-            logger.debug_tfg(tile, fiber, target, logmsg.str().c_str());
+            logger.debug_tfg(tile, loc, target, logmsg.str().c_str());
         }
         return true;
     }
 
     // Const reference to the assignment for this tile.
-    auto const & ftile = fiber_target.at(tile);
+    auto const & ftile = loc_target.at(tile);
 
     std::vector <int32_t> nbs;
     std::vector <int64_t> nbtarget;
 
-    auto const & neighbors = hw->neighbors.at(fiber);
+    auto const & neighbors = hw->neighbors.at(loc);
 
     // Check neighboring assignment.
     for (auto const & nb : neighbors) {
@@ -1336,10 +1375,10 @@ bool fba::Assignment::ok_to_assign (fba::Hardware const * hw, int32_t tile,
                 // Target already assigned to a neighbor.
                 if (extra_log) {
                     logmsg.str("");
-                    logmsg << "ok_to_assign: tile " << tile << ", fiber "
-                        << fiber << ", target " << target
-                        << " already assigned to neighbor fiber " << nb;
-                    logger.debug_tfg(tile, fiber, target, logmsg.str().c_str());
+                    logmsg << "ok_to_assign: tile " << tile << ", loc "
+                        << loc << ", target " << target
+                        << " already assigned to neighbor loc " << nb;
+                    logger.debug_tfg(tile, loc, target, logmsg.str().c_str());
                 }
                 return false;
             }
@@ -1348,12 +1387,12 @@ bool fba::Assignment::ok_to_assign (fba::Hardware const * hw, int32_t tile,
         }
     }
 
-    // Would assigning this target produce a collision?  If a fiber is not
+    // Would assigning this target produce a collision?  If a loc is not
     // yet assigned, we assume that it is positioned at its central location
     // and so will not collide with anything.
 
-    // Center position and target location for this fiber.
-    fbg::dpair tcenter = hw->fiber_pos_xy_mm.at(fiber);
+    // Center position and target location for this location.
+    fbg::dpair tcenter = hw->loc_pos_xy_mm.at(loc);
     fbg::dpair tpos = target_xy.at(target);
 
     size_t nnb = nbs.size();
@@ -1368,17 +1407,17 @@ bool fba::Assignment::ok_to_assign (fba::Hardware const * hw, int32_t tile,
         int64_t nbt = nbtarget[b];
         fbg::dpair ncenter;
         fbg::dpair npos;
-        ncenter = hw->fiber_pos_xy_mm.at(nb);
+        ncenter = hw->loc_pos_xy_mm.at(nb);
         npos = target_xy.at(nbt);
         collide = hw->collide(tcenter, tpos, ncenter, npos);
         // Remove these lines if switching back to threading.
         if (collide) {
             if (extra_log) {
                 logmsg.str("");
-                logmsg << "ok_to_assign: tile " << tile << ", fiber "
-                    << fiber << ", target " << target
+                logmsg << "ok_to_assign: tile " << tile << ", loc "
+                    << loc << ", target " << target
                     << " would collide with target " << nbt;
-                logger.debug_tfg(tile, fiber, target, logmsg.str().c_str());
+                logger.debug_tfg(tile, loc, target, logmsg.str().c_str());
             }
             return false;
         }
@@ -1395,7 +1434,7 @@ bool fba::Assignment::ok_to_assign (fba::Hardware const * hw, int32_t tile,
 
 
 int64_t fba::Assignment::find_best(fba::Hardware const * hw,
-    fba::Targets * tgs, int32_t tile, int32_t fiber, uint8_t type,
+    fba::Targets * tgs, int32_t tile, int32_t loc, uint8_t type,
     std::map <int64_t, std::pair <double, double> > const & target_xy,
     std::vector <int64_t> const & avail) const {
 
@@ -1421,10 +1460,10 @@ int64_t fba::Assignment::find_best(fba::Hardware const * hw,
             // Skip science targets with no remaining observations.
             if (extra_log) {
                 logmsg.str("");
-                logmsg << "find_best: tile " << tile << ", fiber "
-                    << fiber << ", target " << tgid
+                logmsg << "find_best: tile " << tile << ", loc "
+                    << loc << ", target " << tgid
                     << " science target with no remaining obs";
-                logger.debug_tfg(tile, fiber, tgid, logmsg.str().c_str());
+                logger.debug_tfg(tile, loc, tgid, logmsg.str().c_str());
             }
             continue;
         }
@@ -1472,29 +1511,29 @@ int64_t fba::Assignment::find_best(fba::Hardware const * hw,
         if (test_target) {
             if (extra_log) {
                 logmsg.str("");
-                logmsg << "find_best: tile " << tile << ", fiber "
-                    << fiber << ", target " << tgid << ", type " << (int)tg.type
+                logmsg << "find_best: tile " << tile << ", loc "
+                    << loc << ", target " << tgid << ", type " << (int)tg.type
                     << " accept with priority = " << tg.priority
                     << ", subpriority = " << tg.subpriority
                     << ", obsremain = " << tg.obsremain;
-                logger.debug_tfg(tile, fiber, tgid, logmsg.str().c_str());
+                logger.debug_tfg(tile, loc, tgid, logmsg.str().c_str());
             }
-            if ((target_fiber.count(tgid) > 0) &&
-                (target_fiber.at(tgid).count(tile) > 0)) {
+            if ((target_loc.count(tgid) > 0) &&
+                (target_loc.at(tgid).count(tile) > 0)) {
                 if (extra_log) {
                     logmsg.str("");
-                    logmsg << "find_best: tile " << tile << ", fiber "
-                        << fiber << ", target " << tgid << ", type " << (int)tg.type
+                    logmsg << "find_best: tile " << tile << ", loc "
+                        << loc << ", target " << tgid << ", type " << (int)tg.type
                         << " already assigned on current tile";
-                    logger.debug_tfg(tile, fiber, tgid, logmsg.str().c_str());
+                    logger.debug_tfg(tile, loc, tgid, logmsg.str().c_str());
                 }
-            } else if (ok_to_assign(hw, tile, fiber, tgid, target_xy)) {
+            } else if (ok_to_assign(hw, tile, loc, tgid, target_xy)) {
                 if (extra_log) {
                     logmsg.str("");
-                    logmsg << "find_best: tile " << tile << ", fiber "
-                        << fiber << ", target " << tgid << ", type "
+                    logmsg << "find_best: tile " << tile << ", loc "
+                        << loc << ", target " << tgid << ", type "
                         << (int)tg.type << " SELECTED";
-                    logger.debug_tfg(tile, fiber, tgid, logmsg.str().c_str());
+                    logger.debug_tfg(tile, loc, tgid, logmsg.str().c_str());
                 }
                 best_id = tgid;
                 best_priority = tg.priority;
@@ -1508,8 +1547,8 @@ int64_t fba::Assignment::find_best(fba::Hardware const * hw,
 }
 
 
-void fba::Assignment::assign_tilefiber(fba::Hardware const * hw,
-    fba::Targets * tgs, int32_t tile, int32_t fiber, int64_t target,
+void fba::Assignment::assign_tileloc(fba::Hardware const * hw,
+    fba::Targets * tgs, int32_t tile, int32_t loc, int64_t target,
     uint8_t type) {
 
     fba::Logger & logger = fba::Logger::get();
@@ -1519,23 +1558,20 @@ void fba::Assignment::assign_tilefiber(fba::Hardware const * hw,
     if (target < 0) {
         logmsg.str("");
         logmsg << "cannot assign negative target ID to tile "
-            << tile << ", fiber " << fiber << ".  Did you mean to unassign?";
+            << tile << ", loc " << loc << ".  Did you mean to unassign?";
         logger.warning(logmsg.str().c_str());
         return;
     }
 
-    int32_t petal = hw->fiber_petal.at(fiber);
+    int32_t petal = hw->loc_petal.at(loc);
 
-    // if (fiber_target.count(tile) == 0) {
-    //     fiber_target[tile].clear();
-    // }
-    auto & ftarg = fiber_target[tile];
+    auto & ftarg = loc_target[tile];
 
-    if (ftarg.count(fiber) > 0) {
-        int64_t cur = ftarg.at(fiber);
+    if (ftarg.count(loc) > 0) {
+        int64_t cur = ftarg.at(loc);
         if (cur >= 0) {
             logmsg.str("");
-            logmsg << "tile " << tile << ", fiber " << fiber
+            logmsg << "tile " << tile << ", loc " << loc
                 << " already assigned to target " << cur
                 << " cannot assign " << target;
             logger.warning(logmsg.str().c_str());
@@ -1543,10 +1579,7 @@ void fba::Assignment::assign_tilefiber(fba::Hardware const * hw,
         }
     }
 
-    // if (target_fiber.count(target) == 0) {
-    //     target_fiber[target].clear();
-    // }
-    auto & tfiber = target_fiber[target];
+    auto & tfiber = target_loc[target];
 
     if (tfiber.count(tile) > 0) {
         logmsg.str("");
@@ -1565,8 +1598,8 @@ void fba::Assignment::assign_tilefiber(fba::Hardware const * hw,
         throw std::runtime_error(logmsg.str().c_str());
     }
 
-    ftarg[fiber] = target;
-    target_fiber[target][tile] = fiber;
+    ftarg[loc] = target;
+    target_loc[target][tile] = loc;
 
     // Objects can be more than one type (e.g. standards and science).  When
     // incrementing the counts of object types per tile and petal, we want
@@ -1596,34 +1629,34 @@ void fba::Assignment::assign_tilefiber(fba::Hardware const * hw,
 }
 
 
-void fba::Assignment::unassign_tilefiber(fba::Hardware const * hw,
-    fba::Targets * tgs, int32_t tile, int32_t fiber, uint8_t type) {
+void fba::Assignment::unassign_tileloc(fba::Hardware const * hw,
+    fba::Targets * tgs, int32_t tile, int32_t loc, uint8_t type) {
 
     fba::Logger & logger = fba::Logger::get();
     bool extra_log = logger.extra_debug();
     std::ostringstream logmsg;
 
-    if (fiber_target.count(tile) == 0) {
+    if (loc_target.count(tile) == 0) {
         logmsg.str("");
         logmsg << "tile " << tile
-            << " has no fibers assigned.  Ignoring unassign";
+            << " has no locations assigned.  Ignoring unassign";
         logger.warning(logmsg.str().c_str());
         return;
     }
-    auto & ftarg = fiber_target.at(tile);
+    auto & ftarg = loc_target.at(tile);
 
-    if (ftarg.count(fiber) == 0) {
+    if (ftarg.count(loc) == 0) {
         logmsg.str("");
-        logmsg << "tile " << tile << ", fiber " << fiber
+        logmsg << "tile " << tile << ", loc " << loc
             << " already unassigned";
         logger.warning(logmsg.str().c_str());
         return;
     }
 
-    int64_t target = ftarg.at(fiber);
+    int64_t target = ftarg.at(loc);
     if (target < 0) {
         logmsg.str("");
-        logmsg << "tile " << tile << ", fiber " << fiber
+        logmsg << "tile " << tile << ", loc " << loc
             << " already unassigned";
         logger.warning(logmsg.str().c_str());
         return;
@@ -1635,12 +1668,12 @@ void fba::Assignment::unassign_tilefiber(fba::Hardware const * hw,
         logmsg.str("");
         logmsg << "current target " << target << " not of type "
             << (int)type << " requested in unassign of tile " << tile
-            << ", fiber " << fiber;
+            << ", loc " << loc;
         logger.error(logmsg.str().c_str());
         throw std::runtime_error(logmsg.str().c_str());
     }
 
-    int32_t petal = hw->fiber_petal.at(fiber);
+    int32_t petal = hw->loc_petal.at(loc);
 
     // Objects can be more than one type (e.g. standards and science).  When
     // incrementing the counts of object types per tile and petal, we want
@@ -1666,8 +1699,8 @@ void fba::Assignment::unassign_tilefiber(fba::Hardware const * hw,
     }
     tgobj.obsremain++;
 
-    target_fiber[target].erase(tile);
-    ftarg.erase(fiber);
+    target_loc[target].erase(tile);
+    ftarg.erase(loc);
 
     return;
 }
@@ -1676,23 +1709,23 @@ void fba::Assignment::unassign_tilefiber(fba::Hardware const * hw,
 void fba::Assignment::targets_to_project(
     fba::Targets const * tgs,
     std::map <int32_t, std::vector <int64_t> > const & tgsavail,
-    std::vector <int32_t> const & fibers,
+    std::vector <int32_t> const & locs,
     std::vector <int64_t> & tgids,
     std::vector <double> & tgra,
     std::vector <double> & tgdec) const {
     // This function computes the target IDs that need to be projected
-    // for a given set of fibers on a tile.
+    // for a given set of locations on a tile.
 
     std::set <int64_t> seen;
     tgids.clear();
     tgra.clear();
     tgdec.clear();
 
-    for (auto const & fid : fibers) {
-        // Project this fiber's targets
-        if (tgsavail.count(fid) > 0) {
-            // The available targets for this fiber.
-            auto const & avail = tgsavail.at(fid);
+    for (auto const & lid : locs) {
+        // Project this location's targets
+        if (tgsavail.count(lid) > 0) {
+            // The available targets for this location.
+            auto const & avail = tgsavail.at(lid);
             for (auto const & id : avail) {
                 if (seen.count(id) == 0) {
                     // This target has not yet been processed.
@@ -1722,7 +1755,7 @@ void fba::Assignment::project_targets(fba::Hardware const * hw,
     target_xy.clear();
 
     if (tgsavail->data.count(tile_id) == 0) {
-        // This tile has no fibers with available targets.
+        // This tile has no locations with available targets.
         return;
     }
 
@@ -1730,15 +1763,15 @@ void fba::Assignment::project_targets(fba::Hardware const * hw,
     auto const & tfavail = tgsavail->data.at(tile_id);
 
     if (tfavail.size() == 0) {
-        // There are no fibers on this tile with available targets.
+        // There are no locations on this tile with available targets.
         return;
     }
 
-    // List of fibers we are projecting- anything with targets available.
-    std::vector <int32_t> fids;
-    for (auto const & f : hw->fiber_id) {
+    // List of locations we are projecting- anything with targets available.
+    std::vector <int32_t> lids;
+    for (auto const & f : hw->locations) {
         if ((tfavail.count(f) != 0) && (tfavail.at(f).size() > 0)) {
-            fids.push_back(f);
+            lids.push_back(f);
         }
     }
 
@@ -1747,7 +1780,7 @@ void fba::Assignment::project_targets(fba::Hardware const * hw,
     std::vector <double> tgra;
     std::vector <double> tgdec;
 
-    targets_to_project(tgs, tfavail, fids, tgids, tgra, tgdec);
+    targets_to_project(tgs, tfavail, lids, tgids, tgra, tgdec);
 
     // Now thread over the targets to compute
 
@@ -1783,8 +1816,8 @@ fba::TargetsAvailable::pshr fba::Assignment::targets_avail() const {
 }
 
 
-fba::FibersAvailable::pshr fba::Assignment::fibers_avail() const {
-    return favail_;
+fba::LocationsAvailable::pshr fba::Assignment::locations_avail() const {
+    return locavail_;
 }
 
 

--- a/src/assign.cpp
+++ b/src/assign.cpp
@@ -38,7 +38,7 @@ fba::Assignment::Assignment(fba::Targets::pshr tgs,
 
     // This structure is only used in order to reproduce the previous
     // erroneous behavior of looping in fiber ID order.
-    auto loc = hw_->locations;
+    auto loc = hw_->device_locations("POS");
     auto loc_fiber = hw_->loc_fiber;
     for (auto const & lid : loc) {
         fiber_and_loc.push_back(std::make_pair(loc_fiber[lid], lid));
@@ -518,7 +518,7 @@ void fba::Assignment::redistribute_science(int32_t start_tile,
     gtm.start(gtmname.str());
 
     // Select locations based on positioner type
-    auto loc = hw_->device_locations("POS");
+    // auto loc = hw_->device_locations("POS");
     auto loc_fiber = hw_->loc_fiber;
 
     // Determine our range of tiles
@@ -620,7 +620,7 @@ void fba::Assignment::redistribute_science(int32_t start_tile,
             done[tile_id][lid] = true;
 
             if ((best_tile != tile_id) || (best_loc != lid)) {
-                int32_t best_fid = loc_fiber[best_loc];
+                int32_t best_fid = loc_fiber.at(best_loc);
                 // We have a better possible assignment- change it.
                 if (extra_log) {
                     logmsg.str("");
@@ -873,7 +873,7 @@ void fba::Assignment::assign_force(uint8_t tgtype, int32_t required_per_petal,
             }
 
             for (auto const & lid : petal_locations) {
-                int32_t fid = lid_to_fid[lid];
+                int32_t fid = lid_to_fid.at(lid);
                 if (tfavail.count(lid) == 0) {
                     // No targets available for this location
                     continue;
@@ -1211,12 +1211,11 @@ void fba::Assignment::reassign_science_target(int32_t tstart, int32_t tstop,
 
     // Vector of available tile / loc pairs which have a loc that is a
     // science positioner.
-    auto loc_device_type = hw_->loc_device_type;
     auto const & availtfall = locavail_->data.at(target);
     std::vector < std::pair <int32_t, int32_t> > availtf;
     std::string pos_str("POS");
     for (auto const & av : availtfall) {
-        if (pos_str.compare(loc_device_type.at(av.second)) == 0) {
+        if (pos_str.compare(hw_->loc_device_type.at(av.second)) == 0) {
             availtf.push_back(av);
         }
     }

--- a/src/assign.h
+++ b/src/assign.h
@@ -28,7 +28,7 @@ class Assignment : public std::enable_shared_from_this <Assignment> {
         typedef std::shared_ptr <Assignment> pshr;
 
         Assignment(Targets::pshr tgs, TargetsAvailable::pshr tgsavail,
-                   FibersAvailable::pshr favail);
+                   LocationsAvailable::pshr locavail);
 
         void assign_unused(uint8_t tgtype, int32_t max_per_petal = -1,
                            std::string const & pos_type = std::string("POS"),
@@ -48,15 +48,15 @@ class Assignment : public std::enable_shared_from_this <Assignment> {
 
         TargetsAvailable::pshr targets_avail() const;
 
-        FibersAvailable::pshr fibers_avail() const;
+        LocationsAvailable::pshr locations_avail() const;
 
         std::vector <int32_t> tiles_assigned() const;
 
-        std::map <int32_t, int64_t> const & tile_fiber_target(int32_t tile) const;
+        std::map <int32_t, int64_t> const & tile_location_target(int32_t tile) const;
 
-        std::map < int32_t, std::map <int32_t, int64_t> > fiber_target;
+        std::map < int32_t, std::map <int32_t, int64_t> > loc_target;
 
-        std::map < int64_t, std::map <int32_t, int32_t> > target_fiber;
+        std::map < int64_t, std::map <int32_t, int32_t> > target_loc;
 
         std::map < int32_t, std::map <int64_t, std::pair <double, double> > >
             tile_target_xy;
@@ -66,7 +66,7 @@ class Assignment : public std::enable_shared_from_this <Assignment> {
         void parse_tile_range(int32_t start_tile, int32_t stop_tile,
                               int32_t & tstart, int32_t & tstop);
 
-        bool ok_to_assign (Hardware const * hw, int32_t tile, int32_t fiber,
+        bool ok_to_assign (Hardware const * hw, int32_t tile, int32_t loc,
             int64_t target, std::map <int64_t,
             std::pair <double, double> > const & target_xy) const;
 
@@ -75,15 +75,15 @@ class Assignment : public std::enable_shared_from_this <Assignment> {
             std::map <int64_t, std::pair <double, double> > const & target_xy,
             std::vector <int64_t> const & avail) const;
 
-        void assign_tilefiber(Hardware const * hw, Targets * tgs, int32_t tile,
-            int32_t fiber, int64_t target, uint8_t type);
+        void assign_tileloc(Hardware const * hw, Targets * tgs, int32_t tile,
+            int32_t loc, int64_t target, uint8_t type);
 
-        void unassign_tilefiber(Hardware const * hw, Targets * tgs,
-            int32_t tile, int32_t fiber, uint8_t type);
+        void unassign_tileloc(Hardware const * hw, Targets * tgs,
+            int32_t tile, int32_t loc, uint8_t type);
 
         void targets_to_project(Targets const * tgs,
             std::map <int32_t, std::vector <int64_t> > const & tgsavail,
-            std::vector <int32_t> const & fibers,
+            std::vector <int32_t> const & locs,
             std::vector <int64_t> & tgids, std::vector <double> & tgra,
             std::vector <double> & tgdec) const;
 
@@ -96,11 +96,11 @@ class Assignment : public std::enable_shared_from_this <Assignment> {
                                 & target_xy) const;
 
         void reassign_science_target(int32_t tstart, int32_t tstop,
-            int32_t tile, int32_t fiber, int64_t target, bool balance_petals,
+            int32_t tile, int32_t loc, int64_t target, bool balance_petals,
             std::map <int32_t, std::map <int32_t, bool> > const & done,
-            int32_t & best_tile, int32_t & best_fiber) const;
+            int32_t & best_tile, int32_t & best_loc) const;
 
-        // The number of assigned fibers per tile and spectrograph (petal)
+        // The number of assigned locations per tile and spectrograph (petal)
         // For each target class.
         std::map <uint8_t, std::map <int32_t, int32_t> > nassign_tile;
         std::map <uint8_t,
@@ -118,8 +118,8 @@ class Assignment : public std::enable_shared_from_this <Assignment> {
         // shared handle to the available targets.
         TargetsAvailable::pshr tgsavail_;
 
-        // shared handle to the available fibers for targets.
-        FibersAvailable::pshr favail_;
+        // shared handle to the available locations for targets.
+        LocationsAvailable::pshr locavail_;
 
 };
 

--- a/src/assign.h
+++ b/src/assign.h
@@ -121,6 +121,10 @@ class Assignment : public std::enable_shared_from_this <Assignment> {
         // shared handle to the available locations for targets.
         LocationsAvailable::pshr locavail_;
 
+        // FIXME: remove this once we no longer need to loop over things
+        // in fiber order.
+        std::vector <std::pair <int32_t, int32_t> > fiber_and_loc;
+
 };
 
 }

--- a/src/hardware.h
+++ b/src/hardware.h
@@ -34,14 +34,14 @@ class Hardware : public std::enable_shared_from_this <Hardware> {
         typedef std::shared_ptr <Hardware> pshr;
 
         Hardware(
-            std::vector <int32_t> const & fiber,
-            std::vector <int32_t> const & petal,
-            std::vector <int32_t> const & spectro,
             std::vector <int32_t> const & location,
-            std::vector <int32_t> const & slit,
+            std::vector <int32_t> const & petal,
+            std::vector <int32_t> const & device,
             std::vector <int32_t> const & slitblock,
             std::vector <int32_t> const & blockfiber,
-            std::vector <int32_t> const & device,
+            std::vector <int32_t> const & spectro,
+            std::vector <int32_t> const & fiber,
+            std::vector <int32_t> const & slit,
             std::vector <std::string> const & device_type,
             std::vector <double> const & x_mm,
             std::vector <double> const & y_mm,
@@ -83,86 +83,86 @@ class Hardware : public std::enable_shared_from_this <Hardware> {
                      fbg::dpair center2,
                      fbg::dpair position2) const;
 
-        std::pair <fbg::shape, fbg::shape> fiber_position(
-            int32_t fiber_id, fbg::dpair const & xy) const;
+        std::pair <fbg::shape, fbg::shape> loc_position(
+            int32_t loc, fbg::dpair const & xy) const;
 
-        std::vector <std::pair <fbg::shape, fbg::shape> > fiber_position_multi(
-            std::vector <int32_t> const & fiber_id,
+        std::vector <std::pair <fbg::shape, fbg::shape> > loc_position_multi(
+            std::vector <int32_t> const & loc,
             std::vector <fbg::dpair> const & xy, int threads = 0) const;
 
         std::vector <bool> check_collisions_xy(
-            std::vector <int32_t> const & fiber_id,
+            std::vector <int32_t> const & loc,
             std::vector <fbg::dpair> const & xy, int threads = 0) const;
 
         std::vector <bool> check_collisions_thetaphi(
-            std::vector <int32_t> const & fiber_id,
+            std::vector <int32_t> const & loc,
             std::vector <double> const & theta,
             std::vector <double> const & phi, int threads = 0) const;
 
-        // Get the fiber IDs for a particular device type
-        std::vector <int32_t> device_fibers(std::string const & type) const;
+        // Get the Locations for a particular device type
+        std::vector <int32_t> device_locations(std::string const & type) const;
 
-        // The (constant) total number of fibers.
-        int32_t nfiber;
+        // The (constant) total number of locations.
+        int32_t nloc;
 
         // The number of petals (spectraographs)
         int32_t npetal;
 
-        // The number of fibers per petal.
+        // The number of fibers (device == "POS") per petal.
         int32_t nfiber_petal;
 
         // The full focalplane radius on the sky in degrees
         double focalplane_radius_deg;
 
-        // fiber IDs
-        std::vector <int32_t> fiber_id;
+        // Locations
+        std::vector <int32_t> locations;
 
-        // fiber ID to positioner centers in mm
-        std::map <int32_t, std::pair <double, double> > fiber_pos_xy_mm;
-        std::map <int32_t, double> fiber_pos_z_mm;
+        // Location to positioner centers in mm
+        std::map <int32_t, std::pair <double, double> > loc_pos_xy_mm;
+        std::map <int32_t, double> loc_pos_z_mm;
 
-        // fiber ID to petal
-        std::map <int32_t, int32_t> fiber_petal;
+        // Location to petal
+        std::map <int32_t, int32_t> loc_petal;
 
-        // petal to fiber IDs
-        std::map <int32_t, std::vector <int32_t> > petal_fibers;
+        // petal to locations
+        std::map <int32_t, std::vector <int32_t> > petal_locations;
 
-        // fiber ID to device
-        std::map <int32_t, int32_t> fiber_device;
-        std::map <int32_t, std::string> fiber_device_type;
+        // Location to device
+        std::map <int32_t, int32_t> loc_device;
+        std::map <int32_t, std::string> loc_device_type;
 
-        // fiber ID to location
-        std::map <int32_t, int32_t> fiber_location;
+        // Location to fiber ID
+        std::map <int32_t, int32_t> loc_fiber;
 
-        // fiber ID to spectrograph
-        std::map <int32_t, int32_t> fiber_spectro;
+        // Location to spectrograph
+        std::map <int32_t, int32_t> loc_spectro;
 
-        // fiber ID to positioner q/s
-        std::map <int32_t, double> fiber_pos_q_deg;
-        std::map <int32_t, double> fiber_pos_s_mm;
+        // Location to positioner q/s
+        std::map <int32_t, double> loc_pos_q_deg;
+        std::map <int32_t, double> loc_pos_s_mm;
 
-        // fiber ID to slit
-        std::map <int32_t, int32_t> fiber_slit;
+        // Location to slit
+        std::map <int32_t, int32_t> loc_slit;
 
-        // fiber ID to slitblock
-        std::map <int32_t, int32_t> fiber_slitblock;
+        // Location to slitblock
+        std::map <int32_t, int32_t> loc_slitblock;
 
-        // fiber ID to blockfiber
-        std::map <int32_t, int32_t> fiber_blockfiber;
+        // Location to blockfiber
+        std::map <int32_t, int32_t> loc_blockfiber;
 
         // patrol radius in mm
         double patrol_mm;
 
-        // The guaranteed collision distance for fibers in mm
+        // The guaranteed collision distance for positioners in mm
         double collide_mm;
 
-        // The average collision distance for fibers in mm
+        // The average collision distance for positioners in mm
         double collide_avg_mm;
 
-        // The guaranteed collision avoidance for fibers in mm
+        // The guaranteed collision avoidance for positioners in mm
         double no_collide_mm;
 
-        // The radius on the focalplane for considering which fibers are
+        // The radius on the focalplane for considering which locations are
         // neighbors.
         double neighbor_radius_mm;
 
@@ -176,7 +176,7 @@ class Hardware : public std::enable_shared_from_this <Hardware> {
         // The current fiber state.
         std::map <int32_t, int32_t> state;
 
-        // The neighbors of each fiber positioner
+        // The neighbors of each device location.
         std::map <int32_t, std::vector <int32_t> > neighbors;
 
         // The geometric shape of the ferrule holder
@@ -201,99 +201,3 @@ class Hardware : public std::enable_shared_from_this <Hardware> {
 
 }
 #endif
-
-
-//
-// // Can contain information on geometry of fiber one day (hardcoded for now) not
-// // used yet
-// class PosP {
-//     public:
-//         double r1, r2;
-//         PosP (double r1, double r2);
-// };
-//
-// // Rotation of A (angle t) aroud axis axis
-// void rot_pt (dpair & A, const dpair & ax, const dpair & angle);
-//
-// // Intersection between segments p1-q1 and p2-q2
-// bool intersect (const dpair & p1, const dpair & q1, const dpair & p2,
-//                 const dpair & q2);
-//
-// // List segments, or circles
-// class element {
-//     public:
-//         // True if segments, false if circle
-//         bool is_seg;
-//         // Segments
-//         Dplist segs;
-//         // Circle center
-//         dpair O;
-//         // Circle radius
-//         double rad;
-//         // For python plot
-//         char color;
-//         // For plotting
-//         double transparency;
-//         // For plotting
-//         double radplot;
-//         element ();
-//         // b : is_seg
-//         element (bool b);
-//         // Creates circle
-//         element (const dpair & O, const double & rad);
-//         // Creates segment list with only the segment AB
-//         element (const dpair & A, const dpair & B);
-//         // Point with color
-//         element (const dpair & A, char c, double transp, double rad0);
-//         // Add point to segments list
-//         void add (const double & a, const double & b);
-//         // Add point to segments list
-//         void add (const dpair & p);
-//         // Translation by t
-//         void transl (const dpair & t);
-//         // Rotation of the angle def by t (cos,sin) around axis axis
-//         void rotation (const dpair & t, const dpair & axis);
-//         void print () const;
-//         // Xmin, Xmax, Ymin, Ymax of the element
-//         void limits (Dlist & lims) const;
-// };
-//
-// class Elements : public std::vector <element> {};
-//
-// // Intersection between 2 elements
-// bool intersect (const element & e1, const element & e2);
-//
-// class polygon {
-//     public:
-//         // Segments and circles
-//         Elements elmts;
-//         dpair axis;
-//         void add (const element & el);
-//         // Add all elements of p
-//         void add (const polygon & p);
-//         // Translation
-//         void transl (const dpair & t);
-//         // Rotation aroud polygon's axis
-//         void rotation (const dpair & t);
-//         // Rotation around O
-//         void rotation_origin (const dpair & t);
-//         void print () const;
-//         // Change color of the polygon
-//         void set_color (char c);
-//         // Xmin, Xmax, Ymin, Ymax of the polygon
-//         Dlist limits () const;
-// };
-//
-// // fh = ferrule holder
-// polygon create_fh ();
-// // cb = central body
-// polygon create_cb ();
-// // Check collision
-// bool collision (const polygon & p1, const polygon & p2);
-// // cos sin theta and phi for a galaxy which is in A (ref to the origin)
-// Dlist angles (const dpair & A, const PosP & posp);
-// // G loc of galaxy, O origin. Repositions fh and cb in the good position
-// // according to O, G
-// void repos_cb_fh (polygon & cb, polygon & fh, const dpair & O, const dpair & G,
-//                   const PosP & posp);
-//

--- a/src/targets.cpp
+++ b/src/targets.cpp
@@ -250,24 +250,24 @@ fba::TargetsAvailable::TargetsAvailable(Hardware::pshr hw, Targets::pshr objs,
     hw_ = hw;
 
     size_t ntile = tiles_->id.size();
-    size_t nfiber = hw_->nfiber;
+    size_t nloc = hw_->nloc;
 
     // Radius of the tile.
     double tile_radius = hw_->focalplane_radius_deg * deg2rad;
 
     // Patrol radius in mm on focalplane.
-    double fiber_patrol_mm = hw_->patrol_mm;
+    double patrol_mm = hw_->patrol_mm;
 
-    std::vector <int32_t> fiber_id(nfiber);
-    std::vector <double> fiber_center_x(nfiber);
-    std::vector <double> fiber_center_y(nfiber);
+    std::vector <int32_t> loc(nloc);
+    std::vector <double> loc_center_x(nloc);
+    std::vector <double> loc_center_y(nloc);
 
-    for (size_t j = 0; j < nfiber; ++j) {
-        fiber_id[j] = hw_->fiber_id[j];
-        double cx = hw_->fiber_pos_xy_mm[fiber_id[j]].first;
-        double cy = hw_->fiber_pos_xy_mm[fiber_id[j]].second;
-        fiber_center_x[j] = cx;
-        fiber_center_y[j] = cy;
+    for (size_t j = 0; j < nloc; ++j) {
+        loc[j] = hw_->locations[j];
+        double cx = hw_->loc_pos_xy_mm[loc[j]].first;
+        double cy = hw_->loc_pos_xy_mm[loc[j]].second;
+        loc_center_x[j] = cx;
+        loc_center_y[j] = cy;
     }
 
     // shared_ptr reference counting is not threadsafe.  Here we extract
@@ -278,13 +278,13 @@ fba::TargetsAvailable::TargetsAvailable(Hardware::pshr hw, Targets::pshr objs,
     TargetTree * ptree = tree.get();
     Hardware * phw = hw_.get();
 
-    #pragma omp parallel default(none) shared(logger, pobjs, ptiles, ptree, phw, ntile, tile_radius, nfiber, fiber_id, fiber_center_x, fiber_center_y, fiber_patrol_mm)
+    #pragma omp parallel default(none) shared(logger, pobjs, ptiles, ptree, phw, ntile, tile_radius, nloc, loc, loc_center_x, loc_center_y, patrol_mm)
     {
         // We re-use these thread-local vectors to reduce the number
         // of times we are realloc'ing memory for every fiber.
         std::vector <int64_t> nearby;
         std::vector <KdTreePoint> nearby_tree_points;
-        std::vector <int64_t> nearby_fiber;
+        std::vector <int64_t> nearby_loc;
         std::vector <int64_t> result;
         std::vector <weight_index> result_weight;
         std::ostringstream logmsg;
@@ -343,42 +343,41 @@ fba::TargetsAvailable::TargetsAvailable(Hardware::pshr hw, Targets::pshr objs,
             }
             KDtree <KdTreePoint> nearby_tree(nearby_tree_points, 2);
 
-            size_t fibers_with_targets = 0;
+            size_t locs_with_targets = 0;
 
-            double fiber_pos[2];
+            double loc_pos[2];
 
-            for (size_t j = 0; j < nfiber; ++j) {
-                thread_data[tid][fiber_id[j]].resize(0);
-                fiber_pos[0] = fiber_center_x[j];
-                fiber_pos[1] = fiber_center_y[j];
-                auto fiber_xy = std::make_pair(fiber_center_x[j],
-                                               fiber_center_y[j]);
+            for (size_t j = 0; j < nloc; ++j) {
+                thread_data[tid][loc[j]].resize(0);
+                loc_pos[0] = loc_center_x[j];
+                loc_pos[1] = loc_center_y[j];
+                auto loc_xy = std::make_pair(loc_center_x[j],
+                                             loc_center_y[j]);
 
-                // Lookup targets near this fiber in focalplane
+                // Lookup targets near this location in focalplane
                 // coordinates.
-                nearby_fiber = nearby_tree.near(fiber_pos, 0.0,
-                                                fiber_patrol_mm);
+                nearby_loc = nearby_tree.near(loc_pos, 0.0, patrol_mm);
 
-                if (nearby_fiber.size() == 0) {
-                    // No targets for this fiber
+                if (nearby_loc.size() == 0) {
+                    // No targets for this location
                     continue;
                 }
 
                 // The kdtree gets us the targets that are close to our
                 // region of interest.  Now go through these targets and
-                // compute the precise distance from the fiber center.
+                // compute the precise distance from the loc center.
                 // We sort the available targets by priority now,
                 // to avoid doing it multiple times later.
                 result.clear();
                 result_weight.clear();
 
                 size_t tindx = 0;
-                for (auto const & tnear : nearby_fiber) {
+                for (auto const & tnear : nearby_loc) {
                     auto & obj = pobjs->data[tnear];
                     auto obj_xy = phw->radec2xy(tra, tdec, obj.ra,
                                                 obj.dec);
-                    double dist = geom::sq(fiber_xy, obj_xy);
-                    if (dist > geom::sq(fiber_patrol_mm)) {
+                    double dist = geom::sq(loc_xy, obj_xy);
+                    if (dist > geom::sq(patrol_mm)) {
                         // outside the patrol radius
                         continue;
                     }
@@ -399,21 +398,21 @@ fba::TargetsAvailable::TargetsAvailable(Hardware::pshr hw, Targets::pshr objs,
                         logmsg.str("");
                         logmsg << std::setprecision(2) << std::fixed;
                         logmsg << "targets avail:  tile " << tid
-                            << ", fiber " << fiber_id[j]
+                            << ", location " << loc[j]
                             << " append ID "
                             << result[wt.second] << " (type="
                             << (int)(pobjs->data[result[wt.second]].type) << ")"
                             << ", total priority " << wt.first;
-                        logger.debug_tfg(tid, fiber_id[j],
+                        logger.debug_tfg(tid, loc[j],
                                          result[wt.second],
                                          logmsg.str().c_str());
                     }
-                    thread_data[tid][fiber_id[j]].push_back(
+                    thread_data[tid][loc[j]].push_back(
                         result[wt.second]);
                 }
 
-                if (thread_data[tid][fiber_id[j]].size() > 0) {
-                    fibers_with_targets++;
+                if (thread_data[tid][loc[j]].size() > 0) {
+                    locs_with_targets++;
                 }
             }
         }
@@ -432,18 +431,13 @@ fba::TargetsAvailable::TargetsAvailable(Hardware::pshr hw, Targets::pshr objs,
 
                 auto const & fmap = it.second;
 
-                for (size_t f = 0; f < nfiber; ++f) {
-                    int32_t fid = fiber_id[f];
-                    if (fmap.count(fid) == 0) {
-                        // This fiber had no targets.
+                for (size_t f = 0; f < nloc; ++f) {
+                    int32_t lid = loc[f];
+                    if (fmap.count(lid) == 0) {
+                        // This location had no targets.
                         continue;
                     }
-                    // logmsg.str("");
-                    // logmsg << "tile " << ttile << ", fiber "
-                    //     << fid << " copying thread result to output";
-                    // logger.debug_tfg(ttile, fid, -1,
-                    //                  logmsg.str().c_str());
-                    data[ttile][fid] = fmap.at(fid);
+                    data[ttile][lid] = fmap.at(lid);
                 }
             }
             thread_data.clear();
@@ -456,9 +450,9 @@ fba::TargetsAvailable::TargetsAvailable(Hardware::pshr hw, Targets::pshr objs,
             continue;
         }
         size_t total_avail = 0;
-        for (size_t j = 0; j < nfiber; ++j) {
-            if (data.at(tid).count(fiber_id[j]) > 0) {
-                total_avail += data.at(tid).at(fiber_id[j]).size();
+        for (size_t j = 0; j < nloc; ++j) {
+            if (data.at(tid).count(loc[j]) > 0) {
+                total_avail += data.at(tid).at(loc[j]).size();
             }
         }
         std::ostringstream msg;
@@ -469,7 +463,7 @@ fba::TargetsAvailable::TargetsAvailable(Hardware::pshr hw, Targets::pshr objs,
     }
 
     tm.stop();
-    tm.report("Computing targets available to all tile / fibers");
+    tm.report("Computing targets available to all tile / locations");
 }
 
 fba::Hardware::pshr fba::TargetsAvailable::hardware() const {
@@ -490,7 +484,7 @@ std::map <int32_t, std::vector <int64_t> > fba::TargetsAvailable::tile_data(int3
 }
 
 
-fba::FibersAvailable::FibersAvailable(fba::TargetsAvailable::pshr tgsavail) {
+fba::LocationsAvailable::LocationsAvailable(fba::TargetsAvailable::pshr tgsavail) {
     fba::Timer tm;
     tm.start();
 
@@ -498,7 +492,7 @@ fba::FibersAvailable::FibersAvailable(fba::TargetsAvailable::pshr tgsavail) {
 
     data.clear();
 
-    //std::cout << "FibersAvailable:  tgsavail has " << avail.size() << " tiles" << std::endl;
+    //std::cout << "LocationsAvailable:  tgsavail has " << avail.size() << " tiles" << std::endl;
 
     // In order to play well with OpenMP for loops, construct a simple vector of
     // std::map keys for the available objects.
@@ -535,7 +529,7 @@ fba::FibersAvailable::FibersAvailable(fba::TargetsAvailable::pshr tgsavail) {
                     if (logger.extra_debug()) {
                         logmsg.str("");
                         logmsg << "target " << tg
-                            << " has available tile/fiber "
+                            << " has available tile / location "
                             << tid << ", " << fbr;
                         logger.debug_tfg(tid, fbr, tg, logmsg.str().c_str());
                     }
@@ -553,12 +547,6 @@ fba::FibersAvailable::FibersAvailable(fba::TargetsAvailable::pshr tgsavail) {
                     data[tg].resize(0);
                 }
                 for (auto const & ft : it.second) {
-                    // logmsg.str("");
-                    // logmsg << "target " << tg << " copy tile " << ft.first
-                    //     << ", fiber " << ft.second
-                    //     << " from thread-local memory";
-                    // logger.debug_tfg(ft.first, ft.second, tg,
-                    //                  logmsg.str().c_str());
                     data[tg].push_back(ft);
                 }
             }
@@ -592,12 +580,12 @@ fba::FibersAvailable::FibersAvailable(fba::TargetsAvailable::pshr tgsavail) {
     }
 
     tm.stop();
-    tm.report("Computing tile / fibers available to all objects");
+    tm.report("Computing tile / locations available to all objects");
 }
 
 
 std::vector <std::pair <int32_t, int32_t> >
-    fba::FibersAvailable::target_data(int64_t target) const {
+    fba::LocationsAvailable::target_data(int64_t target) const {
     if (data.count(target) == 0) {
         return std::vector <std::pair <int32_t, int32_t> >();
     } else {

--- a/src/targets.h
+++ b/src/targets.h
@@ -145,7 +145,7 @@ typedef struct {
     double pos[2];
 } KdTreePoint;
 
-// Class holding the object IDs available for each tile and fiber.
+// Class holding the object IDs available for each tile and location.
 
 class TargetsAvailable : public std::enable_shared_from_this <TargetsAvailable> {
 
@@ -173,15 +173,15 @@ class TargetsAvailable : public std::enable_shared_from_this <TargetsAvailable> 
 };
 
 
-// Class holding the tile / fibers available for each target ID.
+// Class holding the tile / locations available for each target ID.
 
-class FibersAvailable : public std::enable_shared_from_this <FibersAvailable> {
+class LocationsAvailable : public std::enable_shared_from_this <LocationsAvailable> {
 
     public :
 
-        typedef std::shared_ptr <FibersAvailable> pshr;
+        typedef std::shared_ptr <LocationsAvailable> pshr;
 
-        FibersAvailable(TargetsAvailable::pshr tgsavail);
+        LocationsAvailable(TargetsAvailable::pshr tgsavail);
 
         std::vector <std::pair <int32_t, int32_t> >
             target_data(int64_t target) const;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -243,7 +243,7 @@ fba::Logger::Logger() {
     }
 
     // Check if we are further debugging the assignment process for specific
-    // tile, fiber, and target values.  If these environment variables are set,
+    // tile, loc, and target values.  If these environment variables are set,
     // override the log level and set it to debug.
 
     extra_ = false;
@@ -262,10 +262,10 @@ fba::Logger::Logger() {
         extra_ = true;
     }
 
-    debug_fiber_ = -1;
+    debug_loc_ = -1;
     val = ::getenv("DESI_DEBUG_FIBER");
     if (val != NULL) {
-        debug_fiber_ = ::atoi(val);
+        debug_loc_ = ::atoi(val);
         extra_ = true;
     }
 
@@ -292,7 +292,7 @@ fba::Logger & fba::Logger::get() {
 }
 
 
-void fba::Logger::debug_tfg(int32_t tile, int32_t fiber, int64_t target,
+void fba::Logger::debug_tfg(int32_t tile, int32_t loc, int64_t target,
     char const * msg) {
     if (level_ <= log_level::debug) {
         bool doprint = false;
@@ -302,7 +302,7 @@ void fba::Logger::debug_tfg(int32_t tile, int32_t fiber, int64_t target,
             if ((debug_tile_ >= 0) && (debug_tile_ == tile)) {
                 doprint = true;
             }
-            if ((debug_fiber_ >= 0) && (debug_fiber_ == fiber)) {
+            if ((debug_loc_ >= 0) && (debug_loc_ == loc)) {
                 doprint = true;
             }
             if ((debug_target_ >= 0) && (debug_target_ == target)) {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -263,7 +263,7 @@ fba::Logger::Logger() {
     }
 
     debug_loc_ = -1;
-    val = ::getenv("DESI_DEBUG_FIBER");
+    val = ::getenv("DESI_DEBUG_LOCATION");
     if (val != NULL) {
         debug_loc_ = ::atoi(val);
         extra_ = true;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -277,6 +277,8 @@ fba::Logger::Logger() {
     }
 
     if (extra_) {
+        fprintf(stdout, "%s: Extra debug options enabled.  RUN TIME WILL INCREASE BY AN ORDER OF MAGNITUDE!\n", prefix_.c_str());
+        fflush(stdout);
         if (level_ > log_level::debug) {
             fprintf(stdout, "%s: environment contains extra debug options.  Forcing DESI_LOGLEVEL=DEBUG\n", prefix_.c_str());
             fflush(stdout);

--- a/src/utils.h
+++ b/src/utils.h
@@ -49,6 +49,15 @@ struct weight_rcompare {
     }
 };
 
+typedef std::pair <int32_t, int32_t> fiber_loc;
+
+struct fiber_loc_compare {
+    bool operator() (fiber_loc const & lhs,
+                     fiber_loc const & rhs) const {
+        return lhs.first < rhs.first;
+    }
+};
+
 typedef std::pair <int32_t, int32_t> tile_loc;
 
 struct tile_loc_compare {

--- a/src/utils.h
+++ b/src/utils.h
@@ -163,7 +163,7 @@ class Logger {
         // Singleton access
         static Logger & get();
 
-        void debug_tfg(int32_t tile, int32_t fiber, int64_t target,
+        void debug_tfg(int32_t tile, int32_t loc, int64_t target,
             char const * msg);
 
         void debug(char const * msg);
@@ -182,7 +182,7 @@ class Logger {
         log_level level_;
         std::string prefix_;
         int32_t debug_tile_;
-        int32_t debug_fiber_;
+        int32_t debug_loc_;
         int64_t debug_target_;
         bool debug_all_;
         bool extra_;


### PR DESCRIPTION
Background
----------------------------

During fiberassign, we are actually assigning theta/phi arm positions to devices at particular locations on the focalplane.  Where those positioners are connected on spectrographs should not matter to fiberassign.  However, due to historical reasons, the FIBER value has been used throughout the code as a primary key for indexing things.  This PR changes that behavior to use the unique (and fixed to the focalplane) "device location" as the primary indexing variable.

Consequences
--------------------------

Great care has been taken to ensure that these many small internal changes have no impact on the output files.  I several places there are known loops over things in fiber ID order, and I have implemented the same loop in those cases (those places are the subject of open tickets already).  There are only a few user-facing differences:

- The debugging environment variable `DESI_DEBUG_FIBER` is changed to `DESI_DEBUG_LOCATION`.
- When making plots, the assignments are labeled with the device location, not the fiber ID.

Currently the FIBER and SPECTROGRAPH data from the input fiberpos files are simply propagated to the outputs.  In the future, we may remove that info from the hardware description (see https://github.com/desihub/desimodel/pull/105).  After this branch is merged, fiberassign will be ready to accomodate that change easily.

TO-DO
------------------

The documentation needs updated in a few places before merging.