### PR TITLE
 making lite merge default and full merge an option

### DIFF
--- a/py/fiberassign/scripts/merge.py
+++ b/py/fiberassign/scripts/merge.py
@@ -83,6 +83,12 @@ def parse_merge(optlist=None):
                         help="Do not copy the raw fiberassign HDUs to the "
                              "merged output.")
 
+    parser.add_argument("--full_merge", required=False, default=False,
+                        action="store_true",
+                        help="copy the TARGETS, FASSIGN and FTARGETS "
+                             "HDUs to the merged output.")
+
+
     args = None
     if optlist is None:
         args = parser.parse_args()
@@ -96,6 +102,7 @@ def parse_merge(optlist=None):
 
 
 def run_merge_init(args, comm=None):
+    
     """Initialize merging inputs.
 
     This uses the previously parsed options to load the input files needed.
@@ -145,11 +152,12 @@ def run_merge(args):
         None
 
     """
+
     tiles, columns = run_merge_init(args)
     merge_results(args.targets, args.sky, tiles, result_dir=args.dir,
                   result_prefix=args.prefix, result_split_dir=args.split,
                   out_dir=args.out, out_prefix=args.out_prefix,
-                  out_split_dir=args.out_split, columns=columns,
+                  out_split_dir=args.out_split, columns=columns, full_merge=args.full_merge,
                   copy_fba=(not args.skip_raw))
     return
 
@@ -177,6 +185,7 @@ def run_merge_mpi(args, comm):
         log.info("proc {} doing {} tiles".format(comm.rank, len(ptiles)))
         merge_results(args.targets, args.sky, ptiles, result_dir=args.dir,
                       result_prefix=args.prefix, out_dir=args.out,
-                      out_prefix=args.out_prefix, columns=columns,
+                      out_prefix=args.out_prefix, columns=columns,full_merge=args.full_merge,
                       copy_fba=(not args.skip_raw))
     return
+


### PR DESCRIPTION
@tskisner, @sbailey :

## Trivia:

As of few days ago, ICS accepts commissioning tiles that are much lighter in size than the origonal merged  fiberassign-0XXXXX.fits file (up to 90% lighter!). This was achieved in a postproduction step by redacting **three HDUs** out of 8 HDUs hat were traditionally written into the merged output; the redacted HDUs are: **TARGETS**, **FTARGETS**, **FASSIGN**. 

## This PR: 
Per @sbailey request, full merge is now a running option to be activated by adding **--full_merge** to fba_merge_results; e.g., 

`fba_merge_results --targets ./MTL_tile66000.fits --sky skies_tile66000.fits suppskies_tile66000.fits --dir ${odir} --full_merge`

not adding this --full_merge option would activate the default merging mode in which there are only 5 HDUs in the merged output:
`>>> a.info()`
`Filename: ./FAout/fiberassign-066000.fits`
`No.    Name      Ver    Type      Cards   Dimensions   Format`
`  0  PRIMARY       1 PrimaryHDU      35   ()      `
`  1  FIBERASSIGN    1 BinTableHDU    287   5000R x 125C   [K, I, J, J, J, J, D, D, E, E, E, E, E, E, K, B, 3A, E, E, I, J, D, J, J, I, J, 8A, J, 4A, E, E, 5E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, I, I, I, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, I, I, I, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, B, B, I, K, 2A, E, E, E, E, E, E, E, E, L, E, L, E, E, 1A, K, J, J, K, E, E, E, E, K, K, K]   `
  `2  SKY_MONITOR    1 BinTableHDU     85   20R x 24C   [J, J, I, K, J, J, K, B, D, D, E, E, 8A, J, I, J, J, D, E, E, E, E, E, E]   `
  `3  GFA_TARGETS    1 BinTableHDU    113   1937R x 38C   [J, K, J, J, D, D, E, E, 4A, E, E, E, E, E, E, K, 2A, E, E, E, E, E, E, E, E, E, E, E, E, E, E, K, E, K, I, I, I, I]   `
  `4  POTENTIAL_ASSIGNMENTS    1 BinTableHDU     43   422863R x 3C   [K, J, J]   `
  `5  FAVAIL        1 BinTableHDU     43   422863R x 3C   [J, J, K]   `

Originally I had a branch where --lite_merge was an option and default was the full merge; we can go back to that, if more desired.


