### PR TITLE
Remove call to std::make_unique, which was introduced in C++14.

### DIFF
--- a/src/targets.cpp
+++ b/src/targets.cpp
@@ -229,7 +229,11 @@ fba::TargetTree::TargetTree(Targets::pshr objs, double min_tree_size) {
         treelist_.push_back(tp);
     }
 
-    tree_ = std::make_unique < htmTree <TreePoint> > (treelist_, mintreesz_);
+    tree_ = std::unique_ptr <htmTree <TreePoint> > (
+        new htmTree <TreePoint> (treelist_, mintreesz_)
+    );
+    // This is more convenient, but not introduced until C++14.
+    // tree_ = std::make_unique < htmTree <TreePoint> > (treelist_, mintreesz_);
     tree_->stats();
     tm.stop();
     tm.report("Building target tree");


### PR DESCRIPTION
I verified that with this trivial change, I can build fiberassign inside a CentOS-7 docker container with gcc-4.8.5.  Without this fix, I reproduce the error seen in #272 .

Closes #272.