### PR TITLE
Used fixed rundate for unit tests and improve matplotlib backend selection

### DIFF
--- a/py/fiberassign/test/simulate.py
+++ b/py/fiberassign/test/simulate.py
@@ -24,6 +24,7 @@ from fiberassign.targets import (TARGET_TYPE_SCIENCE, TARGET_TYPE_SKY,
                                  TARGET_TYPE_SUPPSKY,
                                  TARGET_TYPE_SUPPSKY, TARGET_TYPE_STANDARD)
 
+test_assign_date = "2020-01-01T00:00:00"
 
 def sim_data_dir():
     dir = "test_fiberassign_output"
@@ -53,9 +54,12 @@ def sim_science_fractions():
     ]
 
 
-def sim_focalplane(runtime=None, fakepos=False):
-    if runtime is None:
+def sim_focalplane(rundate=None, fakepos=False):
+    runtime = None
+    if rundate is None:
         runtime = datetime.utcnow()
+    else:
+        runtime = datetime.strptime(rundate, "%Y-%m-%dT%H:%M:%S")
 
     # First get the starting focalplane from desimodel
     fp, exclude, state, tmstr = dmio.load_focalplane(runtime)

--- a/py/fiberassign/test/test_assign.py
+++ b/py/fiberassign/test/test_assign.py
@@ -47,7 +47,7 @@ from fiberassign.scripts.qa_plot import parse_plot_qa, run_plot_qa
 
 
 from .simulate import (test_subdir_create, sim_tiles, sim_targets,
-                       sim_focalplane, petal_rotation)
+                       sim_focalplane, petal_rotation, test_assign_date)
 
 
 class TestAssign(unittest.TestCase):
@@ -107,7 +107,7 @@ class TestAssign(unittest.TestCase):
         tree = TargetTree(tgs, 0.01)
 
         # Compute the targets available to each fiber for each tile.
-        fp, exclude, state = sim_focalplane()
+        fp, exclude, state = sim_focalplane(rundate=test_assign_date)
         hw = load_hardware(focalplane=(fp, exclude, state))
         tfile = os.path.join(test_dir, "footprint.fits")
         sim_tiles(tfile)
@@ -340,7 +340,7 @@ class TestAssign(unittest.TestCase):
         tree = TargetTree(tgs, 0.01)
 
         # Read hardware properties
-        fp, exclude, state = sim_focalplane()
+        fp, exclude, state = sim_focalplane(rundate=test_assign_date)
         hw = load_hardware(focalplane=(fp, exclude, state))
         tfile = os.path.join(test_dir, "footprint.fits")
         sim_tiles(tfile)
@@ -451,7 +451,8 @@ class TestAssign(unittest.TestCase):
             "footprint": tfile,
             "standards_per_petal": 10,
             "sky_per_petal": 40,
-            "overwrite": True
+            "overwrite": True,
+            "rundate": test_assign_date
         }
         optlist = option_list(opts)
         args = parse_assign(optlist)
@@ -463,7 +464,8 @@ class TestAssign(unittest.TestCase):
             "footprint": tfile,
             "dir": test_dir,
             "petals": plotpetals,
-            "serial": True
+            "serial": True,
+            "rundate": test_assign_date
         }
         optlist = option_list(opts)
         args = parse_plot(optlist)
@@ -560,7 +562,7 @@ class TestAssign(unittest.TestCase):
                 tile_ids = list(tiles.id)
 
             # Simulate a fake focalplane
-            fp, exclude, state = sim_focalplane(fakepos=True)
+            fp, exclude, state = sim_focalplane(rundate=test_assign_date, fakepos=True)
 
             # Load the focalplane
             hw = load_hardware(focalplane=(fp, exclude, state))

--- a/py/fiberassign/test/test_hardware.py
+++ b/py/fiberassign/test/test_hardware.py
@@ -10,6 +10,8 @@ from fiberassign.utils import Timer
 
 from fiberassign.hardware import load_hardware
 
+from .simulate import test_assign_date
+
 
 class TestHardware(unittest.TestCase):
 
@@ -20,7 +22,7 @@ class TestHardware(unittest.TestCase):
         pass
 
     def test_read(self):
-        hw = load_hardware()
+        hw = load_hardware(rundate=test_assign_date)
         print(hw)
         locs = hw.locations
         cs5 = hw.loc_pos_cs5_mm
@@ -32,7 +34,7 @@ class TestHardware(unittest.TestCase):
         return
 
     def test_collision_xy(self):
-        hw = load_hardware()
+        hw = load_hardware(rundate=test_assign_date)
         center_mm = hw.loc_pos_curved_mm
         locs = hw.locations
         nrot = 100
@@ -51,7 +53,7 @@ class TestHardware(unittest.TestCase):
         return
 
     def test_collision_thetaphi(self):
-        hw = load_hardware()
+        hw = load_hardware(rundate=test_assign_date)
         locs = hw.locations
         ntheta = 10
         nphi = 10

