### PR TITLE
Update formats to match what ICS needs

### DIFF
--- a/bin/qa-fiberassign
+++ b/bin/qa-fiberassign
@@ -159,8 +159,15 @@ for filename in args.tilefiles:
         errors.append('fiber:location map incorrect')
 
     ii = fa['TARGETID'] >= 0
-    dx = (fa['DESIGN_X'][ii] - fiberpos['X'][ii])
-    dy = (fa['DESIGN_Y'][ii] - fiberpos['Y'][ii])
+    if 'DESIGN_X' in fa.colnames:
+        #- old name
+        dx = (fa['DESIGN_X'][ii] - fiberpos['X'][ii])
+        dy = (fa['DESIGN_Y'][ii] - fiberpos['Y'][ii])
+    else:
+        #- new name
+        dx = (fa['FIBERASSIGN_X'][ii] - fiberpos['X'][ii])
+        dy = (fa['FIBERASSIGN_Y'][ii] - fiberpos['Y'][ii])
+
     r = np.sqrt(dx**2 + dy**2)
     if np.max(r) > 6:
         errors.append('Fibers assigned to more than 6mm from positioner center')

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -3,12 +3,13 @@
 fiberassign change log
 ======================
 
-1.1.1 (unreleased)
+1.2.0 (unreleased)
 ------------------
 
 * fiberassign support for CMX targets + MAIN skies (PR `#224`_).
 * Added cmx_science bits for first light targets (PR `#225`_).
 * Use per-tile field rotations from desimodel.focalplane.fieldrot (PR `#226`_).
+* Format updates to match ICS and some cleanup.
 
 .. _`#224`: https://github.com/desihub/fiberassign/pull/224
 .. _`#225`: https://github.com/desihub/fiberassign/pull/225

