### PR TITLE
enforce sorting by FIBER

### DIFF
--- a/py/fiberassign/assign.py
+++ b/py/fiberassign/assign.py
@@ -1080,8 +1080,10 @@ def merge_results_tile(out_dtype, copy_fba, params):
     fd.write(None, header=inhead, extname="PRIMARY")
 
     # Write the main FIBERASSIGN HDU- only the data for science positioners
+    # Enforce sorting by FIBER
     log.info("Writing new data {}".format(outfile))
-    fd.write(outdata[science_rows], header=inhead, extname="FIBERASSIGN")
+    ii = np.argsort(outdata['FIBER'][science_rows])
+    fd.write(outdata[science_rows][ii], header=inhead, extname="FIBERASSIGN")
 
     # Now write out the sky monitor fibers.  We extract the rows and columns
     # from the already-computed recarray.


### PR DESCRIPTION
Downstream code shouldn't require that fiberassign output is sorted by FIBER, but it does.  Until that is fixed, we should write the output sorted by FIBER.  There are comments in assign.py indicating that it is trying to do that, but empirically it wasn't succeeding.  This PR adds a simple pragmatic sort-on-write when writing the FIBERASSIGN table of the merged tile*.fits output.  The unmerged FASSIGN table remains unchanged (i.e. not sorted by FIBER).