### PR TITLE
use desimodel.focalplane.fieldrot

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -7,8 +7,12 @@ fiberassign change log
 ------------------
 
 * fiberassign support for CMX targets + MAIN skies (PR `#224`_).
+* Added cmx_science bits for first light targets (PR `#225`_).
+* Use per-tile field rotations from desimodel.focalplane.fieldrot (PR `#226`_).
 
 .. _`#224`: https://github.com/desihub/fiberassign/pull/224
+.. _`#225`: https://github.com/desihub/fiberassign/pull/225
+.. _`#226`: https://github.com/desihub/fiberassign/pull/226
 
 1.1.0 (2019-09-25)
 ------------------

--- a/py/fiberassign/test/test_tiles.py
+++ b/py/fiberassign/test/test_tiles.py
@@ -12,6 +12,8 @@ from fiberassign.tiles import load_tiles
 
 from .simulate import test_subdir_create, sim_tiles
 
+from astropy.table import Table
+from astropy.time import Time
 
 class TestTiles(unittest.TestCase):
 
@@ -41,6 +43,23 @@ class TestTiles(unittest.TestCase):
         for st in stiles:
             self.assertEqual(tls.order[st], indx)
             indx += 1
+
+        #- Syntax / coverage tests
+        tls = load_tiles(tiles_file=tfile, select=stiles, obstime='2020-10-20')
+        self.assertEqual(tls.obstime[0], Time('2020-10-20T00:00:00').isot)
+        tls = load_tiles(tiles_file=tfile, select=stiles, obstime='2020-10-20T10:20:30')
+        self.assertEqual(tls.obstime[0], Time('2020-10-20T10:20:30').isot)
+
+        #- including obsdate in tile file
+        tiles = Table.read(tfile)
+        tiles['OBSDATE'] = '2020-11-22'    # creates full column
+        tiles['OBSDATE'][1] = '2020-11-23' # override second entry
+        tfile = os.path.join(test_dir, "footprint-obsdate.fits")
+        tiles.write(tfile)
+        tls = load_tiles(tiles_file=tfile, select=stiles)
+        self.assertEqual(tls.obstime[0], Time('2020-11-22').isot)
+        self.assertEqual(tls.obstime[1], Time('2020-11-23').isot)
+
         return
 
 

--- a/py/fiberassign/tiles.py
+++ b/py/fiberassign/tiles.py
@@ -57,40 +57,31 @@ def load_tiles(tiles_file=None, select=None, obstime=None, obstheta=None):
         'ignore', message=
         r'ERFA function \"[a-z0-9_]+\" yielded [0-9]+ of \"dubious year')
 
-    obsdate = None
     if obstime is not None:
-        # We are overriding the observation date for all tiles.
-        dtobs = None
-        if re.match(".*:.*", obstime) is not None:
-            dtobs = datetime.strptime(obstime, "%Y-%m-%dT%H:%M:%S")
-        else:
-            dtobs = datetime.strptime(obstime, "%Y-%m-%d")
-        obsdate = [dtobs for x in range(len(keeprows))]
+        # obstime is given, use that for all tiles
+        obsdate = astropy.time.Time(obstime)
+        obsmjd = [obsdate.mjd,] * len(keeprows)
+        obsdatestr = [obsdate.isot, ] * len(keeprows)
     elif "OBSDATE" in tiles_data.names:
         # We have the obsdate for every tile in the file.
-        obsdate = [
-            datetime.strptime(x, "%Y-%m-%dT%H:%M:%S")
-            for x in tiles_data["OBSDATE"][keeprows]
-        ]
+        obsdate = [astropy.time.Time(x) for x in tiles_data["OBSDATE"][keeprows]]
+        obsmjd = [x.mjd for x in obsdate]
+        obsdatestr = [x.isot for x in obsdate]
     else:
-        # We have no information.  Use the middle of the survey.
-        obsdate = [
-            datetime.strptime("2022-07-01", "%Y-%m-%d")
-            for x in range(len(keeprows))
-        ]
-
-    obsdatestr = [x.isoformat() for x in obsdate]
+        # default to middle of the survey
+        obsdate = astropy.time.Time('2022-07-01')
+        obsmjd = [obsdate.mjd,] * len(keeprows)
+        obsdatestr = [obsdate.isot, ] * len(keeprows)
 
     # Eventually, call a function from desimodel to query the field
     # rotation and hour angle for every tile time.
 
     if obstheta is None:
         theta_obs = list()
-        for tra, tdec, ttime in zip(
+        for tra, tdec, mjd in zip(
                 tiles_data["RA"][keeprows],
                 tiles_data["DEC"][keeprows],
-                obsdate):
-            mjd = astropy.time.Time(ttime).mjd
+                obsmjd):
             th = field_rotation_angle(tra, tdec, mjd)
             theta_obs.append(th)
         theta_obs = np.array(theta_obs)


### PR DESCRIPTION
Uses the new `desimodel.focalplane.fieldrot.field_rotation_angle(mjd)` to get the field rotation to use for each tile if it isn't otherwise specified.  Requires desimodel master (to be tagged as 0.10.1).