### PR TITLE
Fix positioner angle range checks.

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -3,11 +3,19 @@
 fiberassign change log
 ======================
 
-1.4.0 (unreleased)
+1.4.1 (unreleased)
 ------------------
 
-* No changes yet.
+* Fix bug in the range checking of positioner theta / phi angles (PR `#267`_).
+* Move the checks for positioner reachability from the assignment code to the
+  TargetsAvailable class (PR `#264`_).
+* Use a specific rundate for unit tests, to ensure consistent focalplane
+  model (PR `#262`_).
 
+.. _`#267`: https://github.com/desihub/fiberassign/pull/267
+.. _`#264`: https://github.com/desihub/fiberassign/pull/264
+.. _`#262`: https://github.com/desihub/fiberassign/pull/262
+  
 1.4.0 (2020-03-19)
 ------------------
 

--- a/py/fiberassign/test/test_hardware.py
+++ b/py/fiberassign/test/test_hardware.py
@@ -4,7 +4,11 @@ Test fiberassign target operations.
 
 import unittest
 
+from datetime import datetime
+
 import numpy as np
+
+import desimodel.io as dmio
 
 from fiberassign.utils import Timer
 
@@ -68,6 +72,104 @@ class TestHardware(unittest.TestCase):
                 result = hw.check_collisions_thetaphi(locs, theta, phi, 0)
         tm.stop()
         tm.report("check_collisions_thetaphi 100 configurations")
+        return
+
+    def test_thetaphi_range(self):
+        # Function to test that all positioners can reach a circle of
+        # targets at fixed distance from their center.
+        def check_reachable(hrdw, radius, increments, log_fail=True):
+            centers = hw.loc_pos_curved_mm
+            theta_arms = hw.loc_theta_arm
+            phi_arms = hw.loc_phi_arm
+            theta_mins = hw.loc_theta_min
+            theta_maxs = hw.loc_theta_max
+            theta_offsets = hw.loc_theta_offset
+            phi_mins = hw.loc_phi_min
+            phi_maxs = hw.loc_phi_max
+            phi_offsets = hw.loc_phi_offset
+
+            n_failed = 0
+            for loc in hw.locations:
+                center = centers[loc]
+                theta_arm = theta_arms[loc]
+                phi_arm = phi_arms[loc]
+                theta_min = theta_mins[loc]
+                theta_max = theta_maxs[loc]
+                theta_offset = theta_offsets[loc]
+                phi_min = phi_mins[loc]
+                phi_max = phi_maxs[loc]
+                phi_offset = phi_offsets[loc]
+                ang = np.arange(increments) / (2 * np.pi)
+                test_x = radius * np.cos(ang) + center[0]
+                test_y = radius * np.sin(ang) + center[1]
+                for xy in zip(test_x, test_y):
+                    result = hrdw.xy_to_thetaphi(
+                        center,
+                        xy,
+                        theta_arm,
+                        phi_arm,
+                        theta_offset,
+                        phi_offset,
+                        theta_min,
+                        phi_min,
+                        theta_max,
+                        phi_max
+                    )
+                    if result[0] is None or result[1] is None:
+                        if log_fail:
+                            print(
+                                "loc {} at ({}, {}) cannot reach ({}, {})".format(
+                                    loc, center[0], center[1], xy[0], xy[1]
+                                ), flush=True
+                            )
+                        n_failed += 1
+                        break
+                    else:
+                        if not log_fail:
+                            # log success instead
+                            print(
+                                "loc {} at ({}, {}) to ({}, {}) with ({}, {})".format(
+                                    loc, center[0], center[1],
+                                    xy[0], xy[1],
+                                    result[0]*180.0/np.pi, result[1]*180.0/np.pi
+                                ), flush=True
+                            )
+            return n_failed
+
+        # Test nominal focalplane
+        hw = load_hardware(rundate=test_assign_date)
+        failed = check_reachable(hw, 3.0, 100)
+        if (failed > 0):
+            print(
+                "{} positioners failed to reach ring at 3mm from center".format(
+                    failed
+                ),
+                flush=True
+            )
+            self.assertTrue(False)
+
+        # Now we are going to artificially restrict the phi angle range and test that
+        # we cannot access the outer areas of the patrol radius.
+        runtime = datetime.strptime(test_assign_date, "%Y-%m-%dT%H:%M:%S")
+        fp, exclude, state, tmstr = dmio.load_focalplane(runtime)
+
+        limit_radius = 2.0
+        open_limit = 2.0 * np.arcsin(0.5 * limit_radius / 3.0)
+        phi_limit_min = (np.pi - open_limit) * 180.0 / np.pi
+
+        new_min = phi_limit_min - np.array(fp["OFFSET_P"])
+        fp["MIN_P"][:] = new_min
+
+        hw = load_hardware(focalplane=(fp, exclude, state))
+        failed = check_reachable(hw, 3.0, 100, log_fail=False)
+        if (failed != len(hw.locations)):
+            print(
+                "{} positioners reached 3mm from center, despite restricted phi".format(
+                    len(hw.locations) - failed
+                ),
+                flush=True
+            )
+            self.assertTrue(False)
         return
 
 def test_suite():

--- a/src/_pyfiberassign.cpp
+++ b/src/_pyfiberassign.cpp
@@ -656,6 +656,10 @@ PYBIND11_MODULE(_internal, m) {
                       &fba::Hardware::neighbor_radius_mm, R"(
             Radius for considering locations as neighbors.
         )")
+        .def_readonly("patrol_buffer_mm",
+                      &fba::Hardware::patrol_buffer_mm, R"(
+            Buffer to subtract from full patrol radius when considering targets.
+        )")
         .def_readonly("state", &fba::Hardware::state, R"(
             Dictionary of fiber state for each location.
         )")


### PR DESCRIPTION
This work:

  - Handles the case of arbitrary positioner theta / phi
    offsets and min / max.

  - Adds a unit test which attempts to move every positioner
    to a circle of spots halfway from the center to the patrol
    radius.  It also verifies intended failure in the case of
    restricted phi range.

Attached are plots of "*unreachable targets*" computed by taking uniform random RA / DEC points with a density of 50K per sq. deg. and computing the targets available for each positioner.  Then these available targets were removed from the input sample and the remaining targets were plotted.  Starting with the old legacy focalplane model (with equal 3mm arm lengths) you can see good coverage across the patrol radius.  With the more realistic focalplane, you can see some unreachable targets near the center of each positioner and more around the edge of the patrol radius due to varying arm lengths.  The final plot shows the commissioning focalplane with restricted phi range.  Compare these plots to the ones in #266.

Note to @Srheft and @djschlegel , the current master branch did **NOT** apply the phi angle restriction correctly, which means that previous runs did not limit the phi range properly.  This likely explains why you were assigning targets that were then rejected by the online system.  This is now fixed, as you can see in the plots.

![unreachable_2012-06-01](https://user-images.githubusercontent.com/84221/81344892-727ec600-906c-11ea-8224-cd49f04a187f.png)
![unreachable_2020-01-01](https://user-images.githubusercontent.com/84221/81344913-77437a00-906c-11ea-898f-96dd11f0cb01.png)
![unreachable_2020-04-01](https://user-images.githubusercontent.com/84221/81344922-7ca0c480-906c-11ea-89ac-12fbffb454ab.png)

Closes #266.