### PR TITLE
Remove collision check "shortcut"

### DIFF
--- a/py/fiberassign/targets.py
+++ b/py/fiberassign/targets.py
@@ -55,7 +55,7 @@ def default_main_sciencemask():
     sciencemask |= desi_mask["QSO"].mask
     sciencemask |= desi_mask["BGS_ANY"].mask
     sciencemask |= desi_mask["MWS_ANY"].mask
-    sciencemask |= desi_mask["SECONDARY_ANY"].mask
+    sciencemask |= desi_mask["SCND_ANY"].mask
     return sciencemask
 
 
@@ -107,7 +107,7 @@ def default_sv1_sciencemask():
     sciencemask |= sv1_mask["QSO"].mask
     sciencemask |= sv1_mask["BGS_ANY"].mask
     sciencemask |= sv1_mask["MWS_ANY"].mask
-    sciencemask |= sv1_mask["SECONDARY_ANY"].mask
+    sciencemask |= sv1_mask["SCND_ANY"].mask
     return sciencemask
 
 

--- a/py/fiberassign/targets.py
+++ b/py/fiberassign/targets.py
@@ -55,7 +55,10 @@ def default_main_sciencemask():
     sciencemask |= desi_mask["QSO"].mask
     sciencemask |= desi_mask["BGS_ANY"].mask
     sciencemask |= desi_mask["MWS_ANY"].mask
-    sciencemask |= desi_mask["SCND_ANY"].mask
+    if "SCND_ANY" in desi_mask.names():
+        sciencemask |= desi_mask["SCND_ANY"].mask
+    else:
+        sciencemask |= desi_mask["SECONDARY_ANY"].mask
     return sciencemask
 
 
@@ -107,7 +110,10 @@ def default_sv1_sciencemask():
     sciencemask |= sv1_mask["QSO"].mask
     sciencemask |= sv1_mask["BGS_ANY"].mask
     sciencemask |= sv1_mask["MWS_ANY"].mask
-    sciencemask |= sv1_mask["SCND_ANY"].mask
+    if "SCND_ANY" in sv1_mask.names():
+        sciencemask |= sv1_mask["SCND_ANY"].mask
+    else:
+        sciencemask |= sv1_mask["SECONDARY_ANY"].mask
     return sciencemask
 
 

--- a/src/hardware.cpp
+++ b/src/hardware.cpp
@@ -488,20 +488,6 @@ bool fba::Hardware::collide(fbg::dpair center1, fbg::dpair position1,
                             fbg::dpair center2, fbg::dpair position2) const {
     // Check for collisions if we move fibers at given central positions
     // (in mm) to the x/y positions specified.
-    double dist = fbg::dist(position1, position2);
-
-    if (dist < collide_mm) {
-        // Guaranteed to collide.
-        return true;
-    }
-
-    if (dist > no_collide_mm) {
-        // Guaranteed to NOT collide.
-        return false;
-    }
-
-    // We need to do a detailed calculation of the fiber holder and central
-    // body positions and test for intersection.
 
     fbg::shape fh1(ferrule_holder);
     fbg::shape fh2(ferrule_holder);


### PR DESCRIPTION
This shortcut in the code (to avoid doing an explicit collision calculation) was left over from the original codebase.  As part of debugging the focalplane format, I discovered that there were a small number of cases where doing the full calculation gave different results than the "shortcut".  This small PR removes the shortcut.

Note that the development in the "hwstate" branch had already removed this kind of shortcut, since it is not compatible with realistic positioner geometries.