### PR TITLE
Fixes creation of sv1_sciencemask

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,7 +6,9 @@ fiberassign change log
 1.3.1 (unreleased)
 ------------------
 
-* No changes yet.
+* Fix issue with creation of SV1 science target mask (PR `#248`_).
+
+.. _`#248`: https://github.com/desihub/fiberassign/pull/248
 
 1.3.0 (2019-12-20)
 ------------------

--- a/py/fiberassign/targets.py
+++ b/py/fiberassign/targets.py
@@ -21,6 +21,7 @@ from desitarget.targetmask import desi_mask
 from desitarget.cmx.cmx_targetmask import cmx_mask
 
 from desitarget.sv1.sv1_targetmask import desi_mask as sv1_mask
+from desitarget.sv1.sv1_targetmask import scnd_mask as sv1_scnd_mask
 
 from desitarget.targets import main_cmx_or_sv
 
@@ -123,52 +124,8 @@ def default_sv1_sciencemask():
     sciencemask |= sv1_mask["MWS_ANY"].mask
     if "SCND_ANY" in sv1_mask.names():
         sciencemask |= sv1_mask["SCND_ANY"].mask
-        sciencemask |= sv1_mask['MWS_WD_SV']
-        sciencemask |= sv1_mask['MWS_SPECIAL_DRACO_SV']
-        sciencemask |= sv1_mask['MWS_SPECIAL_DDOGIANTS_SV']
-        sciencemask |= sv1_mask['MWS_SPECIAL_WDBINARY_SV']
-        sciencemask |= sv1_mask['MWS_SPECIAL_RRLYR_SV']
-        sciencemask |= sv1_mask['MWS_SPECIAL_HYADES_SV']
-        sciencemask |= sv1_mask['MWS_SPECIAL_GC_SV']
-        sciencemask |= sv1_mask['MWS_WD_SV_VERYBRIGHT']
-        sciencemask |= sv1_mask['MWS_SPECIAL_DDOGIANTS_VERYBRIGHT_SV']
-        sciencemask |= sv1_mask['MWS_SPECIAL_HYADES_VERYBRIGHT_SV']
-        sciencemask |= sv1_mask['MWS_SPECIAL_GC_VERYBRIGHT_SV']
-        sciencemask |= sv1_mask['MWS_CALIB_APOGEE']
-        sciencemask |= sv1_mask['MWS_CALIB_APOGEE_VERYBRIGHT']
-        sciencemask |= sv1_mask['MWS_CALIB_GAIAESO']
-        sciencemask |= sv1_mask['MWS_CALIB_GAIAESO_VERYBRIGHT']
-        sciencemask |= sv1_mask['MWS_CALIB_SEGUE']
-        sciencemask |= sv1_mask['MWS_CALIB_SEGUE_VERYBRIGHT']
-        sciencemask |= sv1_mask['MWS_CALIB_GALAH']
-        sciencemask |= sv1_mask['MWS_CALIB_GALAH_VERYBRIGHT']
-        sciencemask |= sv1_mask['MWS_CALIB_BOSS']
-        sciencemask |= sv1_mask['MWS_CALIB_BOSS_VERYBRIGHT']
-
     else:
         sciencemask |= sv1_mask["SECONDARY_ANY"].mask
-        sciencemask |= sv1_mask['MWS_WD_SV']
-        sciencemask |= sv1_mask['MWS_SPECIAL_DRACO_SV']
-        sciencemask |= sv1_mask['MWS_SPECIAL_DDOGIANTS_SV']
-        sciencemask |= sv1_mask['MWS_SPECIAL_WDBINARY_SV']
-        sciencemask |= sv1_mask['MWS_SPECIAL_RRLYR_SV']
-        sciencemask |= sv1_mask['MWS_SPECIAL_HYADES_SV']
-        sciencemask |= sv1_mask['MWS_SPECIAL_GC_SV']
-        sciencemask |= sv1_mask['MWS_WD_SV_VERYBRIGHT']
-        sciencemask |= sv1_mask['MWS_SPECIAL_DDOGIANTS_VERYBRIGHT_SV']
-        sciencemask |= sv1_mask['MWS_SPECIAL_HYADES_VERYBRIGHT_SV']
-        sciencemask |= sv1_mask['MWS_SPECIAL_GC_VERYBRIGHT_SV']
-        sciencemask |= sv1_mask['MWS_CALIB_APOGEE']
-        sciencemask |= sv1_mask['MWS_CALIB_APOGEE_VERYBRIGHT']
-        sciencemask |= sv1_mask['MWS_CALIB_GAIAESO']
-        sciencemask |= sv1_mask['MWS_CALIB_GAIAESO_VERYBRIGHT']
-        sciencemask |= sv1_mask['MWS_CALIB_SEGUE']
-        sciencemask |= sv1_mask['MWS_CALIB_SEGUE_VERYBRIGHT']
-        sciencemask |= sv1_mask['MWS_CALIB_GALAH']
-        sciencemask |= sv1_mask['MWS_CALIB_GALAH_VERYBRIGHT']
-        sciencemask |= sv1_mask['MWS_CALIB_BOSS']
-        sciencemask |= sv1_mask['MWS_CALIB_BOSS_VERYBRIGHT']
-
     return sciencemask
 
 

--- a/py/fiberassign/targets.py
+++ b/py/fiberassign/targets.py
@@ -21,7 +21,6 @@ from desitarget.targetmask import desi_mask
 from desitarget.cmx.cmx_targetmask import cmx_mask
 
 from desitarget.sv1.sv1_targetmask import desi_mask as sv1_mask
-from desitarget.sv1.sv1_targetmask import scnd_mask as sv1_scnd_mask
 
 from desitarget.targets import main_cmx_or_sv
 


### PR DESCRIPTION
The code to create `sv1_sciencemask` in `targets.py` was looking up `scnd_mask` bits in `desi_mask`. 

Unless I'm missing something, this doesn't work. This PR just removes those lines. `SCND_ANY` is being `OR-`ed, so all secondary targets are counted as science anyway.

If some secondary targets shouldn't be counted as science, an alternative would be to use a custom bitmask in place of `SCND_ANY`, based on just the whitelisted secondary bits.