### PR TITLE
adding SUPP_SKY targets to OBJTYPE=SKY

### DIFF
--- a/py/fiberassign/assign.py
+++ b/py/fiberassign/assign.py
@@ -1160,6 +1160,8 @@ def merge_results_tile(out_dtype, copy_fba, params):
                     is_sky = (tile_targets["DESI_TARGET"][target_rows]
                               & desi_mask.SKY) != 0
                     objtype[is_sky] = "SKY"
+                    is_sky |= (tile_targets["DESI_TARGET"][target_rows]
+                              & desi_mask.SUPP_SKY) != 0
                     badmask = \
                         desi_mask.mask("BAD_SKY|NO_TARGET|IN_BRIGHT_OBJECT")
                     is_bad = (tile_targets["DESI_TARGET"][target_rows]

--- a/py/fiberassign/assign.py
+++ b/py/fiberassign/assign.py
@@ -1159,9 +1159,9 @@ def merge_results_tile(out_dtype, copy_fba, params):
                     objtype[:] = "TGT"
                     is_sky = (tile_targets["DESI_TARGET"][target_rows]
                               & desi_mask.SKY) != 0
-                    objtype[is_sky] = "SKY"
                     is_sky |= (tile_targets["DESI_TARGET"][target_rows]
                               & desi_mask.SUPP_SKY) != 0
+                    objtype[is_sky] = "SKY"
                     badmask = \
                         desi_mask.mask("BAD_SKY|NO_TARGET|IN_BRIGHT_OBJECT")
                     is_bad = (tile_targets["DESI_TARGET"][target_rows]


### PR DESCRIPTION
This PR is to set OBJTYPE="SKY" for SUPP_SKY targets in the assign files (those currently have OBJTYPE="TGT").
The modification is only two lines in py/fiberassign/assign.py to check DESI_TARGET against desi_mask.SUPP_SKY, when determining the OBJTYPE value.