### PR TITLE
output_rename

### DIFF
--- a/py/fiberassign/assign.py
+++ b/py/fiberassign/assign.py
@@ -92,7 +92,7 @@ results_avail_columns = OrderedDict([
 ])
 
 
-def result_tiles(dir=".", prefix="fiberassign_"):
+def result_tiles(dir=".", prefix="fba-"):
     # Find all the per-tile files and get the tile IDs
     tiles = list()
     for root, dirs, files in os.walk(dir):
@@ -104,7 +104,7 @@ def result_tiles(dir=".", prefix="fiberassign_"):
     return tiles
 
 
-def result_path(tile_id, dir=".", prefix="fiberassign_",
+def result_path(tile_id, dir=".", prefix="fba-",
                 ext="fits", create=False, split=False):
     tiledir = dir
     if split:
@@ -450,7 +450,7 @@ def write_assignment_fits_tile(asgn, fulltarget, overwrite, params):
     return
 
 
-def write_assignment_fits(tiles, asgn, out_dir=".", out_prefix="fiberassign_",
+def write_assignment_fits(tiles, asgn, out_dir=".", out_prefix="fba-",
                           split_dir=False, all_targets=False,
                           gfa_targets=None, overwrite=False):
     """Write out assignment results in FITS format.
@@ -515,7 +515,7 @@ def write_assignment_fits(tiles, asgn, out_dir=".", out_prefix="fiberassign_",
     return
 
 
-def write_assignment_ascii(tiles, asgn, out_dir=".", out_prefix="fiberassign_",
+def write_assignment_ascii(tiles, asgn, out_dir=".", out_prefix="fba-",
                            split_dir=False):
     """Write out assignment results in ASCII format.
 
@@ -1186,8 +1186,8 @@ def merge_results_tile(out_dtype, copy_fba, params):
 
 
 def merge_results(targetfiles, skyfiles, tiles, result_dir=".",
-                  result_prefix="fiberassign_", result_split_dir=False,
-                  out_dir=None, out_prefix="tile-", out_split_dir=False,
+                  result_prefix="fba-", result_split_dir=False,
+                  out_dir=None, out_prefix="fiberassign-", out_split_dir=False,
                   columns=None, copy_fba=True):
     """Merge target files and assignment output.
 

--- a/py/fiberassign/qa.py
+++ b/py/fiberassign/qa.py
@@ -235,7 +235,7 @@ def qa_tile_file(hw, params):
 
     return qa_data
 
-def qa_tiles(hw, tiles, result_dir=".", result_prefix="fiberassign_",
+def qa_tiles(hw, tiles, result_dir=".", result_prefix="fba-",
              result_split_dir=False, qa_out=None):
     """Run QA on a set of tiles.
 

--- a/py/fiberassign/scripts/assign.py
+++ b/py/fiberassign/scripts/assign.py
@@ -102,7 +102,7 @@ def parse_assign(optlist=None):
                         help="Output directory.")
 
     parser.add_argument("--prefix", type=str, required=False,
-                        default="fiberassign_",
+                        default="fba-",
                         help="Prefix of each file (before the <tile>.fits).")
 
     parser.add_argument("--split", required=False, default=False,

--- a/py/fiberassign/scripts/fulltest.py
+++ b/py/fiberassign/scripts/fulltest.py
@@ -173,7 +173,7 @@ def run_fulltest(args):
     opts = dict()
     opts["footprint"] = args.footprint
     opts["dir"] = rawout
-    opts["prefix"] = "fiberassign_"
+    opts["prefix"] = "fba-"
 
     options = option_list(opts)
     parsed = parse_qa(options)
@@ -196,7 +196,7 @@ def run_fulltest(args):
     opts = dict()
     opts["footprint"] = args.footprint
     opts["dir"] = rawout
-    opts["prefix"] = "fiberassign_"
+    opts["prefix"] = "fba-"
     opts["out"] = rawplot
     opts["petals"] = args.plotpetals
 

--- a/py/fiberassign/scripts/merge.py
+++ b/py/fiberassign/scripts/merge.py
@@ -53,7 +53,7 @@ def parse_merge(optlist=None):
                         help="Directory containing fiberassign results.")
 
     parser.add_argument("--prefix", type=str, required=False,
-                        default="fiberassign_",
+                        default="fba-",
                         help="Prefix of each file (before the <tile>.fits).")
 
     parser.add_argument("--split", required=False, default=False,
@@ -65,7 +65,7 @@ def parse_merge(optlist=None):
                         " is the directory containing the fiberassign output.")
 
     parser.add_argument("--out_prefix", type=str, required=False,
-                        default="tile-",
+                        default="fiberassign-",
                         help="Prefix of each output file.")
 
     parser.add_argument("--out_split", required=False, default=False,

--- a/py/fiberassign/scripts/plot.py
+++ b/py/fiberassign/scripts/plot.py
@@ -41,7 +41,7 @@ def parse_plot(optlist=None):
                         help="Directory containing fiberassign results.")
 
     parser.add_argument("--prefix", type=str, required=False,
-                        default="fiberassign_",
+                        default="fba-",
                         help="Prefix of each file (before the <tile>.fits).")
 
     parser.add_argument("--split", required=False, default=False,

--- a/py/fiberassign/scripts/qa.py
+++ b/py/fiberassign/scripts/qa.py
@@ -41,7 +41,7 @@ def parse_qa(optlist=None):
                         help="Directory containing fiberassign outputs.")
 
     parser.add_argument("--prefix", type=str, required=False,
-                        default="fiberassign_",
+                        default="fba-",
                         help="Prefix of each file (before the <tile>.fits).")
 
     parser.add_argument("--split", required=False, default=False,


### PR DESCRIPTION
@sbailey 
sorry it's later than you asked; had a distracting delivery item.
This PR does these name changes:
 * fiberassign_{tileid}.fits --> fba-{tileid}.fits
 * tile-{tileid}.fits --> fiberassign-{tileid}.fits
 * fiberassign_{tileid}.pdf --> fba-{tileid}.pdf

This breaks Tilepicker is several places but not a huge deal.