### PR TITLE
fix tests and bin/qa-fiberassign

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Compiled files
 *.py[co]
+*.so
 
 # Other generated files
 htmlcov

--- a/bin/qa-fiberassign
+++ b/bin/qa-fiberassign
@@ -22,8 +22,6 @@ from desitarget.sv1.sv1_targetmask import desi_mask as sv1_mask
 
 from desitarget.targets import main_cmx_or_sv
 
-from fiberassign.targets import default_survey_target_masks
-
 from fiberassign.targets import (TARGET_TYPE_SKY, TARGET_TYPE_SAFE, desi_target_type,
                       default_target_masks, default_survey_target_masks)
 
@@ -86,10 +84,11 @@ for filename in args.tilefiles:
     col=None
     if survey is not None:
             
-        sciencemask, stdmask, skymask, safemask, excludemask = default_survey_target_masks(survey)
+        sciencemask, stdmask, skymask, suppskymask, safemask, excludemask = \
+                default_survey_target_masks(survey)
   
     else:
-        fsurvey, col, sciencemask, stdmask, skymask, safemask, \
+        fsurvey, col, sciencemask, stdmask, skymask, suppskymask, safemask, \
                 excludemask = default_target_masks(fbtargets)
         survey = fsurvey
 

--- a/py/fiberassign/targets.py
+++ b/py/fiberassign/targets.py
@@ -345,8 +345,8 @@ def default_survey_target_masks(survey):
         survey (str): The survey name.
 
     Returns:
-        (tuple): The science mask, standard mask, sky mask, safe mask,
-            and exclude mask for the data.
+        (tuple): The science mask, standard mask, sky mask, suppsky mask,
+            safe mask, and exclude mask for the data.
 
     """
     sciencemask = None
@@ -390,7 +390,7 @@ def default_target_masks(data):
 
     Returns:
         (tuple):  The survey, column name, science mask, standard mask,
-            sky mask, safe mask, and exclude mask for the data.
+            sky mask, suppsky mask, safe mask, and exclude mask for the data.
 
     """
     col = None

--- a/py/fiberassign/test/simulate.py
+++ b/py/fiberassign/test/simulate.py
@@ -64,6 +64,10 @@ def sim_focalplane(rundate=None, fakepos=False):
     # First get the starting focalplane from desimodel
     fp, exclude, state, tmstr = dmio.load_focalplane(runtime)
 
+    # Make a copy since desimodel is caching the original
+    fp = fp.copy()
+    state = state.copy()
+
     npos = len(fp)
 
     # Are we replacing the arms and theta lengths with the nominal values?

--- a/py/fiberassign/test/test_hardware.py
+++ b/py/fiberassign/test/test_hardware.py
@@ -153,6 +153,9 @@ class TestHardware(unittest.TestCase):
         runtime = datetime.strptime(test_assign_date, "%Y-%m-%dT%H:%M:%S")
         fp, exclude, state, tmstr = dmio.load_focalplane(runtime)
 
+        # make a copy so that we aren't modifying the desimodel cache
+        fp = fp.copy()
+
         limit_radius = 2.0
         open_limit = 2.0 * np.arcsin(0.5 * limit_radius / 3.0)
         phi_limit_min = (np.pi - open_limit) * 180.0 / np.pi

--- a/py/fiberassign/test/test_qa.py
+++ b/py/fiberassign/test/test_qa.py
@@ -2,17 +2,12 @@
 Test fiberassign target operations.
 """
 import os
-
+import subprocess
 import re
-
 import shutil
-
 import unittest
-
 from datetime import datetime
-
 import json
-
 import glob
 
 import numpy as np
@@ -20,6 +15,8 @@ import numpy as np
 import fitsio
 
 import desimodel
+
+import fiberassign
 
 from fiberassign.utils import option_list, GlobalTimers
 
@@ -261,6 +258,16 @@ class TestQA(unittest.TestCase):
 
         self.assertGreaterEqual(frac,  99.0)
 
+        #- Test if qa-fiberassign script runs without crashing
+        bindir = os.path.join(os.path.dirname(fiberassign.__file__), '..', '..', 'bin')
+        script = os.path.join(os.path.abspath(bindir), 'qa-fiberassign')
+        if os.path.exists(script):
+            fafiles = glob.glob(f"{test_dir}/fiberassign-*.fits")
+            cmd = "{} --targets {}".format(script, " ".join(fafiles))
+            err = subprocess.call(cmd.split())
+            self.assertEqual(err, 0, f"FAILED ({err}): {cmd}")
+        else:
+            print(f"ERROR: didn't find {script}")
 
 
 def test_suite():

--- a/py/fiberassign/test/test_qa.py
+++ b/py/fiberassign/test/test_qa.py
@@ -259,7 +259,7 @@ class TestQA(unittest.TestCase):
         with open(log_file, "w") as f:
             f.write(log_msg)
 
-        self.assertTrue(frac >= 99.0)
+        self.assertGreaterEqual(frac,  99.0)
 
 
 


### PR DESCRIPTION
This PR adds a basic test for `bin/qa-fiberassign` and fixes that script, which had been broken by `default_target_masks` and `default_survey_target_masks` returning the suppsky mask in addition to the other masks.

It also fixes a bug in the tests that was revealed by testing with python 3.8: the tests were altering the cached desimodel focalplane tables, and thus the success/failure of the tests depended upon the order in which they ran.  Now the tests make a copy before modifying the focal plane (e.g. to limit `MIN_P`).

This PR is needed for the integration tests of the 20.7 (20.8?) software release.