### PR TITLE
Support supplemental sky targets

### DIFF
--- a/py/fiberassign/assign.py
+++ b/py/fiberassign/assign.py
@@ -34,7 +34,8 @@ from ._version import __version__
 
 from .utils import Logger, Timer, default_mp_proc
 
-from .targets import (TARGET_TYPE_SKY, TARGET_TYPE_SAFE, desi_target_type,
+from .targets import (TARGET_TYPE_SKY, TARGET_TYPE_SUPPSKY,
+                      TARGET_TYPE_SAFE, desi_target_type,
                       default_target_masks, default_survey_target_masks)
 
 from .hardware import (FIBER_STATE_UNASSIGNED, FIBER_STATE_STUCK,
@@ -730,14 +731,16 @@ def read_assignment_fits_tile(params):
         fsciencemask = None
         fstdmask = None
         fskymask = None
+        fsuppskymask = None
         fexcludemask = None
         fcol = None
         if survey is not None:
-            fsciencemask, fstdmask, fskymask, fsafemask, fexcludemask = \
-                default_survey_target_masks(survey)
+            fsciencemask, fstdmask, fskymask, fsuppskymask, fsafemask, \
+                fexcludemask = default_survey_target_masks(survey)
             fcol = "FA_TARGET"
         else:
-            fsurvey, fcol, fsciencemask, fstdmask, fskymask, fsafemask, \
+            fsurvey, fcol, fsciencemask, fstdmask, fskymask, \
+                fsuppskymask, fsafemask, \
                 fexcludemask = default_target_masks(fbtargets)
             survey = fsurvey
 
@@ -745,7 +748,7 @@ def read_assignment_fits_tile(params):
             if col == "FA_TYPE":
                 targets_data[col][:nrawtarget] = [
                     desi_target_type(x, fsciencemask, fstdmask, fskymask,
-                                     fsafemask, fexcludemask)
+                                     fsuppskymask, fsafemask, fexcludemask)
                     for x in fbtargets[fcol][:]]
             elif col == "FA_TARGET":
                 targets_data[col][:nrawtarget] = fbtargets[fcol]
@@ -1266,8 +1269,8 @@ def merge_results(targetfiles, skyfiles, tiles, result_dir=".",
         # Read data directly into shared buffer
         tgview[:] = fd[1].read()
         if survey is None:
-            (survey, col, sciencemask, stdmask, skymask, safemask,
-             excludemask) = default_target_masks(tgview)
+            (survey, col, sciencemask, stdmask, skymask, suppskymask,
+             safemask, excludemask) = default_target_masks(tgview)
 
         # Sort rows by TARGETID if not already done
         tgviewids = tgview["TARGETID"]

--- a/py/fiberassign/qa.py
+++ b/py/fiberassign/qa.py
@@ -71,27 +71,28 @@ def qa_parse_table(header, tgdata):
 
 def qa_tile_with_gfa(hw, tile_id, tgs, tgprops, tile_assign, tile_avail, tile_gfa):
     props = dict()
-    
+
     locs = np.array(hw.device_locations("POS"))
     nassign = 0
     nscience = 0
     nstd = 0
     nsky = 0
+    nsuppsky = 0
     nsafe = 0
     unassigned = list()
     objtypes = dict()
-       
+
     # SE to add GFA info to props
     petals = list(range(10))
     petals_wgfa = list(tile_gfa.keys())
-    petals_wogfa = list(set(petals)-set(petals_wgfa))  
+    petals_wogfa = list(set(petals)-set(petals_wgfa))
     gfas_per_tile = [nsafe]*10
     brightest_gfas = [nsafe]*10
     faintest_gfas = [nsafe]*10
     gfas_upto_18th = [nsafe]*10
-    gfas_upto_19th = [nsafe]*10  
-    gfas_upto_20th = [nsafe]*10  
-   
+    gfas_upto_19th = [nsafe]*10
+    gfas_upto_20th = [nsafe]*10
+
     for cam in petals_wgfa:
         if (len(tile_gfa[cam])>0):
             gfas_per_tile[cam] = len(tile_gfa[cam])
@@ -107,8 +108,8 @@ def qa_tile_with_gfa(hw, tile_id, tgs, tgprops, tile_assign, tile_avail, tile_gf
             faintest_gfas[cam] = ['NaN']
             gfas_upto_18th[cam] = [0]
             gfas_upto_19th[cam] = [0]
-            gfas_upto_20th[cam] = [0] 
-               
+            gfas_upto_20th[cam] = [0]
+
     for lid in locs:
         if lid not in tile_assign:
             unassigned.append(int(lid))
@@ -130,25 +131,28 @@ def qa_tile_with_gfa(hw, tile_id, tgs, tgprops, tile_assign, tile_avail, tile_gf
             nstd += 1
         if tg.is_sky():
             nsky += 1
+        if tg.is_suppsky():
+            nsuppsky += 1
         if tg.is_safe():
             nsafe += 1
     props["assign_total"] = nassign
     props["assign_science"] = nscience
     props["assign_std"] = nstd
     props["assign_sky"] = nsky
+    props["assign_suppsky"] = nsuppsky
     props["assign_safe"] = nsafe
     # SE: added this key for the number of GFA stars per camera: list of 10 integers per tile
     props["gfa_stars_percam"] = gfas_per_tile
-    # SE: added this key for the list of 10 magnitudes of the brightest GFA stars available per camera  
-    props["brightest_gfa_star_percam"] = [np.round(b*(nsafe+1)/(nsafe+1),2) for b in list(brightest_gfas)] 
-    # SE: Number of gfa stars <18 per camera 
+    # SE: added this key for the list of 10 magnitudes of the brightest GFA stars available per camera
+    props["brightest_gfa_star_percam"] = [np.round(b*(nsafe+1)/(nsafe+1),2) for b in list(brightest_gfas)]
+    # SE: Number of gfa stars <18 per camera
     props["gfa_stars_brighter_than_18th"] = [int(b*(nsafe+1)/(nsafe+1)) for b in list(gfas_upto_18th)]
     props["gfa_stars_brighter_than_19th"] = [int(b*(nsafe+1)/(nsafe+1)) for b in list(gfas_upto_19th)]
     props["gfa_stars_brighter_than_20th"] = [int(b*(nsafe+1)/(nsafe+1)) for b in list(gfas_upto_20th)]
 
-    # SE: added this key for the list of 10 magnitudes of the faintest GFA stars available per camera  
+    # SE: added this key for the list of 10 magnitudes of the faintest GFA stars available per camera
     props["faintest_gfa_star_percam"] = [np.round(b*(nsafe+1)/(nsafe+1),2) for b in list(faintest_gfas)]
-        
+
     for ot, cnt in objtypes.items():
         props["assign_obj_{}".format(ot)] = cnt
     props["unassigned"] = unassigned
@@ -167,10 +171,11 @@ def qa_tile(hw, tile_id, tgs, tgprops, tile_assign, tile_avail):
     nscience = 0
     nstd = 0
     nsky = 0
+    nsuppsky = 0
     nsafe = 0
     unassigned = list()
     objtypes = dict()
-    
+
     for lid in locs:
         if lid not in tile_assign:
             unassigned.append(int(lid))
@@ -192,12 +197,15 @@ def qa_tile(hw, tile_id, tgs, tgprops, tile_assign, tile_avail):
             nstd += 1
         if tg.is_sky():
             nsky += 1
+        if tg.is_suppsky():
+            nsuppsky += 1
         if tg.is_safe():
             nsafe += 1
     props["assign_total"] = nassign
     props["assign_science"] = nscience
     props["assign_std"] = nstd
     props["assign_sky"] = nsky
+    props["assign_suppsky"] = nsuppsky
     props["assign_safe"] = nsafe
     for ot, cnt in objtypes.items():
         props["assign_obj_{}".format(ot)] = cnt
@@ -214,7 +222,7 @@ def qa_tile_file(hw, params):
 
     header, fiber_data, targets_data, avail_data, gfa_data = \
         read_assignment_fits_tile((tile_id, tile_file))
-       
+
     # Target properties
     tgs, tgprops = qa_parse_table(header, targets_data)
 
@@ -226,7 +234,7 @@ def qa_tile_file(hw, params):
                if (x["LOCATION"] >= 0)}
 
     tavail = avail_table_to_dict(avail_data)
-    if gfa_data is not None:  
+    if gfa_data is not None:
         tgfa = gfa_table_to_dict(gfa_data)
 
         qa_data = qa_tile_with_gfa(hw, tile_id, tgs, tgprops, tassign, tavail, tgfa)

--- a/py/fiberassign/scripts/assign.py
+++ b/py/fiberassign/scripts/assign.py
@@ -23,7 +23,8 @@ from ..tiles import load_tiles
 from ..gfa import get_gfa_targets
 
 from ..targets import (str_to_target_type, TARGET_TYPE_SCIENCE,
-                       TARGET_TYPE_SKY, TARGET_TYPE_STANDARD,
+                       TARGET_TYPE_SKY, TARGET_TYPE_SUPPSKY,
+                       TARGET_TYPE_STANDARD,
                        TARGET_TYPE_SAFE, Targets, TargetsAvailable,
                        TargetTree, LocationsAvailable,
                        load_target_file)
@@ -355,15 +356,20 @@ def run_assign_full(args):
     # Assign sky to unused fibers, up to some limit
     asgn.assign_unused(TARGET_TYPE_SKY, args.sky_per_petal)
 
+    # Assign suppsky to unused fibers, up to some limit
+    asgn.assign_unused(TARGET_TYPE_SUPPSKY, args.sky_per_petal)
+
     # Force assignment if needed
     asgn.assign_force(TARGET_TYPE_STANDARD, args.standards_per_petal)
     asgn.assign_force(TARGET_TYPE_SKY, args.sky_per_petal)
+    asgn.assign_force(TARGET_TYPE_SUPPSKY, args.sky_per_petal)
 
     # If there are any unassigned fibers, try to place them somewhere.
     # Assigning science again is a no-op, but...
     asgn.assign_unused(TARGET_TYPE_SCIENCE)
     asgn.assign_unused(TARGET_TYPE_STANDARD)
     asgn.assign_unused(TARGET_TYPE_SKY)
+    asgn.assign_unused(TARGET_TYPE_SUPPSKY)
 
     # Assign safe location to unused fibers (no maximum).  There should
     # always be at least one safe location (i.e. "BAD_SKY") for each fiber.
@@ -372,6 +378,7 @@ def run_assign_full(args):
 
     # Assign sky monitor fibers
     asgn.assign_unused(TARGET_TYPE_SKY, -1, "ETC")
+    asgn.assign_unused(TARGET_TYPE_SUPPSKY, -1, "ETC")
     asgn.assign_unused(TARGET_TYPE_SAFE, -1, "ETC")
 
     gt.stop("run_assign_full calculation")
@@ -450,10 +457,16 @@ def run_assign_bytile(args):
         asgn.assign_unused(TARGET_TYPE_SKY, args.sky_per_petal, "POS",
                            tile_id, tile_id)
 
+        # Assign suppsky to unused fibers, up to some limit
+        asgn.assign_unused(TARGET_TYPE_SUPPSKY, args.sky_per_petal, "POS",
+                           tile_id, tile_id)
+
         # Force assignment if needed
         asgn.assign_force(TARGET_TYPE_STANDARD, args.standards_per_petal,
                           tile_id, tile_id)
         asgn.assign_force(TARGET_TYPE_SKY, args.sky_per_petal,
+                          tile_id, tile_id)
+        asgn.assign_force(TARGET_TYPE_SUPPSKY, args.sky_per_petal,
                           tile_id, tile_id)
 
         # If there are any unassigned fibers, try to place them somewhere.
@@ -461,6 +474,7 @@ def run_assign_bytile(args):
         asgn.assign_unused(TARGET_TYPE_SCIENCE, -1, "POS", tile_id, tile_id)
         asgn.assign_unused(TARGET_TYPE_STANDARD, -1, "POS", tile_id, tile_id)
         asgn.assign_unused(TARGET_TYPE_SKY, -1, "POS", tile_id, tile_id)
+        asgn.assign_unused(TARGET_TYPE_SUPPSKY, -1, "POS", tile_id, tile_id)
 
         # Assign safe location to unused fibers (no maximum).  There should
         # always be at least one safe location (i.e. "BAD_SKY") for each
@@ -470,6 +484,7 @@ def run_assign_bytile(args):
 
         # Assign sky monitor fibers
         asgn.assign_unused(TARGET_TYPE_SKY, -1, "ETC", tile_id, tile_id)
+        asgn.assign_unused(TARGET_TYPE_SUPPSKY, -1, "ETC", tile_id, tile_id)
         asgn.assign_unused(TARGET_TYPE_SAFE, -1, "ETC", tile_id, tile_id)
 
     gt.stop("run_assign_bytile calculation")

--- a/py/fiberassign/targets.py
+++ b/py/fiberassign/targets.py
@@ -28,6 +28,7 @@ from .utils import Logger, Timer
 
 from ._internal import (TARGET_TYPE_SCIENCE, TARGET_TYPE_SKY,
                         TARGET_TYPE_STANDARD, TARGET_TYPE_SAFE,
+                        TARGET_TYPE_SUPPSKY,
                         Target, Targets, TargetTree, TargetsAvailable,
                         LocationsAvailable)
 
@@ -37,6 +38,8 @@ def str_to_target_type(input):
         return TARGET_TYPE_SCIENCE
     elif input == "sky":
         return TARGET_TYPE_SKY
+    elif input == "suppsky":
+        return TARGET_TYPE_SUPPSKY
     elif input == "standard":
         return TARGET_TYPE_STANDARD
     elif input == "safe":
@@ -78,6 +81,14 @@ def default_main_skymask():
     skymask = 0
     skymask |= desi_mask["SKY"].mask
     return skymask
+
+
+def default_main_suppskymask():
+    """Returns default mask of bits for suppsky targets in main survey.
+    """
+    suppskymask = 0
+    suppskymask |= desi_mask["SUPP_SKY"].mask
+    return suppskymask
 
 
 def default_main_safemask():
@@ -179,6 +190,14 @@ def default_sv1_skymask():
     return skymask
 
 
+def default_sv1_suppskymask():
+    """Returns default mask of bits for suppsky targets in SV1 survey.
+    """
+    suppskymask = 0
+    suppskymask |= sv1_mask["SUPP_SKY"].mask
+    return suppskymask
+
+
 def default_sv1_safemask():
     """Returns default mask of bits for 'safe' targets in SV1 survey.
 
@@ -209,7 +228,6 @@ def default_cmx_sciencemask():
     sciencemask |= cmx_mask["STD_TEST"].mask
     sciencemask |= cmx_mask["STD_CALSPEC"].mask
     sciencemask |= cmx_mask["STD_DITHER"].mask
-    # SE: ADDED NEW CMX SCIENCE BITS From /desitarget/blob/0.32.0/py/desitarget/cmx/data/cmx_targetmask.yaml 
     sciencemask |= cmx_mask["STD_FAINT"].mask
     sciencemask |= cmx_mask["SV0_BGS"].mask
     sciencemask |= cmx_mask["SV0_MWS"].mask
@@ -217,9 +235,6 @@ def default_cmx_sciencemask():
     sciencemask |= cmx_mask["SV0_ELG"].mask
     sciencemask |= cmx_mask["SV0_QSO"].mask
     sciencemask |= cmx_mask["SV0_WD"].mask
-    
-    #SE: ADDED NEW FIRST_LIGHT SCEINCE TARGERTS FROM https://github.com/desihub/desitarget/blob/master/py/desitarget/cmx/data/cmx_targetmask.yaml#L19-L39
-    
     sciencemask |= cmx_mask["BACKUP_BRIGHT"].mask
     sciencemask |= cmx_mask["BACKUP_FAINT"].mask
     sciencemask |= cmx_mask["M31_STD_BRIGHT"].mask
@@ -247,7 +262,6 @@ def default_cmx_sciencemask():
     sciencemask |= cmx_mask["M33_M33cen"].mask
     sciencemask |= cmx_mask["M33_M33out"].mask
 
-
     return sciencemask
 
 
@@ -271,6 +285,14 @@ def default_cmx_skymask():
     return skymask
 
 
+def default_cmx_suppskymask():
+    """Returns default mask of bits for suppsky targets in CMX survey.
+    """
+    suppskymask = 0
+    suppskymask |= cmx_mask["SUPP_SKY"].mask
+    return suppskymask
+
+
 def default_cmx_safemask():
     """Returns default mask of bits for 'safe' targets in CMX survey.
 
@@ -290,7 +312,7 @@ def default_cmx_excludemask():
 
 
 def desi_target_type(desi_target, sciencemask, stdmask,
-                     skymask, safemask, excludemask):
+                     skymask, suppskymask, safemask, excludemask):
     """Determine fiber assign type from the data column.
 
     Args:
@@ -301,6 +323,8 @@ def desi_target_type(desi_target, sciencemask, stdmask,
             standards targets.
         skymask (int):  Integer value to bitwise-and when checking for
             sky targets.
+        suppskymask (int):  Integer value to bitwise-and when checking for
+            suppsky targets.
         safemask (int):  Integer value to bitwise-and when checking for
             safe targets.
         excludemask (int):  Integer value to bitwise-and when checking for
@@ -324,6 +348,8 @@ def desi_target_type(desi_target, sciencemask, stdmask,
             ttype |= TARGET_TYPE_STANDARD
         if desi_target & skymask != 0:
             ttype |= TARGET_TYPE_SKY
+        if desi_target & suppskymask != 0:
+            ttype |= TARGET_TYPE_SUPPSKY
         if desi_target & safemask != 0:
             ttype |= TARGET_TYPE_SAFE
         if desi_target & excludemask != 0:
@@ -334,6 +360,7 @@ def desi_target_type(desi_target, sciencemask, stdmask,
         ttype[desi_target & sciencemask != 0] |= TARGET_TYPE_SCIENCE
         ttype[desi_target & stdmask != 0] |= TARGET_TYPE_STANDARD
         ttype[desi_target & skymask != 0] |= TARGET_TYPE_SKY
+        ttype[desi_target & suppskymask != 0] |= TARGET_TYPE_SUPPSKY
         ttype[desi_target & safemask != 0] |= TARGET_TYPE_SAFE
         ttype[desi_target & excludemask != 0] = 0
 
@@ -354,27 +381,31 @@ def default_survey_target_masks(survey):
     sciencemask = None
     stdmask = None
     skymask = None
+    suppskymask = None
     safemask = None
     excludemask = None
     if survey == "main":
         sciencemask = default_main_sciencemask()
         stdmask = default_main_stdmask()
         skymask = default_main_skymask()
+        suppskymask = default_main_suppskymask()
         safemask = default_main_safemask()
         excludemask = default_main_excludemask()
     elif survey == "cmx":
         sciencemask = default_cmx_sciencemask()
         stdmask = default_cmx_stdmask()
         skymask = default_cmx_skymask()
+        suppskymask = default_cmx_suppskymask()
         safemask = default_cmx_safemask()
         excludemask = default_cmx_excludemask()
     elif survey == "sv1":
         sciencemask = default_sv1_sciencemask()
         stdmask = default_sv1_stdmask()
         skymask = default_sv1_skymask()
+        suppskymask = default_sv1_suppskymask()
         safemask = default_sv1_safemask()
         excludemask = default_sv1_excludemask()
-    return (sciencemask, stdmask, skymask, safemask, excludemask)
+    return (sciencemask, stdmask, skymask, suppskymask, safemask, excludemask)
 
 
 def default_target_masks(data):
@@ -399,14 +430,14 @@ def default_target_masks(data):
         col = filecols[0]
     elif filesurvey == "sv1":
         col = "SV1_DESI_TARGET"
-    sciencemask, stdmask, skymask, safemask, excludemask = \
+    sciencemask, stdmask, skymask, suppskymask, safemask, excludemask = \
         default_survey_target_masks(filesurvey)
-    return (filesurvey, col, sciencemask, stdmask, skymask, safemask,
-            excludemask)
+    return (filesurvey, col, sciencemask, stdmask, skymask, suppskymask,
+            safemask, excludemask)
 
 
 def append_target_table(tgs, tgdata, survey, typeforce, typecol, sciencemask,
-                        stdmask, skymask, safemask, excludemask):
+                        stdmask, skymask, suppskymask, safemask, excludemask):
     """Append a target recarray / table to a Targets object.
 
     This function is used to take a slice of targets table (as read from a
@@ -427,6 +458,8 @@ def append_target_table(tgs, tgdata, survey, typeforce, typecol, sciencemask,
             standards targets.
         skymask (int):  Integer value to bitwise-and when checking for
             sky targets.
+        suppskymask (int):  Integer value to bitwise-and when checking for
+            suppsky targets.
         safemask (int):  Integer value to bitwise-and when checking for
             safe targets.
         excludemask (int):  Integer value to bitwise-and when checking for
@@ -439,6 +472,7 @@ def append_target_table(tgs, tgdata, survey, typeforce, typecol, sciencemask,
     validtypes = [
         TARGET_TYPE_SCIENCE,
         TARGET_TYPE_SKY,
+        TARGET_TYPE_SUPPSKY,
         TARGET_TYPE_STANDARD,
         TARGET_TYPE_SAFE
     ]
@@ -479,8 +513,8 @@ def append_target_table(tgs, tgdata, survey, typeforce, typecol, sciencemask,
         else:
             d_bits[:] = tgdata[typecol][:]
             d_type[:] = desi_target_type(
-                tgdata[typecol], sciencemask, stdmask, skymask, safemask,
-                excludemask)
+                tgdata[typecol], sciencemask, stdmask, skymask, suppskymask,
+                safemask, excludemask)
 
     if "OBSCONDITIONS" in tgdata.dtype.fields:
         d_obscond[:] = tgdata["OBSCONDITIONS"][:]
@@ -516,7 +550,7 @@ def append_target_table(tgs, tgdata, survey, typeforce, typecol, sciencemask,
 
 def load_target_table(tgs, tgdata, survey=None, typeforce=None, typecol=None,
                       sciencemask=None, stdmask=None, skymask=None,
-                      safemask=None, excludemask=None):
+                      suppskymask=None, safemask=None, excludemask=None):
     """Append targets from a table.
 
     Use the table data to append targets to the input Targets object.
@@ -539,6 +573,7 @@ def load_target_table(tgs, tgdata, survey=None, typeforce=None, typecol=None,
         sciencemask (int): Bitmask for classifying targets as science.
         stdmask (int): Bitmask for classifying targets as a standard.
         skymask (int): Bitmask for classifying targets as sky.
+        suppskymask (int): Bitmask for classifying targets as suppsky.
         safemask (int): Bitmask for classifying targets as a safe location.
         excludemask (int): Bitmask for excluding targets.
 
@@ -589,6 +624,7 @@ def load_target_table(tgs, tgdata, survey=None, typeforce=None, typecol=None,
     fsciencemask = None
     fstdmask = None
     fskymask = None
+    fsuppskymask = None
     fsafemask = None
     fexcludemask = None
     if typecol == "FA_TYPE":
@@ -597,18 +633,19 @@ def load_target_table(tgs, tgdata, survey=None, typeforce=None, typecol=None,
                 specified"
             log.error(msg)
             raise RuntimeError(msg)
-        fsciencemask, fstdmask, fskymask, fsafemask, fexcludemask = \
-            default_survey_target_masks(survey)
+        fsciencemask, fstdmask, fskymask, fsuppskymask, fsafemask, \
+            fexcludemask = default_survey_target_masks(survey)
     else:
-        fsurvey, fcol, fsciencemask, fstdmask, fskymask, fsafemask, \
-            fexcludemask = default_target_masks(tgdata)
+        fsurvey, fcol, fsciencemask, fstdmask, fskymask, fsuppskymask, \
+            fsafemask, fexcludemask = default_target_masks(tgdata)
         if fcol is None:
             # File could not be identified.  In this case, the user must
             # completely specify the bitmask and column to use.
             if typeforce is None:
                 if (typecol is None) or (sciencemask is None) \
                         or (stdmask is None) or (skymask is None) \
-                        or (safemask is None) or (excludemask is None):
+                        or (suppskymask is None) or (safemask is None) \
+                        or (excludemask is None):
                     msg = "Unknown survey type.  To use this table, \
                         specify the column name and every bitmask."
                     log.error(msg)
@@ -624,6 +661,8 @@ def load_target_table(tgs, tgdata, survey=None, typeforce=None, typecol=None,
         stdmask = fstdmask
     if skymask is None:
         skymask = fskymask
+    if suppskymask is None:
+        suppskymask = fsuppskymask
     if safemask is None:
         safemask = fsafemask
     if excludemask is None:
@@ -638,6 +677,8 @@ def load_target_table(tgs, tgdata, survey=None, typeforce=None, typecol=None,
             "|".join(desi_mask.names(stdmask))))
         log.debug("  skymask     {}".format(
             "|".join(desi_mask.names(skymask))))
+        log.debug("  suppskymask     {}".format(
+            "|".join(desi_mask.names(suppskymask))))
         log.debug("  safemask    {}".format(
             "|".join(desi_mask.names(safemask))))
         log.debug("  excludemask {}".format(
@@ -649,6 +690,8 @@ def load_target_table(tgs, tgdata, survey=None, typeforce=None, typecol=None,
             "|".join(cmx_mask.names(stdmask))))
         log.debug("  skymask     {}".format(
             "|".join(cmx_mask.names(skymask))))
+        log.debug("  suppskymask     {}".format(
+            "|".join(cmx_mask.names(suppskymask))))
         log.debug("  safemask    {}".format(
             "|".join(cmx_mask.names(safemask))))
         log.debug("  excludemask {}".format(
@@ -660,6 +703,8 @@ def load_target_table(tgs, tgdata, survey=None, typeforce=None, typecol=None,
             "|".join(sv1_mask.names(stdmask))))
         log.debug("  skymask     {}".format(
             "|".join(sv1_mask.names(skymask))))
+        log.debug("  suppskymask     {}".format(
+            "|".join(sv1_mask.names(suppskymask))))
         log.debug("  safemask    {}".format(
             "|".join(sv1_mask.names(safemask))))
         log.debug("  excludemask {}".format(
@@ -667,13 +712,14 @@ def load_target_table(tgs, tgdata, survey=None, typeforce=None, typecol=None,
     else:
         raise RuntimeError("unknown survey type, should never get here!")
     append_target_table(tgs, tgdata, survey, typeforce, typecol, sciencemask,
-                        stdmask, skymask, safemask, excludemask)
+                        stdmask, skymask, suppskymask, safemask, excludemask)
     return
 
 
 def load_target_file(tgs, tfile, survey=None, typeforce=None, typecol=None,
                      sciencemask=None, stdmask=None, skymask=None,
-                     safemask=None, excludemask=None, rowbuffer=1000000):
+                     suppskymask=None, safemask=None, excludemask=None,
+                     rowbuffer=1000000):
     """Append targets from a file.
 
     Read the specified file and append targets to the input Targets object.
@@ -697,6 +743,7 @@ def load_target_file(tgs, tfile, survey=None, typeforce=None, typecol=None,
         sciencemask (int): Bitmask for classifying targets as science.
         stdmask (int): Bitmask for classifying targets as a standard.
         skymask (int): Bitmask for classifying targets as sky.
+        suppskymask (int): Bitmask for classifying targets as suppsky.
         safemask (int): Bitmask for classifying targets as a safe location.
         excludemask (int): Bitmask for excluding targets.
         rowbuffer (int): Optional number of rows to read at once when loading
@@ -736,7 +783,9 @@ def load_target_file(tgs, tfile, survey=None, typeforce=None, typecol=None,
                           typeforce=typeforce,
                           typecol=typecol,
                           sciencemask=sciencemask,
-                          stdmask=stdmask, skymask=skymask,
+                          stdmask=stdmask,
+                          skymask=skymask,
+                          suppskymask=suppskymask,
                           safemask=safemask,
                           excludemask=excludemask)
         offset += n

--- a/py/fiberassign/test/simulate.py
+++ b/py/fiberassign/test/simulate.py
@@ -21,7 +21,8 @@ from fiberassign.hardware import (load_hardware, FIBER_STATE_STUCK,
                                   FIBER_STATE_BROKEN)
 
 from fiberassign.targets import (TARGET_TYPE_SCIENCE, TARGET_TYPE_SKY,
-                                 TARGET_TYPE_STANDARD)
+                                 TARGET_TYPE_SUPPSKY,
+                                 TARGET_TYPE_SUPPSKY, TARGET_TYPE_STANDARD)
 
 
 def sim_data_dir():
@@ -167,6 +168,7 @@ def sim_targets(path, tgtype, tgoffset, density=5000.0):
     fdata["SUBPRIORITY"] = np.random.uniform(low=0.0, high=1.0, size=ntarget)
 
     sky_mask = desi_mask["SKY"].mask
+    suppsky_mask = desi_mask["SUPP_SKY"].mask
     std_mask = desi_mask["STD_BRIGHT"].mask
     # We could be fancier and set the DESI_TARGET bits for science targets
     # to exactly match the priority class.  For now we just set a single
@@ -180,6 +182,9 @@ def sim_targets(path, tgtype, tgoffset, density=5000.0):
     elif tgtype == TARGET_TYPE_STANDARD:
         fdata["PRIORITY"] = 1500 * np.ones(ntarget, dtype=np.int32)
         fdata["DESI_TARGET"] |= std_mask
+    elif tgtype == TARGET_TYPE_SUPPSKY:
+        fdata["PRIORITY"] = np.zeros(ntarget, dtype=np.int32)
+        fdata["DESI_TARGET"] |= suppsky_mask
     else:
         fdata["DESI_TARGET"] |= sci_mask
         # These are the fractions of each target type:

--- a/py/fiberassign/test/test_targets.py
+++ b/py/fiberassign/test/test_targets.py
@@ -18,6 +18,7 @@ from fiberassign.targets import (TARGET_TYPE_SCIENCE, TARGET_TYPE_SKY,
                                  TARGET_TYPE_STANDARD, load_target_file,
                                  desi_target_type, default_main_sciencemask,
                                  default_main_skymask, default_main_stdmask,
+                                 default_main_suppskymask,
                                  default_main_safemask,
                                  default_main_excludemask,
                                  Targets, TargetTree, TargetsAvailable,
@@ -86,8 +87,8 @@ class TestTargets(unittest.TestCase):
             ])
         result = desi_target_type(
             desi_target, default_main_sciencemask(), default_main_stdmask(),
-            default_main_skymask(), default_main_safemask(),
-            default_main_excludemask())
+            default_main_skymask(), default_main_suppskymask(),
+            default_main_safemask(), default_main_excludemask())
         self.assertTrue(np.all(result == fbatype))
 
         # Scalar inputs
@@ -95,26 +96,28 @@ class TestTargets(unittest.TestCase):
             result = desi_target_type(
                 desi_target[i],
                 default_main_sciencemask(), default_main_stdmask(),
-                default_main_skymask(), default_main_safemask(),
-                default_main_excludemask())
+                default_main_skymask(), default_main_suppskymask(),
+                default_main_safemask(), default_main_excludemask())
             self.assertEqual(result, fbatype[i])
 
         # Does excludemask work?
         mask = desi_mask["ELG"].mask
         result = desi_target_type(
             mask, default_main_sciencemask(), default_main_stdmask(),
-            default_main_skymask(), default_main_safemask(),
-            default_main_excludemask())
+            default_main_skymask(), default_main_suppskymask(),
+            default_main_safemask(), default_main_excludemask())
         self.assertEqual(result, TARGET_TYPE_SCIENCE)
 
         result = desi_target_type(
             mask, default_main_sciencemask(), default_main_stdmask(),
-            default_main_skymask(), default_main_safemask(), mask)
+            default_main_skymask(), default_main_suppskymask(),
+            default_main_safemask(), mask)
         self.assertEqual(result, 0)
 
         result = desi_target_type(
             [mask, mask], default_main_sciencemask(), default_main_stdmask(),
-            default_main_skymask(), default_main_safemask(), mask)
+            default_main_skymask(), default_main_suppskymask(),
+            default_main_safemask(), mask)
         self.assertTrue(not np.any(result))
 
 

