### PR TITLE
Sort by FIBER; set sciencemask et al by name or number even for SV

### DIFF
--- a/bin/fiberassign
+++ b/bin/fiberassign
@@ -153,21 +153,15 @@ run_assign_full(assign_args)
 # ------
 # - fba_merge_results
 
-#- mtl, sky, stdstar -> targets
-opts = args.__dict__.copy()
+#- Setup options for merging
+opts = dict()
 opts['targets'] = [args.mtl, args.sky]
 if args.stdstar is not None:
     opts["targets"].append(args.stdstar)
 
-#- other options that were renamed
+opts['sky'] = args.sky
 opts['dir'] = args.outdir
 opts['out'] = args.outdir
-
-#- remove keys for options that were renamed or not used by fba_merge_results
-for key in ['mtl', 'sky', 'stdstar', 'outdir', 'fibstatusfile', 'surveytiles',
-            'nstarpetal', 'nskypetal', 'starmask', 'footprint', 'overwrite']:
-    if key in opts:
-        del opts[key]
 
 optlist = option_list(opts)
 merge_args = parse_merge(optlist)

--- a/py/fiberassign/assign.py
+++ b/py/fiberassign/assign.py
@@ -378,6 +378,11 @@ def write_assignment_fits_tile(asgn, fulltarget, overwrite, params):
         log.debug("Write:  writing assignment data for tile {}"
                   .format(tile_id))
 
+        # Downstream code still requires assignments sorted by fibers
+        log.info("Sorting by fiber number instead of location")
+        ii = np.argsort(fdata['FIBER'])
+        fdata = fdata[ii]
+
         fd.write(fdata, header=header, extname="FASSIGN")
         del fdata
 

--- a/py/fiberassign/scripts/assign.py
+++ b/py/fiberassign/scripts/assign.py
@@ -186,19 +186,34 @@ def parse_assign(optlist=None):
 
         # convert str bit names -> int bit mask
         if isinstance(args.sciencemask, str):
-            args.sciencemask = desi_mask.mask(args.sciencemask.replace(",","|"))
+            try:
+                args.sciencemask = int(args.sciencemask)
+            except ValueError:
+                args.sciencemask = desi_mask.mask(args.sciencemask.replace(",","|"))
 
         if isinstance(args.stdmask, str):
-            args.stdmask = desi_mask.mask(args.stdmask.replace(",", "|"))
+            try:
+                args.stdmask = int(args.stdmask)
+            except ValueError:
+                args.stdmask = desi_mask.mask(args.stdmask.replace(",", "|"))
 
         if isinstance(args.skymask, str):
-            args.skymask = desi_mask.mask(args.skymask.replace(",", "|"))
+            try:
+                args.skymask = int(args.skymask)
+            except ValueError:
+                args.skymask = desi_mask.mask(args.skymask.replace(",", "|"))
 
         if isinstance(args.safemask, str):
-            args.safemask = desi_mask.mask(args.safemask.replace(",", "|"))
+            try:
+                args.safemask = int(args.safemask)
+            except ValueError:
+                args.safemask = desi_mask.mask(args.safemask.replace(",", "|"))
 
         if isinstance(args.excludemask, str):
-            args.excludemask = desi_mask.mask(args.excludemask.replace(",","|"))
+            try:
+                args.excludemask = int(args.excludemask)
+            except ValueError:
+                args.excludemask = desi_mask.mask(args.excludemask.replace(",","|"))
 
     # Set output directory
     if args.dir is None:
@@ -256,6 +271,7 @@ def run_assign_init(args):
 
     # Append each input target file.  These target files must all be of the
     # same survey type, and will set the Targets object to be of that survey.
+
     for tgarg in args.targets:
         tgprops = tgarg.split(",")
         tgfile = tgprops[0]

--- a/py/fiberassign/scripts/assign.py
+++ b/py/fiberassign/scripts/assign.py
@@ -13,8 +13,6 @@ import os
 import sys
 import argparse
 
-from desitarget.targetmask import desi_mask
-
 from ..utils import GlobalTimers, Logger
 
 from ..hardware import load_hardware
@@ -173,26 +171,34 @@ def parse_assign(optlist=None):
     if args.sky is None:
         args.sky = list()
 
-    # FIXME:  The code below is only valid for the main survey.  However,
-    # determining the survey type from the first target file requires
-    # reading it, which is expensive.  Do we really need to support strings
-    # like this?
+    # If any of the masks are strings, determine the survey type from
+    # the first target file to know which bitmask to use
+    if isinstance(args.sciencemask, str) or \
+       isinstance(args.stdmask, str) or \
+       isinstance(args.skymask, str) or \
+       isinstance(args.safemask, str) or \
+       isinstance(args.excludemask, str):
+        import fitsio
+        from desitarget.targets import main_cmx_or_sv
+        data = fitsio.read(args.targets[0], 1, rows=[0,1])
+        filecols, filemasks, filesurvey = main_cmx_or_sv(data)
+        desi_mask = filemasks[0]
 
-    # Allow sciencemask, stdmask, etc. to be int or string
-    if (args.sciencemask is not None) and isinstance(args.sciencemask, str):
-        args.sciencemask = desi_mask.mask(args.sciencemask.replace(",", "|"))
+        # convert str bit names -> int bit mask
+        if isinstance(args.sciencemask, str):
+            args.sciencemask = desi_mask.mask(args.sciencemask.replace(",","|"))
 
-    if (args.stdmask is not None) and isinstance(args.stdmask, str):
-        args.stdmask = desi_mask.mask(args.stdmask.replace(",", "|"))
+        if isinstance(args.stdmask, str):
+            args.stdmask = desi_mask.mask(args.stdmask.replace(",", "|"))
 
-    if (args.skymask is not None) and isinstance(args.skymask, str):
-        args.skymask = desi_mask.mask(args.skymask.replace(",", "|"))
+        if isinstance(args.skymask, str):
+            args.skymask = desi_mask.mask(args.skymask.replace(",", "|"))
 
-    if (args.safemask is not None) and isinstance(args.safemask, str):
-        args.safemask = desi_mask.mask(args.safemask.replace(",", "|"))
+        if isinstance(args.safemask, str):
+            args.safemask = desi_mask.mask(args.safemask.replace(",", "|"))
 
-    if (args.excludemask is not None) and isinstance(args.excludemask, str):
-        args.excludemask = desi_mask.mask(args.excludemask.replace(",", "|"))
+        if isinstance(args.excludemask, str):
+            args.excludemask = desi_mask.mask(args.excludemask.replace(",","|"))
 
     # Set output directory
     if args.dir is None:

--- a/py/fiberassign/targets.py
+++ b/py/fiberassign/targets.py
@@ -223,6 +223,12 @@ def desi_target_type(desi_target, sciencemask, stdmask,
         (array):  The fiberassign target types.
 
     """
+    # print('sciencemask {}'.format(sciencemask))
+    # print('stdmask     {}'.format(stdmask))
+    # print('skymask     {}'.format(skymask))
+    # print('safemask    {}'.format(safemask))
+    # print('excludemask {}'.format(excludemask))
+
     if np.isscalar(desi_target):
         ttype = 0
         if desi_target & sciencemask != 0:


### PR DESCRIPTION
This PR adds a few features used by the Survey Validation Data Challenge:
* sort output by FIBER (even though downstream code shouldn't care about the fiber order, it currently does care)
* allow setting sciencemask etc. by name in addition to number, including for SV target catalogs
* There were also some updates to how it parses `fiberassign` options into `fba_run` and `fba_merge_results` options, which might make that slightly more maintainable by making it opt-in instead of opt-out.
