### PR TITLE
Propagate run date / time and dependency versions to output headers

### DIFF
--- a/py/fiberassign/assign.py
+++ b/py/fiberassign/assign.py
@@ -24,6 +24,8 @@ from collections import OrderedDict
 
 import fitsio
 
+from desiutil.depend import add_dependencies
+
 import desimodel.focalplane
 
 from desitarget.targetmask import desi_mask
@@ -257,14 +259,27 @@ def write_assignment_fits_tile(asgn, fulltarget, overwrite, params):
         header["TILERA"] = tile_ra
         header["TILEDEC"] = tile_dec
         header["FIELDROT"] = tile_obstheta
-        header["FA_DATE"] = tile_obstime
+        header["FA_PLAN"] = tile_obstime
         header["FA_HA"] = tile_obsha
+        header["FA_RUN"] = hw.time()
 
         header["REQRA"] = tile_ra
         header["REQDEC"] = tile_dec
         header["FIELDNUM"] = 0
         header["FA_VER"] = __version__
         header["FA_SURV"] = tgs.survey()
+        add_dependencies(
+            header,
+            module_names=[
+                "numpy",
+                "matplotlib",
+                "astropy",
+                "fitsio",
+                "desiutil",
+                "desimodel",
+                "desitarget"
+            ]
+        )
         fd.write(None, header=header, extname="PRIMARY")
 
         # FIXME:  write "-1" for unassigned targets.  Write all other fiber

--- a/py/fiberassign/hardware.py
+++ b/py/fiberassign/hardware.py
@@ -49,7 +49,7 @@ def load_hardware(focalplane=None, rundate=None):
     fp = None
     exclude = None
     state = None
-    tmstr = None
+    tmstr = "UNKNOWN"
     if focalplane is None:
         fp, exclude, state, tmstr = dmio.load_focalplane(runtime)
     else:
@@ -125,7 +125,7 @@ def load_hardware(focalplane=None, rundate=None):
         else:
             positioners[loc]["petal"] = Shape()
 
-    hw = Hardware(locations,
+    hw = Hardware(tmstr, locations,
                   fp["PETAL"][keep_rows],
                   fp["DEVICE"][keep_rows],
                   fp["SLITBLOCK"][keep_rows],

--- a/py/fiberassign/test/simulate.py
+++ b/py/fiberassign/test/simulate.py
@@ -94,13 +94,13 @@ def sim_tiles(path, selectfile=None):
         ("OBSCONDITIONS", "i4")
     ])
     # ntile = 7
-    ntile = 5
+    ntile = 2
     fdata = np.zeros(ntile, dtype=tile_dtype)
     fdata[0] = (11108, 150.87, 31.23, 1, "DARK", 1)
     fdata[1] = (1165, 150.69, 33.86, 1, "DARK", 1)
-    fdata[2] = (18465, 150.47, 33.20, 1, "DARK", 1)
-    fdata[3] = (6927, 151.78, 33.84, 1, "DARK", 1)
-    fdata[4] = (24227, 151.56, 33.18, 2, "DARK", 1)
+    # fdata[2] = (18465, 150.47, 33.20, 1, "DARK", 1)
+    # fdata[3] = (6927, 151.78, 33.84, 1, "DARK", 1)
+    # fdata[4] = (24227, 151.56, 33.18, 2, "DARK", 1)
     # fdata[5] = (16870, 151.96, 31.21, 1, "DARK", 1)
     # fdata[6] = (28408, 150.73, 30.52, 2, "DARK", 1)
 

