### PR TITLE
fiberassign support cmx targets + main skies

### DIFF
--- a/bin/fiberassign
+++ b/bin/fiberassign
@@ -128,7 +128,7 @@ if args.starmask is not None:
 
 #- mtl, sky, stdstar -> targets
 opts = args.__dict__.copy()
-opts['targets'] = [args.mtl, args.sky]
+opts['targets'] = [args.mtl,]
 if args.stdstar is not None:
     opts["targets"].append(args.stdstar)
 
@@ -140,7 +140,7 @@ opts['standards_per_petal'] = args.nstarpetal
 opts['sky_per_petal'] = args.nskypetal
 
 #- remove keys for options that were renamed
-for key in ['mtl', 'sky', 'stdstar', 'outdir', 'fibstatusfile', 'surveytiles',
+for key in ['mtl', 'stdstar', 'outdir', 'fibstatusfile', 'surveytiles',
             'nstarpetal', 'nskypetal', 'starmask']:
     if key in opts:
         del opts[key]

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,7 +6,9 @@ fiberassign change log
 1.1.1 (unreleased)
 ------------------
 
-* No changes yet.
+* fiberassign support for CMX targets + MAIN skies (PR `#224`_).
+
+.. _`#224`: https://github.com/desihub/fiberassign/pull/224
 
 1.1.0 (2019-09-25)
 ------------------


### PR DESCRIPTION
This PR is a small update to support mixing CMX targets with MAIN skies when using the `fiberassign` wrapper to `fba_run` and `fba_merge_results`.  This requires passing in the sky file to `fba_run --sky ...` (like `fiberassign` itself) rather than just adding it to the list of `fba_run --targets ...` files (which works for the MAIN survey, but not when mixing and matching CMX with MAIN).

Thanks @Srheft for providing the existence proof of how to mix-and-match CMX with MAIN to help me understand why it wasn't working for me.