--- a/py/fiberassign/test/test_targets.py
+++ b/py/fiberassign/test/test_targets.py
@@ -15,6 +15,7 @@ from fiberassign.hardware import load_hardware
 from fiberassign.tiles import load_tiles
 
 from fiberassign.targets import (TARGET_TYPE_SCIENCE, TARGET_TYPE_SKY,
+                                 TARGET_TYPE_SUPPSKY,
                                  TARGET_TYPE_STANDARD, load_target_file,
                                  desi_target_type, default_main_sciencemask,
                                  default_main_skymask, default_main_stdmask,
@@ -40,14 +41,21 @@ class TestTargets(unittest.TestCase):
         input_mtl = os.path.join(test_dir, "mtl.fits")
         input_std = os.path.join(test_dir, "standards.fits")
         input_sky = os.path.join(test_dir, "sky.fits")
-        nscience = sim_targets(input_mtl, TARGET_TYPE_SCIENCE, 0)
-        nstd = sim_targets(input_std, TARGET_TYPE_STANDARD, nscience)
-        nsky = sim_targets(input_sky, TARGET_TYPE_SKY, (nscience + nstd))
+        input_suppsky = os.path.join(test_dir, "suppsky.fits")
+        tgoff = 0
+        nscience = sim_targets(input_mtl, TARGET_TYPE_SCIENCE, tgoff)
+        tgoff += nscience
+        nstd = sim_targets(input_std, TARGET_TYPE_STANDARD, tgoff)
+        tgoff += nstd
+        nsky = sim_targets(input_sky, TARGET_TYPE_SKY, tgoff)
+        tgoff += nsky
+        nsuppsky = sim_targets(input_suppsky, TARGET_TYPE_SUPPSKY, tgoff)
 
         tgs = Targets()
         load_target_file(tgs, input_mtl)
         load_target_file(tgs, input_std)
         load_target_file(tgs, input_sky)
+        load_target_file(tgs, input_suppsky)
         print(tgs)
 
         # Create a hierarchical triangle mesh lookup of the targets positions
@@ -77,12 +85,14 @@ class TestTargets(unittest.TestCase):
             desi_mask["ELG"].mask,
             desi_mask["STD_FAINT"].mask,
             desi_mask["SKY"].mask,
+            desi_mask["SUPP_SKY"].mask,
             desi_mask["IN_BRIGHT_OBJECT"].mask,
             ]
         fbatype = np.array([
             TARGET_TYPE_SCIENCE,
             TARGET_TYPE_STANDARD,
             TARGET_TYPE_SKY,
+            TARGET_TYPE_SUPPSKY,
             0
             ])
         result = desi_target_type(

--- a/py/fiberassign/vis.py
+++ b/py/fiberassign/vis.py
@@ -33,6 +33,7 @@ from .tiles import load_tiles
 
 from .targets import (Targets, load_target_table,
                       TARGET_TYPE_SCIENCE, TARGET_TYPE_SKY,
+                      TARGET_TYPE_SUPPSKY,
                       TARGET_TYPE_STANDARD, TARGET_TYPE_SAFE)
 
 from .assign import (read_assignment_fits_tile, result_tiles, result_path,
@@ -46,6 +47,8 @@ def plot_target_type_color(tgtype):
         color = "black"
     elif (tp & TARGET_TYPE_SKY) != 0:
         color = "blue"
+    elif (tp & TARGET_TYPE_SUPPSKY) != 0:
+        color = "cyan"
     elif (tp & TARGET_TYPE_STANDARD) != 0:
         color = "gold"
         if (tp & TARGET_TYPE_SCIENCE) != 0:
@@ -506,9 +509,9 @@ def plot_qa(data, outroot, outformat="pdf", labels=False):
     fig = plt.figure(figsize=(12, 10))
 
     plot_param = [
-        ("Total Fibers Assigned Per Tile", "assign_total", 5000, 5),
-        ("Standards Assigned Per Tile", "assign_std", 100, 2),
-        ("Sky Assigned Per Tile", "assign_sky", 400, 2),
+        ("Total Fibers Assigned Per Tile", ["assign_total"], 5000, 5),
+        ("Standards Assigned Per Tile", ["assign_std"], 100, 2),
+        ("Sky Assigned Per Tile", ["assign_sky", "assign_suppsky"], 400, 2),
     ]
 
     pindx = 1
@@ -530,7 +533,8 @@ def plot_qa(data, outroot, outformat="pdf", labels=False):
                 ymax = ycent
             if ycent < ymin:
                 ymin = ycent
-            color = plot_qa_tile_color(desired, props[key], incr)
+            keytot = np.sum([props[x] for x in key])
+            color = plot_qa_tile_color(desired, keytot, incr)
             circ = plt.Circle((xcent, ycent), radius=tile_radius, fc="none",
                               ec=color, linewidth=linewidth)
             ax.add_artist(circ)

--- a/src/_pyfiberassign.cpp
+++ b/src/_pyfiberassign.cpp
@@ -35,6 +35,7 @@ PYBIND11_MODULE(_internal, m) {
     m.attr("TARGET_TYPE_SCIENCE") = py::int_(TARGET_TYPE_SCIENCE);
     m.attr("TARGET_TYPE_STANDARD") = py::int_(TARGET_TYPE_STANDARD);
     m.attr("TARGET_TYPE_SKY") = py::int_(TARGET_TYPE_SKY);
+    m.attr("TARGET_TYPE_SUPPSKY") = py::int_(TARGET_TYPE_SUPPSKY);
     m.attr("TARGET_TYPE_SAFE") = py::int_(TARGET_TYPE_SAFE);
 
     // Wrap the fiber states
@@ -1036,6 +1037,9 @@ PYBIND11_MODULE(_internal, m) {
         )")
         .def("is_sky", &fba::Target::is_sky, R"(
             Returns True if this is a sky target, else False.
+        )")
+        .def("is_suppsky", &fba::Target::is_suppsky, R"(
+            Returns True if this is a suppsky target, else False.
         )")
         .def("is_safe", &fba::Target::is_safe, R"(
             Returns True if this is a safe target, else False.

--- a/src/targets.cpp
+++ b/src/targets.cpp
@@ -24,6 +24,8 @@ std::string fba::target_string(uint8_t type) {
         ret = "standard";
     } else if (type == TARGET_TYPE_SAFE) {
         ret = "safe";
+    } else if (type == TARGET_TYPE_SUPPSKY) {
+        ret = "suppsky";
     } else {
         ret = "NA";
         throw std::runtime_error("Unknown target type");
@@ -81,6 +83,11 @@ bool fba::Target::is_sky() const {
 }
 
 
+bool fba::Target::is_suppsky() const {
+    return ((type & TARGET_TYPE_SUPPSKY) != 0);
+}
+
+
 bool fba::Target::is_safe() const {
     return ((type & TARGET_TYPE_SAFE) != 0);
 }
@@ -124,7 +131,7 @@ void fba::Targets::append(std::string const & tsurvey,
     for (size_t t = 0; t < id.size(); ++t) {
         if (type[t] == 0) {
             // This target is not one of the recognized categories (science,
-            // standard, sky, or safe).  Skip it.
+            // standard, sky, suppsky, or safe).  Skip it.
             logmsg.str("");
             logmsg << "Survey " << survey
                 << " target ID " << id[t]

--- a/src/targets.h
+++ b/src/targets.h
@@ -29,6 +29,7 @@ namespace fiberassign {
 #define TARGET_TYPE_STANDARD 2
 #define TARGET_TYPE_SKY 4
 #define TARGET_TYPE_SAFE 8
+#define TARGET_TYPE_SUPPSKY 16
 
 std::string target_string(uint8_t type);
 
@@ -69,6 +70,7 @@ class Target {
         bool is_science() const;
         bool is_standard() const;
         bool is_sky() const;
+        bool is_suppsky() const;
         bool is_safe() const;
         bool is_type(uint8_t t) const;
 


### PR DESCRIPTION
This adds support for a new target type (`SUPPSKY`).  These targets are assigned after normal `SKY` targets in order to meet the per-petal sky budget requirement.  The unit tests verify that in the case of under-dense sky targets, the suppsky targets are used instead.  See attached plot generated by the unit tests (blue == normal sky, cyan == suppsky).

This support in fiberassign requires that input targets can be differentiated between sky and suppsky.  I believe that current target files in use make this challenging (by setting both `SKY` and 'SUPP_SKY` target bits).

This PR should not be merged until that issue is clarified.