### PR TITLE
Fba cmx gzip

### DIFF
--- a/bin/fba_cmx
+++ b/bin/fba_cmx
@@ -866,7 +866,7 @@ def main():
                 os.remove("{}.gz".format(fn))
                 log.info("{:.1f}s\t deleting existing {}.gz".format(
                     time() - start, fn))
-            os.system("gzip "+fn)
+            os.system("gzip {}".format(fn))
             log.info(
                 "{:.1f}s\t gzipping {}".format(
                     time() - start, fn)

--- a/bin/fba_cmx
+++ b/bin/fba_cmx
@@ -860,11 +860,17 @@ def main():
                 )
 
     if dozip:  # gzip all fiberassign files
-        files_to_zip = glob(os.path.join(args.outdir, "fiberassign-*.fits"))
-        for file_to_zip in files_to_zip:
-            print(file_to_zip, files_to_zip)
-            log.info("gzipping file {}".format(file_to_zip))
-            os.system("gzip -f {}".format(file_to_zip))
+        fns = [os.path.join(args.outdir, "fiberassign-{:06d}.fits".format(tileid)) for tileid in tileids]
+        for fn in fns:
+            if os.path.isfile("{}.gz".format(fn)):
+                os.remove("{}.gz".format(fn))
+                log.info("{:.1f}s\t deleting existing {}.gz".format(
+                    time() - start, fn))
+            os.system("gzip "+fn)
+            log.info(
+                "{:.1f}s\t gzipping {}".format(
+                    time() - start, fn)
+               )
 
     if doplot:
 


### PR DESCRIPTION
Slight re-writing of the dozip step in fba_cmx: now taking action on a given list of TILEIDs, and no more on all fiberassign-*.fits files, which could be potentially problematic in case of parallel, simultaneous calls looking in the same folder. 