--- a/src/_pyfiberassign.cpp
+++ b/src/_pyfiberassign.cpp
@@ -492,6 +492,7 @@ PYBIND11_MODULE(_internal, m) {
         Class representing the hardware configuration of the telescope.
 
         Args:
+            timestr (str):  ISO 8601 format time string in UTC.
             location (array):  int32 array of location.
             petal (array):  int32 array of petal index.
             device (array):  int32 array of device number.
@@ -528,6 +529,7 @@ PYBIND11_MODULE(_internal, m) {
 
         )")
         .def(py::init <
+            std::string const &,
             std::vector <int32_t> const &,
             std::vector <int32_t> const &,
             std::vector <int32_t> const &,
@@ -549,7 +551,8 @@ PYBIND11_MODULE(_internal, m) {
             std::vector <fbg::shape> const &,
             std::vector <fbg::shape> const &,
             std::vector <fbg::shape> const &,
-            std::vector <fbg::shape> const &> (), py::arg("location"),
+            std::vector <fbg::shape> const &> (), py::arg("timestr"),
+            py::arg("location"),
             py::arg("petal"), py::arg("device"), py::arg("slitblock"),
             py::arg("blockfiber"), py::arg("fiber"), py::arg("device_type"),
             py::arg("x"), py::arg("y"), py::arg("status"),
@@ -650,6 +653,13 @@ PYBIND11_MODULE(_internal, m) {
         .def("device_locations", &fba::Hardware::device_locations,
             py::arg("type"), R"(
             Dictionary of locations for each device type (POS or ETC).
+        )")
+        .def("time", &fba::Hardware::time, R"(
+            Return the time used when loading the focalplane model.
+
+            Returns:
+                (str): the focalplane model time.
+
         )")
         .def("radec2xy", &fba::Hardware::radec2xy, py::arg("tilera"),
             py::arg("tiledec"), py::arg("tiletheta"), py::arg("ra"),
@@ -902,6 +912,7 @@ PYBIND11_MODULE(_internal, m) {
         .def(py::pickle(
             [](fba::Hardware const & p) { // __getstate__
                 int32_t nloc = p.locations.size();
+                std::string timestr = p.time();
                 std::vector <int32_t> lid(nloc);
                 std::vector <int32_t> petal(nloc);
                 std::vector <int32_t> device(nloc);
@@ -949,6 +960,7 @@ PYBIND11_MODULE(_internal, m) {
                     excl_petal[i] = p.loc_petal_excl.at(lid[i]);
                 }
                 return py::make_tuple(
+                    timestr,
                     lid, petal, device, slitblock, blockfiber, fiber,
                     device_type, x_mm, y_mm, status, theta_offset,
                     theta_min, theta_max, theta_arm, phi_offset, phi_min,
@@ -957,17 +969,17 @@ PYBIND11_MODULE(_internal, m) {
             },
             [](py::tuple t) { // __setstate__
                 return new fba::Hardware(
-                    t[0].cast<std::vector<int32_t> >(),
+                    t[0].cast<std::string>(),
                     t[1].cast<std::vector<int32_t> >(),
                     t[2].cast<std::vector<int32_t> >(),
                     t[3].cast<std::vector<int32_t> >(),
                     t[4].cast<std::vector<int32_t> >(),
                     t[5].cast<std::vector<int32_t> >(),
-                    t[6].cast<std::vector<std::string> >(),
-                    t[7].cast<std::vector<double> >(),
+                    t[6].cast<std::vector<int32_t> >(),
+                    t[7].cast<std::vector<std::string> >(),
                     t[8].cast<std::vector<double> >(),
-                    t[9].cast<std::vector<int32_t> >(),
-                    t[10].cast<std::vector<double> >(),
+                    t[9].cast<std::vector<double> >(),
+                    t[10].cast<std::vector<int32_t> >(),
                     t[11].cast<std::vector<double> >(),
                     t[12].cast<std::vector<double> >(),
                     t[13].cast<std::vector<double> >(),
@@ -975,10 +987,11 @@ PYBIND11_MODULE(_internal, m) {
                     t[15].cast<std::vector<double> >(),
                     t[16].cast<std::vector<double> >(),
                     t[17].cast<std::vector<double> >(),
-                    t[18].cast<std::vector<fbg::shape> >(),
+                    t[18].cast<std::vector<double> >(),
                     t[19].cast<std::vector<fbg::shape> >(),
                     t[20].cast<std::vector<fbg::shape> >(),
-                    t[21].cast<std::vector<fbg::shape> >()
+                    t[21].cast<std::vector<fbg::shape> >(),
+                    t[22].cast<std::vector<fbg::shape> >()
                 );
             }
         ));

--- a/src/hardware.cpp
+++ b/src/hardware.cpp
@@ -16,7 +16,8 @@ namespace fba = fiberassign;
 namespace fbg = fiberassign::geom;
 
 
-fba::Hardware::Hardware(std::vector <int32_t> const & location,
+fba::Hardware::Hardware(std::string const & timestr,
+                        std::vector <int32_t> const & location,
                         std::vector <int32_t> const & petal,
                         std::vector <int32_t> const & device,
                         std::vector <int32_t> const & slitblock,
@@ -42,6 +43,8 @@ fba::Hardware::Hardware(std::vector <int32_t> const & location,
 
     fba::Logger & logger = fba::Logger::get();
     std::ostringstream logmsg;
+
+    timestr_ = timestr;
 
     int32_t maxpetal = 0;
     for (auto const & p : petal) {
@@ -167,6 +170,11 @@ fba::Hardware::Hardware(std::vector <int32_t> const & location,
         loc_petal_excl.at(lid).rotation_origin(csang);
     }
 
+}
+
+
+std::string fba::Hardware::time() const {
+    return timestr_;
 }
 
 

--- a/src/hardware.h
+++ b/src/hardware.h
@@ -35,6 +35,7 @@ class Hardware : public std::enable_shared_from_this <Hardware> {
         typedef std::shared_ptr <Hardware> pshr;
 
         Hardware(
+            std::string const & timestr,
             std::vector <int32_t> const & location,
             std::vector <int32_t> const & petal,
             std::vector <int32_t> const & device,
@@ -58,6 +59,8 @@ class Hardware : public std::enable_shared_from_this <Hardware> {
             std::vector <fbg::shape> const & excl_gfa,
             std::vector <fbg::shape> const & excl_petal
         );
+
+        std::string time() const;
 
         double radial_ang2dist (double const & theta_rad) const;
 
@@ -239,6 +242,8 @@ class Hardware : public std::enable_shared_from_this <Hardware> {
         std::map <int32_t, fbg::shape> loc_petal_excl;
 
     private :
+
+        std::string timestr_;
 
         bool move_positioner(fbg::shape & shptheta, fbg::shape & shpphi,
                              fbg::dpair const & center,


### PR DESCRIPTION
Change the header keys to FA_RUN and FA_PLAN for the run time and planned observing time.  Add dependency versions to output FITS header.