--- a/py/fiberassign/test/test_qa.py
+++ b/py/fiberassign/test/test_qa.py
@@ -39,7 +39,7 @@ from fiberassign.assign import (Assignment, write_assignment_fits,
 
 from fiberassign.qa import qa_tiles, qa_targets
 
-from fiberassign.vis import plot_tiles, plot_qa
+from fiberassign.vis import plot_tiles, plot_qa, set_matplotlib_pdf_backend
 
 from fiberassign.scripts.assign import parse_assign, run_assign_full
 
@@ -51,7 +51,7 @@ from fiberassign.scripts.qa_plot import parse_plot_qa, run_plot_qa
 
 
 from .simulate import (test_subdir_create, sim_tiles, sim_targets,
-                       sim_focalplane, petal_rotation)
+                       sim_focalplane, petal_rotation, test_assign_date)
 
 
 class TestQA(unittest.TestCase):
@@ -67,6 +67,7 @@ class TestQA(unittest.TestCase):
         pass
 
     def test_science(self):
+        set_matplotlib_pdf_backend()
         import matplotlib.pyplot as plt
         test_dir = test_subdir_create("qa_test_science")
         log_file = os.path.join(test_dir, "log.txt")
@@ -96,7 +97,7 @@ class TestQA(unittest.TestCase):
         tree = TargetTree(tgs, 0.01)
 
         # Read hardware properties
-        fp, exclude, state = sim_focalplane()
+        fp, exclude, state = sim_focalplane(rundate=test_assign_date)
         hw = load_hardware(focalplane=(fp, exclude, state))
         tfile = os.path.join(test_dir, "footprint.fits")
         sim_tiles(tfile)

--- a/py/fiberassign/test/test_targets.py
+++ b/py/fiberassign/test/test_targets.py
@@ -25,7 +25,7 @@ from fiberassign.targets import (TARGET_TYPE_SCIENCE, TARGET_TYPE_SKY,
                                  Targets, TargetTree, TargetsAvailable,
                                  LocationsAvailable)
 
-from .simulate import (test_subdir_create, sim_tiles, sim_targets)
+from .simulate import (test_subdir_create, sim_tiles, sim_targets, test_assign_date)
 
 
 class TestTargets(unittest.TestCase):

--- a/py/fiberassign/test/test_tiles.py
+++ b/py/fiberassign/test/test_tiles.py
@@ -10,7 +10,11 @@ from fiberassign.hardware import load_hardware
 
 from fiberassign.tiles import load_tiles
 
-from .simulate import test_subdir_create, sim_tiles
+from .simulate import (
+    test_subdir_create,
+    sim_tiles,
+    test_assign_date
+)
 
 from astropy.table import Table
 from astropy.time import Time

--- a/py/fiberassign/test/test_vis.py
+++ b/py/fiberassign/test/test_vis.py
@@ -11,10 +11,16 @@ import numpy as np
 
 from fiberassign.hardware import load_hardware
 
-from fiberassign.vis import (plot_positioner, plot_positioner_simple, Shape)
+from fiberassign.vis import (
+    plot_positioner,
+    plot_positioner_simple,
+    Shape,
+    set_matplotlib_pdf_backend
+)
 
-from .simulate import test_subdir_create, sim_focalplane
+from .simulate import test_subdir_create, sim_focalplane, test_assign_date
 
+set_matplotlib_pdf_backend()
 import matplotlib.pyplot as plt
 
 
@@ -140,7 +146,7 @@ class TestVis(unittest.TestCase):
 
     def test_plotpos(self):
         test_dir = test_subdir_create("vis_test_plotpos")
-        time = datetime.utcnow().isoformat(timespec="seconds")
+        time = test_assign_date
         suffix = "{}_simple".format(time)
         self._load_and_plotpos(time, test_dir, suffix, simple=True)
         suffix = "{}".format(time)
@@ -216,10 +222,7 @@ class TestVis(unittest.TestCase):
 
     def test_plotfp(self):
         test_dir = test_subdir_create("vis_test_plotfp")
-        try:
-            time = datetime.utcnow().isoformat(timespec="seconds")
-        except TypeError:
-            time = datetime.utcnow().isoformat()
+        time = test_assign_date
         hw = load_hardware(rundate=time)
         suffix = "{}_simple".format(time)
         self._load_and_plotfp(hw, test_dir, suffix, simple=True)
@@ -235,10 +238,10 @@ class TestVis(unittest.TestCase):
 
     def test_plot_fakefp(self):
         test_dir = test_subdir_create("vis_test_fakefp")
-        time = datetime.utcnow().isoformat(timespec="seconds")
+        time = test_assign_date
 
         # Simulate a fake focalplane
-        fp, exclude, state = sim_focalplane(fakepos=True)
+        fp, exclude, state = sim_focalplane(rundate=test_assign_date, fakepos=True)
 
         # Load the focalplane
         hw = load_hardware(focalplane=(fp, exclude, state))