--- a/py/fiberassign/assign.py
+++ b/py/fiberassign/assign.py
@@ -71,8 +71,6 @@ results_assign_columns = OrderedDict([
     ("FA_TYPE", "u1"),
     ("DESIGN_X", "f4"),
     ("DESIGN_Y", "f4"),
-    ("DESIGN_Q", "f4"),
-    ("DESIGN_S", "f4"),
 ])
 
 results_targets_columns = OrderedDict([
@@ -336,12 +334,6 @@ def write_assignment_fits_tile(asgn, fulltarget, overwrite, params):
         fdata["DESIGN_Y"] = assigned_tgy
         fdata["FA_TARGET"] = assigned_tgbits
         fdata["FA_TYPE"] = assigned_tgtype
-
-        assigned_q, assigned_s = desimodel.focalplane.xy2qs(
-            assigned_tgx, assigned_tgy)
-
-        fdata["DESIGN_Q"] = assigned_q
-        fdata["DESIGN_S"] = assigned_s
 
         fibers = dict(hw.loc_fiber)
         etcloc = sorted([x for x, y in fibers.items() if y < 0])
@@ -822,8 +814,6 @@ merged_fiberassign_req_columns = OrderedDict([
     ("DESIGN_Y", "f4"),
     ("BRICKNAME", "a8"),
     ("FIBERSTATUS", "i4"),
-    ("DESIGN_Q", "f4"),
-    ("DESIGN_S", "f4"),
     ("LAMBDA_REF", "f4"),
     ("OBJTYPE", "a3"),
     ("PETAL_LOC", "i2"),
@@ -847,8 +837,6 @@ merged_skymon_columns = OrderedDict([
     ("DESIGN_Y", "f4"),
     ("BRICKNAME", "a8"),
     ("FIBERSTATUS", "i4"),
-    ("DESIGN_Q", "f4"),
-    ("DESIGN_S", "f4"),
     ("PETAL_LOC", "i2"),
     ("DEVICE_LOC", "i4"),
     ("PRIORITY", "i4"),

--- a/py/fiberassign/assign.py
+++ b/py/fiberassign/assign.py
@@ -69,8 +69,8 @@ results_assign_columns = OrderedDict([
     ("TARGET_DEC", "f8"),
     ("FA_TARGET", "i8"),
     ("FA_TYPE", "u1"),
-    ("DESIGN_X", "f4"),
-    ("DESIGN_Y", "f4"),
+    ("FIBERASSIGN_X", "f4"),
+    ("FIBERASSIGN_Y", "f4"),
 ])
 
 results_targets_columns = OrderedDict([
@@ -330,8 +330,8 @@ def write_assignment_fits_tile(asgn, fulltarget, overwrite, params):
 
         fdata["TARGET_RA"] = assigned_tgra
         fdata["TARGET_DEC"] = assigned_tgdec
-        fdata["DESIGN_X"] = assigned_tgx
-        fdata["DESIGN_Y"] = assigned_tgy
+        fdata["FIBERASSIGN_X"] = assigned_tgx
+        fdata["FIBERASSIGN_Y"] = assigned_tgy
         fdata["FA_TARGET"] = assigned_tgbits
         fdata["FA_TYPE"] = assigned_tgtype
 
@@ -798,30 +798,40 @@ merged_fiberassign_swap = {
     "RA": "TARGET_RA",
     "DEC": "TARGET_DEC",
     "RA_IVAR": "TARGET_RA_IVAR",
-    "DEC_IVAR": "TARGET_DEC_IVAR"
+    "DEC_IVAR": "TARGET_DEC_IVAR",
+    "APFLUX_G": "FIBERFLUX_G",
+    "APFLUX_R": "FIBERFLUX_R",
+    "APFLUX_Z": "FIBERFLUX_Z",
+    "APFLUX_IVAR_G": "FIBERFLUX_IVAR_G",
+    "APFLUX_IVAR_R": "FIBERFLUX_IVAR_R",
+    "APFLUX_IVAR_Z": "FIBERFLUX_IVAR_Z",
 }
 
 merged_fiberassign_req_columns = OrderedDict([
-    ("FIBER", "i4"),
-    ("LOCATION", "i4"),
-    ("NUMTARGET", "i2"),
     ("TARGETID", "i8"),
-    ("FA_TARGET", "i8"),
-    ("FA_TYPE", "u1"),
-    ("TARGET_RA", "f8"),
-    ("TARGET_DEC", "f8"),
-    ("DESIGN_X", "f4"),
-    ("DESIGN_Y", "f4"),
-    ("BRICKNAME", "a8"),
-    ("FIBERSTATUS", "i4"),
-    ("LAMBDA_REF", "f4"),
-    ("OBJTYPE", "a3"),
     ("PETAL_LOC", "i2"),
     ("DEVICE_LOC", "i4"),
+    ("LOCATION", "i4"),
+    ("FIBER", "i4"),
+    ("FIBERSTATUS", "i4"),
+    ("TARGET_RA", "f8"),
+    ("TARGET_DEC", "f8"),
+    ("PMRA", "f4"),
+    ("PMDEC", "f4"),
+    ("PMRA_IVAR", "f4"),
+    ("PMDEC_IVAR", "f4"),
+    ("REF_EPOCH", "f4"),
+    ("LAMBDA_REF", "f4"),
+    ("FA_TARGET", "i8"),
+    ("FA_TYPE", "u1"),
+    ("OBJTYPE", "a3"),
+    ("FIBERASSIGN_X", "f4"),
+    ("FIBERASSIGN_Y", "f4"),
+    ("NUMTARGET", "i2"),
     ("PRIORITY", "i4"),
     ("SUBPRIORITY", "f8"),
     ("OBSCONDITIONS", "i4"),
-    ("NUMOBS_MORE", "i4")
+    ("NUMOBS_MORE", "i4"),
 ])
 
 merged_skymon_columns = OrderedDict([
@@ -829,17 +839,26 @@ merged_skymon_columns = OrderedDict([
     ("LOCATION", "i4"),
     ("NUMTARGET", "i2"),
     ("TARGETID", "i8"),
+    ("BRICKID", "i4"),
+    ("BRICK_OBJID", "i4"),
     ("FA_TARGET", "i8"),
     ("FA_TYPE", "u1"),
     ("TARGET_RA", "f8"),
     ("TARGET_DEC", "f8"),
-    ("DESIGN_X", "f4"),
-    ("DESIGN_Y", "f4"),
+    ("FIBERASSIGN_X", "f4"),
+    ("FIBERASSIGN_Y", "f4"),
     ("BRICKNAME", "a8"),
     ("FIBERSTATUS", "i4"),
     ("PETAL_LOC", "i2"),
     ("DEVICE_LOC", "i4"),
     ("PRIORITY", "i4"),
+    ("SUBPRIORITY", "f8"),
+    ("FIBERFLUX_G", "f4"),
+    ("FIBERFLUX_R", "f4"),
+    ("FIBERFLUX_Z", "f4"),
+    ("FIBERFLUX_IVAR_G", "f4"),
+    ("FIBERFLUX_IVAR_R", "f4"),
+    ("FIBERFLUX_IVAR_Z", "f4"),
 ])
 
 merged_potential_columns = OrderedDict([
@@ -1072,6 +1091,12 @@ def merge_results_tile(out_dtype, copy_fba, params):
             else:
                 outdata[c][fassign_valid] = tile_targets[c][target_rows]
 
+    # Special check for REF_EPOCH which isn't in MTL yet
+    ismoving = (outdata['PMRA'] != 0) | (outdata['PMDEC'] != 0)
+    if np.all(outdata['REF_EPOCH'] == 0.0) and np.any(ismoving):
+        log.error('REF_EPOCH not set, using 2015.5')
+        outdata['REF_EPOCH'][ismoving] = 2015.5
+
     # tm.stop()
     # tm.report("  copy external data to output {}".format(tile_id))
     # tm.clear()
@@ -1108,7 +1133,7 @@ def merge_results_tile(out_dtype, copy_fba, params):
 
     # Copy GFA data if it exists
     if gfa_targets is not None:
-        fd.write(gfa_targets, extname="GFA_TARGETS")
+        fd.write(gfa_targets, header=inhead, extname="GFA_TARGETS")
 
     # Write the per-tile catalog information also.  Sadly, this HDU is
     # expected to have the original column names.  We swap them back, which


### PR DESCRIPTION
This branch updates the fiberassign output format to match what ICS requires (to be confirmed by Klaus).  Don't merge until we have signoff from him.  A test file is at KPNO in /n/home/datasystems/users/sbailey/fiberassign/tile-003000.fits (I can also put a copy at NERSC after it gets power back if this ticket is still active).

Changes for ICS:
* Adds missing header keywords to all HDUs
* Propagates some previously missing columns (PMRA, PMDEC...)

Other cleanup:
* Adds proper motion REF_EPOCH column (not single value header keyword)
* Rename DESIGN_X, DESIGN_Y -> FIBERASSIGN_X, FIBERASSIGN_Y to prevent confusion about who is doing the designing
  * some thought it was the Platemaker x,y values by the time it made it through
    to the outputs
* Drop unused DESIGN_Q, DESIGN_S
  * if you need them, use `desimodel.focalplane.xy2qs()`
* Rename sky target APFLUX_* to FIBERFLUX_*
  * previously we ended up with both columns but only APFLUX was filled
    in for sky targets and FIBERFLUX for science targets...)
  * I acknowledge the sky apertures are calculated differently from science target
    model FIBERFLUXs, but having extra columns that aren't completely filled in
    is also confusing / problematic.

@Srheft @kdawson1000 the tests pass, but I wouldn't be surprised if this branch broke something in QA / visualization / tilepicker, especially due to the DESIGN_X/Y -> FIBERASSIGN_X/Y change.  Please test and report problems.

*Note*: there is still a huge amount of replicated data between the FIBERASSIGN HDU and the TARGETS HDU.  I haven't tried to clean that up here (requires downstream coordination with the spectro pipeline), but I did try to isolate what is required by ICS from what is along for the ride in the FIBERASSIGN HDU.