### PR TITLE
Remove redundant ORs with mws scnd bits

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -11,10 +11,12 @@ fiberassign change log
   TargetsAvailable class (PR `#264`_).
 * Use a specific rundate for unit tests, to ensure consistent focalplane
   model (PR `#262`_).
+* Simplify handling of MWS secondary bits in creating sv1_sciencemask (PR `#268`_).
 
-.. _`#267`: https://github.com/desihub/fiberassign/pull/267
-.. _`#264`: https://github.com/desihub/fiberassign/pull/264
 .. _`#262`: https://github.com/desihub/fiberassign/pull/262
+.. _`#264`: https://github.com/desihub/fiberassign/pull/264
+.. _`#267`: https://github.com/desihub/fiberassign/pull/267
+.. _`#268`: https://github.com/desihub/fiberassign/pull/268
   
 1.4.0 (2020-03-19)
 ------------------

--- a/py/fiberassign/targets.py
+++ b/py/fiberassign/targets.py
@@ -125,51 +125,8 @@ def default_sv1_sciencemask():
 
     if "SCND_ANY" in desi_mask.names():
         sciencemask |= desi_mask["SCND_ANY"].mask
-        sciencemask |= sv1_scnd_mask['MWS_WD_SV']
-        sciencemask |= sv1_scnd_mask['MWS_SPECIAL_DRACO_SV']
-        sciencemask |= sv1_scnd_mask['MWS_SPECIAL_DDOGIANTS_SV']
-        sciencemask |= sv1_scnd_mask['MWS_SPECIAL_WDBINARY_SV']
-        sciencemask |= sv1_scnd_mask['MWS_SPECIAL_RRLYR_SV']
-        sciencemask |= sv1_scnd_mask['MWS_SPECIAL_HYADES_SV']
-        sciencemask |= sv1_scnd_mask['MWS_SPECIAL_GC_SV']
-        sciencemask |= sv1_scnd_mask['MWS_WD_SV_VERYBRIGHT']
-        sciencemask |= sv1_scnd_mask['MWS_SPECIAL_DDOGIANTS_VERYBRIGHT_SV']
-        sciencemask |= sv1_scnd_mask['MWS_SPECIAL_HYADES_VERYBRIGHT_SV']
-        sciencemask |= sv1_scnd_mask['MWS_SPECIAL_GC_VERYBRIGHT_SV']
-        sciencemask |= sv1_scnd_mask['MWS_CALIB_APOGEE']
-        sciencemask |= sv1_scnd_mask['MWS_CALIB_APOGEE_VERYBRIGHT']
-        sciencemask |= sv1_scnd_mask['MWS_CALIB_GAIAESO']
-        sciencemask |= sv1_scnd_mask['MWS_CALIB_GAIAESO_VERYBRIGHT']
-        sciencemask |= sv1_scnd_mask['MWS_CALIB_SEGUE']
-        sciencemask |= sv1_scnd_mask['MWS_CALIB_SEGUE_VERYBRIGHT']
-        sciencemask |= sv1_scnd_mask['MWS_CALIB_GALAH']
-        sciencemask |= sv1_scnd_mask['MWS_CALIB_GALAH_VERYBRIGHT']
-        sciencemask |= sv1_scnd_mask['MWS_CALIB_BOSS']
-        sciencemask |= sv1_scnd_mask['MWS_CALIB_BOSS_VERYBRIGHT']
-
     else:
         sciencemask |= desi_mask["SECONDARY_ANY"].mask
-        sciencemask |= sv1_scnd_mask['MWS_WD_SV']
-        sciencemask |= sv1_scnd_mask['MWS_SPECIAL_DRACO_SV']
-        sciencemask |= sv1_scnd_mask['MWS_SPECIAL_DDOGIANTS_SV']
-        sciencemask |= sv1_scnd_mask['MWS_SPECIAL_WDBINARY_SV']
-        sciencemask |= sv1_scnd_mask['MWS_SPECIAL_RRLYR_SV']
-        sciencemask |= sv1_scnd_mask['MWS_SPECIAL_HYADES_SV']
-        sciencemask |= sv1_scnd_mask['MWS_SPECIAL_GC_SV']
-        sciencemask |= sv1_scnd_mask['MWS_WD_SV_VERYBRIGHT']
-        sciencemask |= sv1_scnd_mask['MWS_SPECIAL_DDOGIANTS_VERYBRIGHT_SV']
-        sciencemask |= sv1_scnd_mask['MWS_SPECIAL_HYADES_VERYBRIGHT_SV']
-        sciencemask |= sv1_scnd_mask['MWS_SPECIAL_GC_VERYBRIGHT_SV']
-        sciencemask |= sv1_scnd_mask['MWS_CALIB_APOGEE']
-        sciencemask |= sv1_scnd_mask['MWS_CALIB_APOGEE_VERYBRIGHT']
-        sciencemask |= sv1_scnd_mask['MWS_CALIB_GAIAESO']
-        sciencemask |= sv1_scnd_mask['MWS_CALIB_GAIAESO_VERYBRIGHT']
-        sciencemask |= sv1_scnd_mask['MWS_CALIB_SEGUE']
-        sciencemask |= sv1_scnd_mask['MWS_CALIB_SEGUE_VERYBRIGHT']
-        sciencemask |= sv1_scnd_mask['MWS_CALIB_GALAH']
-        sciencemask |= sv1_scnd_mask['MWS_CALIB_GALAH_VERYBRIGHT']
-        sciencemask |= sv1_scnd_mask['MWS_CALIB_BOSS']
-        sciencemask |= sv1_scnd_mask['MWS_CALIB_BOSS_VERYBRIGHT']
 
     return sciencemask
 


### PR DESCRIPTION
The creation of `sv1_sciencemask` in `targets.py` involves the following:

```python
if "SCND_ANY" in desi_mask.names():
        sciencemask |= desi_mask["SCND_ANY"].mask
        sciencemask |= sv1_scnd_mask['MWS_WD_SV']
        sciencemask |= sv1_scnd_mask['MWS_SPECIAL_DRACO_SV']
        :
        :  
        : etc.
 else:
        sciencemask |= desi_mask["SECONDARY_ANY"].mask
        sciencemask |= sv1_scnd_mask['MWS_WD_SV']
        sciencemask |= sv1_scnd_mask['MWS_SPECIAL_DRACO_SV']
        :
        : 
        : etc. 
```

Since all targets with `SCND_ANY` are `|=`'d on the first line, the subsequent `|=`'s with individual MWS secondary bits don't have any effect (any of those bits being set implies `SNCD_ANY` is set). This PR just removes those lines.

The following points are redundant after that change, but for completeness:
- Even if it was necessary to `|=` against the MWS bits, there's no need to do that inside the `if`, which seems only to be there to deal with the name of `SCND_ANY`;
- Maintaining a separate list of secondary bits inside FA is hard to maintain, because it requires lock-step updates with any changes to the mask in `desitarget` (this was the motivation for the PR).

There may be good reasons to remove the check on `SCND_ANY` and only whitelist (or perhaps blacklist) individual bits, if some of the SCND targets shouldn't be part of the 'science mask' (e.g. `VETO`?). I think that's a separate problem.

(If this looks familiar: the same change was suggested alongside an actual bugfix in a previous PR. Before that PR was reviewed, the bug was fixed separately, so the PR got deleted as a duplicate.)