--- a/py/fiberassign/vis.py
+++ b/py/fiberassign/vis.py
@@ -47,9 +47,7 @@ def set_matplotlib_pdf_backend():
         return
     try:
         import matplotlib
-        warnings.simplefilter("ignore")
-        matplotlib.use("pdf")
-        warnings.simplefilter("default")
+        matplotlib.use("pdf", warn=False)
         import matplotlib.pyplot as plt
     except:
         warnings.warn(

--- a/py/fiberassign/vis.py
+++ b/py/fiberassign/vis.py
@@ -10,13 +10,9 @@ Visualization tools.
 from __future__ import absolute_import, division, print_function
 
 import os
+import warnings
 
 import numpy as np
-
-import matplotlib
-matplotlib.use("pdf")
-import matplotlib.pyplot as plt
-from matplotlib.patches import Patch
 
 import multiprocessing as mp
 from functools import partial
@@ -38,6 +34,30 @@ from .targets import (Targets, load_target_table,
 
 from .assign import (read_assignment_fits_tile, result_tiles, result_path,
                      avail_table_to_dict)
+
+plt = None
+
+def set_matplotlib_pdf_backend():
+    """Set the matplotlib backend to PDF.
+
+    This is necessary to render high resolution figures.
+    """
+    global plt
+    if plt is not None:
+        return
+    try:
+        import matplotlib
+        warnings.simplefilter("ignore")
+        matplotlib.use("pdf")
+        warnings.simplefilter("default")
+        import matplotlib.pyplot as plt
+    except:
+        warnings.warn(
+            """Couldn't set the PDF matplotlib backend,
+positioner plots may be low resolution.
+Proceeding with the default matplotlib backend."""
+        )
+        import matplotlib.pyplot as plt
 
 
 def plot_target_type_color(tgtype):
@@ -62,6 +82,7 @@ def plot_positioner(ax, patrol_rad, loc, center, shptheta, shpphi, color="k",
                     linewidth=0.2):
     """Plot one fiber positioner.
     """
+    set_matplotlib_pdf_backend()
     patrol = plt.Circle((center[0], center[1]), radius=patrol_rad, fc=color,
                         ec="none", alpha=0.1)
     ax.add_artist(patrol)
@@ -113,6 +134,7 @@ def plot_positioner_simple(ax, patrol_rad, loc, center, theta_ang, theta_arm,
     speed up the plotting.
 
     """
+    set_matplotlib_pdf_backend()
     patrol = plt.Circle((center[0], center[1]), radius=patrol_rad, fc=color,
                         ec="none", alpha=0.1)
     ax.add_artist(patrol)
@@ -285,6 +307,7 @@ def plot_assignment_tile_file_initialize(hw):
 
 def plot_assignment_tile_file(locs, real_shapes, params):
     (tile_id, tile_ra, tile_dec, tile_theta, infile, outfile) = params
+    set_matplotlib_pdf_backend()
     log = Logger.get()
 
     if os.path.isfile(outfile):
@@ -432,6 +455,7 @@ def plot_tiles(hw, tiles, result_dir=".", result_prefix="fiberassign-",
 def plot_assignment_tile(hw, tgs, tile_id, tile_ra, tile_dec, tile_theta,
                          tile_assign, tile_avail=None, petals=None,
                          real_shapes=False, outfile=None, figsize=8):
+    set_matplotlib_pdf_backend()
     # Get selected fibers
     locs = None
     if petals is None:
@@ -502,6 +526,10 @@ def plot_qa_tile_color(desired, value, incr):
 def plot_qa(data, outroot, outformat="pdf", labels=False):
     """Make plots of QA data.
     """
+    set_matplotlib_pdf_backend()
+    # Imported here, to ensure that the backend has been set.
+    from matplotlib.patches import Patch
+
     hw = load_hardware()
     tile_radius = hw.focalplane_radius_deg
 

--- a/src/_pyfiberassign.cpp
+++ b/src/_pyfiberassign.cpp
@@ -1127,6 +1127,9 @@ PYBIND11_MODULE(_internal, m) {
         .def("is_safe", &fba::Target::is_safe, R"(
             Returns True if this is a safe target, else False.
         )")
+        .def("total_priority", &fba::Target::total_priority, R"(
+            Return the total priority based on PRIORITY, SUBPRIORITY, and obs remaining.
+        )")
         .def("__repr__",
             [](fba::Target const & tg) {
                 std::ostringstream o;


### PR DESCRIPTION
This PR does 2 unrelated things (mea culpa).  The first is just to place the matplotlib backend selection into a function which is called by the visualization routines and attempts to set the backend to "PDF", so that vector plots of the positioners look OK.  If the backend is already selected (which will be the case for jupyter notebooks), then it just prints a warning and moves on.

The second change is updating the unit tests to use a nominal fixed hardware model prior to commissioning, rather than the current state in desimodel.