### PR TITLE
Orion rosette praesepe

### DIFF
--- a/bin/fba_sv1
+++ b/bin/fba_sv1
@@ -38,6 +38,8 @@ faflavors_all = [
     "cmxm33",
     "cmxorion",
     "sv1m31",
+    "sv1orion",
+    "sv1rosette",
     "sv1praesepe",
     "sv1elg",
     "sv1elgqso",
@@ -102,6 +104,16 @@ yaml_masks = {
     "SV1_MWS_TARGET": sv1_targetmask.mws_mask,
     "SV1_SCND_TARGET": sv1_targetmask.scnd_mask,
 }
+# AR WD masks
+wd_msks = {
+            master_key: [key for key in yaml_masks[master_key].names() if "WD" in key]
+            for master_key in list(yaml_masks.keys())
+            }
+# AR STD masks
+std_msks = {
+            master_key: [key for key in yaml_masks[master_key].names() if "STD" in key and key not in wd_msks[master_key]]
+            for master_key in list(yaml_masks.keys())
+            }
 
 
 # AR like read_targets_in_tiles(), but allows two folders
@@ -557,7 +569,7 @@ def plot_cutout(
     alpha=None,
     txt=None,
     xtxt=0.5,
-    ytxt=0.93,
+    ytxt=0.98,
     vmin=None,
     vmax=None,
     cmap=mycmap("jet_r", 10, 0, 1),
@@ -613,10 +625,11 @@ def plot_cutout(
         xtxt,
         ytxt,
         txt,
-        color="w",
+        color="y",
         fontweight="bold",
         fontsize=10,
         ha="center",
+        va="top",
         transform=ax.transAxes,
     )
     return
@@ -657,7 +670,7 @@ def plot_hist(ax, x, xp, bins, msk):
     )
     axr.yaxis.label.set_color("r")
     axr.tick_params(axis="y", colors="r")
-    axr.set_ylabel("ratio", labelpad=-10)
+    axr.set_ylabel("ratio", labelpad=0)
     axr.set_ylim(0, 1)
     return
 
@@ -766,6 +779,15 @@ def main():
         fdict["stdmsks"] = {"CMX_TARGET": "STD_DITHER_GAIA"} # only STD targets in this tile... no WD
         fdict["nskypet"] = "80"
         fdict["nstdpet"] = "40"
+    elif args.faflavor in ["sv1orion", "sv1rosette"]:
+        fdict["survey"] = "sv1"
+        fdict["dtobscon"] = "bright"
+        fdict["obscon"] = "BRIGHT"
+        fdict["msks"] = {
+            "SV1_MWS_TARGET": "GAIA_STD_WD,GAIA_STD_BRIGHT,BACKUP_FAINT,BACKUP_VERY_FAINT", "SV1_SCND_TARGET": ",".join([key for key in yaml_masks["SV1_SCND_TARGET"].names() if key not in ["VETO"]])}
+        fdict["stdmsks"] = {"SV1_MWS_TARGET": "GAIA_STD_WD,GAIA_STD_BRIGHT,GAIA_STD_FAINT"} 
+        fdict["nskypet"] = "80"
+        fdict["nstdpet"] = "40"
     elif args.faflavor == "sv1m31":
         fdict["survey"] = "sv1"
         fdict["dtobscon"] = "dark"
@@ -872,7 +894,7 @@ def main():
 
     mydirs = {}
     # AR targ directory (now a list)
-    if args.faflavor in ["sv1m31", "cmxorion", "cmxrosette"]:
+    if args.faflavor in ["sv1m31", "cmxorion", "cmxrosette", "sv1orion", "sv1rosette"]:
         mydirs["targ"] = [os.path.join(
             path_to_targets,
             "gaiadr2",
@@ -1428,6 +1450,7 @@ def main():
             "FLUX_W1",
             "FLUX_W2",
             "EBV",
+            "GAIA_PHOT_G_MEAN_MAG",
             "RA",
             "DEC",
         ] + list(fdict["msks"].keys())
@@ -1490,21 +1513,23 @@ def main():
                 tsky, d["TARGET_RA"][keep], d["TARGET_DEC"][keep]
             )
             petbad = d["PETAL_LOC"][keep]
+            # AR WD
+            keep = np.zeros(len(d), dtype=bool)
+            for key in np.unique(list(fdict["msks"].keys()) + list(fdict["stdmsks"].keys())):
+                for msk in wd_msks[key]:
+                    keep |= (d[key] & yaml_masks[key][msk]) > 0
+                    print(msk,((d[key] & yaml_masks[key][msk]) > 0).sum())
+            drawd, ddecwd = get_tpos(
+                tsky, d["TARGET_RA"][keep], d["TARGET_DEC"][keep]
+            )
+            petwd = d["PETAL_LOC"][keep]
+            mydict["NWD"] = keep.sum()
             # AR STD
             keep = np.zeros(len(d), dtype=bool)
-            std_msks = [
-                "STD_FAINT",
-                "SV0_WD",
-                "STD_WD",
-                "STD_BRIGHT",
-                "GAIA_STD_FAINT",
-                "GAIA_STD_WD",
-                "GAIA_STD_BRIGHT",
-            ]  # AR all possible STD...
-            for key in list(fdict["stdmsks"].keys()):
-                for msk in std_msks:
-                    if msk in yaml_masks[key].names():
-                        keep |= (d[key] & yaml_masks[key][msk]) > 0
+            for key in np.unique(list(fdict["msks"].keys()) + list(fdict["stdmsks"].keys())):
+                for msk in std_msks[key]:
+                    keep |= (d[key] & yaml_masks[key][msk]) > 0
+                    print(msk,((d[key] & yaml_masks[key][msk]) > 0).sum())
             drastd, ddecstd = get_tpos(
                 tsky, d["TARGET_RA"][keep], d["TARGET_DEC"][keep]
             )
@@ -1530,13 +1555,14 @@ def main():
                 tmpmsks = [
                     msk
                     for msk in fdict["msks"][key].split(",")
-                    if "STD" not in msk and "WD" not in msk
+                    if msk not in wd_msks[key] and
+                    msk not in std_msks[key]
                 ]
                 msks += tmpmsks
                 mskkeys += [key for msk in tmpmsks]
             # AR start plotting
-            fig = plt.figure(figsize=(25, 3 * (1 + len(msks))))
-            gs = gridspec.GridSpec(1 + len(msks), 6, wspace=0.5, hspace=0.3)
+            fig = plt.figure(figsize=(30, 3 * (1 + len(msks))))
+            gs = gridspec.GridSpec(1 + len(msks), 7, wspace=0.5, hspace=0.3)
 
             # AR overall infos
             ax = plt.subplot(gs[0, 0])
@@ -1564,14 +1590,15 @@ def main():
             # AR stats per petal
             ax = plt.subplot(gs[0, 1])
             ax.axis("off")
-            x0, x1, x2, x3, x4 = 0.05, 0.25, 0.45, 0.65, 0.85
+            x0, x1, x2, x3, x4, x5 = 0.05, 0.25, 0.45, 0.65, 0.85, 1.05
             y, dy = 0.95, -0.1
             fs = 10
             ax.text(x0, y, "PETAL", fontsize=fs, ha="center", transform=ax.transAxes)
             ax.text(x1, y, "NSKY", fontsize=fs, ha="center", transform=ax.transAxes)
             ax.text(x2, y, "NBAD", fontsize=fs, ha="center", transform=ax.transAxes)
-            ax.text(x3, y, "NSTD", fontsize=fs, ha="center", transform=ax.transAxes)
-            ax.text(x4, y, "NTGT", fontsize=fs, ha="center", transform=ax.transAxes)
+            ax.text(x3, y, "NWD", fontsize=fs, ha="center", transform=ax.transAxes)
+            ax.text(x4, y, "NSTD", fontsize=fs, ha="center", transform=ax.transAxes)
+            ax.text(x5, y, "NTGT", fontsize=fs, ha="center", transform=ax.transAxes)
             y += dy
             for p in range(10):
                 ax.text(
@@ -1601,13 +1628,21 @@ def main():
                 ax.text(
                     x3,
                     y,
-                    "{:.0f}".format((petstd == p).sum()),
+                    "{:.0f}".format((petwd == p).sum()),
                     fontsize=fs,
                     ha="center",
                     transform=ax.transAxes,
                 )
                 ax.text(
                     x4,
+                    y,
+                    "{:.0f}".format((petstd == p).sum()),
+                    fontsize=fs,
+                    ha="center",
+                    transform=ax.transAxes,
+                )
+                ax.text(
+                    x5,
                     y,
                     "{:.0f}".format((mydict["PETAL_LOC"] == p).sum()),
                     fontsize=fs,
@@ -1635,13 +1670,21 @@ def main():
             ax.text(
                 x3,
                 y,
+                "{:.0f}".format(len(petwd)),
+                fontsize=fs,
+                ha="center",                                                                                                                                                        
+                transform=ax.transAxes,
+            )
+            ax.text(
+                x4,
+                y,
                 "{:.0f}".format(len(petstd)),
                 fontsize=fs,
                 ha="center",
                 transform=ax.transAxes,
             )
             ax.text(
-                x4,
+                x5,
                 y,
                 "{:.0f}".format(np.isfinite(mydict["PETAL_LOC"]).sum()),
                 fontsize=fs,
@@ -1666,13 +1709,13 @@ def main():
             #os.remove("{}tmp-{}.jpeg".format(args.outdir, tileid))
             img = np.zeros((size, size, 3))
 
-            # AR SKY, BAD, STD, TGT
+            # AR SKY, BAD, WD, STD, TGT
             for iy, x, y, txt, alpha in zip(
-                [2, 3, 4, 5],
-                [drasky, drabad, drastd, dra],
-                [ddecsky, ddecbad, ddecstd, ddec],
-                ["SKY", "BAD", "STD", "TGT"],
-                [0.25, 1.0, 1.0, 0.025],
+                [2, 3, 4, 5, 6],
+                [drasky, drabad, drawd, drastd, dra],
+                [ddecsky, ddecbad, ddecwd, ddecstd, ddec],
+                ["SKY", "BAD", "WD", "STD", "TGT"],
+                [0.25, 1.0, 1.0, 1.0, 0.025],
             ):
                 ax = fig.add_subplot(gs[0, iy])
                 plot_cutout(
@@ -1681,20 +1724,24 @@ def main():
 
             # AR looping on tracers
             exts = {"G": 3.214, "R": 2.165, "Z": 1.211, "W1": 0.184, "W2": 0.113}
-            for ix, msk, mskkey in zip(
-                np.arange(1, 1 + len(msks), dtype=int), msks, mskkeys
-            ):
+            ix = 1
+            for msk, mskkey in zip(msks, mskkeys):
                 # AR selecting the relevant tracers
                 if mskkey in list(dp.keys()):
                     mskpsel = (dp[mskkey] & yaml_masks[mskkey][msk]) > 0
                 else:
                     mskpsel = np.zeros(len(dp["TARGETID"]), dtype=bool)
+                # AR if no parent target, just skip
+                if mskpsel.sum() == 0:
+                    continue
+                print(msk,mskpsel.sum())
                 msksel = (mydict[mskkey] & yaml_masks[mskkey][msk]) > 0
                 fafrac = msksel.sum() / float(mskpsel.sum())
                 # famin = np.clip(fafrac-0.2,0,1)
                 # famax = np.clip(fafrac+0.2,0,1)
                 famin, famax = 0, 1
                 # AR mag hist
+                band, famin, famax = "G", 0.0, 0.5
                 if msk in ["MWS_ANY"]:
                     band, famin, famax = "R", 0.0, 0.5
                 if msk in ["BGS_ANY"]:
@@ -1705,12 +1752,11 @@ def main():
                     band, famin, famax = "G", 0.0, 0.5
                 if msk in ["QSO", "SV0_QSO"]:
                     band, famin, famax = "R", 0.0, 0.5
-                if "M33" in msk or "M31" in msk or "ORI_" or "MWS" in msk:
-                    band, famin, famax = "G", 0.0, 0.5
-                # AR handling outside desi cases
-                # if (tile_in_desi == 1) & (args.faflavor != "cmxm33"):
-                if args.faflavor not in ["cmxm33", "cmxorion", "cmxrosette", "sv1m31", "sv1praesepe"]:
-                    ax = plt.subplot(gs[ix, 0])
+                # 
+                ax = plt.subplot(gs[ix, 1])
+                dohist = 0
+                if ((dp["FLUX_" + band] > 0) & (mskpsel)).sum() > 0:
+                    dohist = 1
                     keep = (dp["FLUX_" + band] > 0) & (mskpsel)
                     xp = (
                         22.5
@@ -1723,27 +1769,40 @@ def main():
                         - 2.5 * np.log10(mydict["FLUX_" + band][keep])
                         - exts[band] * mydict["EBV"][keep]
                     )
-                    bins = np.linspace(xp.min(), xp.max(), 26)
-                    plot_hist(ax, x, xp, bins, msk)
-                    _, ymax = ax.get_ylim()
-                    ax.set_ylim(0.8, 100 * ymax)
-                    ax.set_yscale("log")
                     ax.set_xlabel(
                         "22.5 - 2.5*log10(FLUX_{}) - {:.3f} * EBV".format(
                             band, exts[band]
                         )
                     )
+                elif ((np.isfinite(dp["GAIA_PHOT_G_MEAN_MAG"])) & (mskpsel)).sum() > 0:
+                    dohist = 1
+                    keep = (np.isfinite(dp["GAIA_PHOT_G_MEAN_MAG"])) & (mskpsel)
+                    xp = dp["GAIA_PHOT_G_MEAN_MAG"][keep]
+                    keep = (np.isfinite(mydict["GAIA_PHOT_G_MEAN_MAG"])) & (mskpsel)
+                    x = mydict["GAIA_PHOT_G_MEAN_MAG"][keep]
+                    ax.set_xlabel("GAIA_PHOT_G_MEAN_MAG")
+                if dohist == 1:
+                    bins = np.linspace(xp.min(), xp.max(), 26)
+                    plot_hist(ax, x, xp, bins, msk)
+                    _, ymax = ax.get_ylim()
+                    ax.set_ylim(0.8, 100 * ymax)
+                    ax.set_yscale("log")
 
                 # AR color-color diagram
                 if "M33" not in msk and "M31" not in msk:
                     gridsize = 25
                     for iy, xbands, ybands, xlim, ylim in zip(
-                        [1, 2],
+                        [2, 3],
                         [("R", "Z"), ("R", "Z")],
                         [("G", "R"), ("R", "W1")],
                         [(-0.5, 2.5), (-0.5, 2.5)],
                         [(-0.5, 2.5), (-2, 5)],
                     ):
+                        keep = np.zeros(len(dp["TARGETID"]),dtype=bool)
+                        for band in [xbands[0],xbands[1],ybands[0],ybands[1]]:
+                            keep &= (dp["FLUX_{}".format(band)] > 0)
+                        if keep.sum() == 0:
+                            continue
                         ax = plt.subplot(gs[ix, iy])
                         xp = (
                             -2.5
@@ -1835,13 +1894,13 @@ def main():
                         cbar.mappable.set_clim(famin, famax)
 
                 # AR position in tile
-                ax = plt.subplot(gs[ix, 3])  # AR will be over-written
+                ax = plt.subplot(gs[ix, 4])  # AR will be over-written
                 xlim, ylim, gridsize = (rdlim, -rdlim), (-rdlim, rdlim), 50
                 plot_area = (xlim[0] - xlim[1]) * (
                     ylim[1] - ylim[0]
                 )  # AR area of the plotting window in deg2
                 # AR parent
-                ax = plt.subplot(gs[ix, 3])
+                ax = plt.subplot(gs[ix, 4])
                 plot_cutout(
                     ax,
                     img,
@@ -1849,7 +1908,7 @@ def main():
                     drap[mskpsel],
                     ddecp[mskpsel],
                     pet=True,
-                    txt="{} parent : {:.0f}".format(msk, mskpsel.sum() / tarea)
+                    txt="{}\nparent : {:.0f}".format(msk, mskpsel.sum() / tarea)
                     + r" deg$^{-2}$",
                 )
                 hbp = ax.hexbin(
@@ -1862,7 +1921,7 @@ def main():
                     visible=False,
                 )
                 # AR assigned
-                ax = plt.subplot(gs[ix, 4])
+                ax = plt.subplot(gs[ix, 5])
                 plot_cutout(
                     ax,
                     img,
@@ -1870,7 +1929,7 @@ def main():
                     dra[msksel],
                     ddec[msksel],
                     pet=True,
-                    txt="{} assign : {:.0f}".format(msk, msksel.sum() / tarea)
+                    txt="{}\nassign : {:.0f}".format(msk, msksel.sum() / tarea)
                     + r" deg$^{-2}$",
                 )
                 hb = ax.hexbin(
@@ -1889,7 +1948,7 @@ def main():
                 keep = (hbp.get_array() > 0) & (c > 0)
                 tmpx, tmpy, c = tmpx[keep], tmpy[keep], c[keep]
                 txt = r"mean = {:.2f}".format(fafrac)
-                ax = plt.subplot(gs[ix, 5])
+                ax = plt.subplot(gs[ix, 6])
                 SC = ax.scatter(
                     tmpx, tmpy, c=c, s=3, vmin=famin, vmax=famax, alpha=0.5, cmap=cm,
                 )
@@ -1910,6 +1969,8 @@ def main():
                 cbar = plt.colorbar(SC)
                 cbar.set_label("{} fraction assigned".format(msk))
                 cbar.mappable.set_clim(famin, famax)
+                #
+                ix += 1
 
             #  AR saving plot
             plt.savefig(

--- a/bin/fba_sv1
+++ b/bin/fba_sv1
@@ -8,7 +8,13 @@ from glob import glob
 from astropy.io import fits
 from astropy.table import Table
 import fitsio
-from desitarget.io import read_targets_in_tiles, write_targets, write_mtl,decode_targetid,releasedict
+from desitarget.io import (
+    read_targets_in_tiles,
+    write_targets,
+    write_mtl,
+    decode_targetid,
+    releasedict,
+)
 from desitarget.cmx import cmx_targetmask
 from desitarget.sv1 import sv1_targetmask
 from desitarget.targetmask import obsconditions
@@ -41,6 +47,7 @@ faflavors_all = [
     "sv1orion",
     "sv1rosette",
     "sv1praesepe",
+    "sv1umaii",
     "sv1elg",
     "sv1elgqso",
     "sv1lrgqso",
@@ -106,14 +113,18 @@ yaml_masks = {
 }
 # AR WD masks
 wd_msks = {
-            master_key: [key for key in yaml_masks[master_key].names() if "WD" in key]
-            for master_key in list(yaml_masks.keys())
-            }
+    master_key: [key for key in yaml_masks[master_key].names() if "WD" in key]
+    for master_key in list(yaml_masks.keys())
+}
 # AR STD masks
 std_msks = {
-            master_key: [key for key in yaml_masks[master_key].names() if "STD" in key and key not in wd_msks[master_key]]
-            for master_key in list(yaml_masks.keys())
-            }
+    master_key: [
+        key
+        for key in yaml_masks[master_key].names()
+        if "STD" in key and key not in wd_msks[master_key]
+    ]
+    for master_key in list(yaml_masks.keys())
+}
 
 
 # AR like read_targets_in_tiles(), but allows two folders
@@ -123,8 +134,10 @@ def custom_read_targets_in_tiles(targdirs, tiles, log=None):
     if log is not None:
         log.info(
             "{:.1f}s\treading input targets from {}".format(time() - start, targdirs)
-                )
-    ds = [read_targets_in_tiles(targdir, tiles=tiles, quick=True) for targdir in targdirs]
+        )
+    ds = [
+        read_targets_in_tiles(targdir, tiles=tiles, quick=True) for targdir in targdirs
+    ]
     # AR merging
     d = np.concatenate(ds)
     # AR remove duplicates based on TARGETID (so duplicates not identified if in mixed surveys)
@@ -399,7 +412,7 @@ def update_nowradec(
     for key in [pmra_key, pmdec_key]:
         keep = ~np.isfinite(d[key])
         if keep.sum() > 0:
-            d[key][keep] = 0.
+            d[key][keep] = 0.0
             log.info(
                 "{:.1f}s\t{}: replacing NaN by 0 for {} targets".format(
                     time() - start, key, keep.sum()
@@ -482,9 +495,9 @@ def custom_make_mtl(d, outfn, survey, scnd=False):
     # AR sanity check for using the mixed=True option
     all_release = np.array(list(releasedict.keys()))
     if args.dr == "dr8":
-        dr_release = all_release[(all_release>=8000) & (all_release<9000)]
+        dr_release = all_release[(all_release >= 8000) & (all_release < 9000)]
     if args.dr == "dr9":
-        dr_release = all_release[(all_release>=9000) & (all_release<10000)]
+        dr_release = all_release[(all_release >= 9000) & (all_release < 10000)]
     _, _, release, _, _, _ = decode_targetid(d["TARGETID"])
     release = np.unique(release)
     if release.max() > dr_release.max():
@@ -496,7 +509,12 @@ def custom_make_mtl(d, outfn, survey, scnd=False):
         sys.exit()
     # AR writing
     n, tmpfn = write_mtl(
-        args.outdir, mtl.as_array(), indir=args.outdir, survey=survey, ecsv=False, mixed=True
+        args.outdir,
+        mtl.as_array(),
+        indir=args.outdir,
+        survey=survey,
+        ecsv=False,
+        mixed=True,
     )
     if n:
         os.rename(tmpfn, outfn)
@@ -763,10 +781,10 @@ def main():
         fdict["survey"] = "cmx"
         fdict["dtobscon"] = "no-obscon"
         fdict["obscon"] = "BRIGHT"
-        fdict["msks"] = {
-            "CMX_TARGET": "SV0_WD,ORI_STD_BRIGHT,ORI_QSO,ORI_ORI,ORI_HA"
-        }
-        fdict["stdmsks"] = {"CMX_TARGET": "STD_DITHER_GAIA"} # only STD targets in this tile... no WD
+        fdict["msks"] = {"CMX_TARGET": "SV0_WD,ORI_STD_BRIGHT,ORI_QSO,ORI_ORI,ORI_HA"}
+        fdict["stdmsks"] = {
+            "CMX_TARGET": "STD_DITHER_GAIA"
+        }  # only STD targets in this tile... no WD
         fdict["nskypet"] = "80"
         fdict["nstdpet"] = "40"
     elif args.faflavor == "cmxrosette":  # AR ! using CMX_TARGET !
@@ -776,16 +794,36 @@ def main():
         fdict["msks"] = {
             "CMX_TARGET": "SV0_WD,ROS_STD_BRIGHT,ROS_QSO,ROS_ROSM17,ROS_ROS1,ROS_HA,ROS_ROS2"
         }
-        fdict["stdmsks"] = {"CMX_TARGET": "STD_DITHER_GAIA"} # only STD targets in this tile... no WD
+        fdict["stdmsks"] = {
+            "CMX_TARGET": "STD_DITHER_GAIA"
+        }  # only STD targets in this tile... no WD
         fdict["nskypet"] = "80"
         fdict["nstdpet"] = "40"
     elif args.faflavor in ["sv1orion", "sv1rosette"]:
         fdict["survey"] = "sv1"
         fdict["dtobscon"] = "bright"
-        fdict["obscon"] = "BRIGHT"
+        fdict["obscon"] = "DARK|GRAY|BRIGHT"
         fdict["msks"] = {
-            "SV1_MWS_TARGET": "GAIA_STD_WD,GAIA_STD_BRIGHT,BACKUP_FAINT,BACKUP_VERY_FAINT", "SV1_SCND_TARGET": ",".join([key for key in yaml_masks["SV1_SCND_TARGET"].names() if key not in ["VETO"]])}
-        fdict["stdmsks"] = {"SV1_MWS_TARGET": "GAIA_STD_WD,GAIA_STD_BRIGHT,GAIA_STD_FAINT"} 
+            "SV1_MWS_TARGET": "GAIA_STD_WD,GAIA_STD_BRIGHT,BACKUP_FAINT,BACKUP_VERY_FAINT",
+            "SV1_SCND_TARGET": ",".join(
+                [
+                    key
+                    for key in yaml_masks["SV1_SCND_TARGET"].names()
+                    if key not in ["VETO"]
+                ]
+            ),
+        }
+        fdict["stdmsks"] = {
+            "SV1_MWS_TARGET": "GAIA_STD_WD,GAIA_STD_BRIGHT,GAIA_STD_FAINT"
+        }
+        fdict["nskypet"] = "80"
+        fdict["nstdpet"] = "40"
+    elif args.faflavor == "sv1umaii":
+        fdict["survey"] = "sv1"
+        fdict["dtobscon"] = "dark"
+        fdict["obscon"] = "DARK|GRAY|BRIGHT"                                                                                                                                        
+        fdict["msks"] = {"SV1_DESI_TARGET": "MWS_ANY", "SV1_SCND_TARGET": "MWS_CALIB,BACKUP_CALIB,MWS_MAIN_CLUSTER_SV,MWS_RRLYR,BHB"}
+        fdict["stdmsks"] = {"SV1_DESI_TARGET": "STD_WD,STD_FAINT"}
         fdict["nskypet"] = "80"
         fdict["nstdpet"] = "40"
     elif args.faflavor == "sv1m31":
@@ -800,7 +838,16 @@ def main():
         fdict["survey"] = "sv1"
         fdict["dtobscon"] = "bright"
         fdict["obscon"] = "BRIGHT"
-        fdict["msks"] = {"SV1_MWS_TARGET": "MWS_WD,MWS_MAIN_BROAD,MWS_NEARBY", "SV1_SCND_TARGET": ",".join([key for key in yaml_masks["SV1_SCND_TARGET"].names() if key not in ["VETO", "LOW_Z"]])}
+        fdict["msks"] = {
+            "SV1_MWS_TARGET": "MWS_WD,MWS_MAIN_BROAD,MWS_NEARBY",
+            "SV1_SCND_TARGET": ",".join(
+                [
+                    key
+                    for key in yaml_masks["SV1_SCND_TARGET"].names()
+                    if key not in ["VETO", "LOW_Z"]
+                ]
+            ),
+        }
         fdict["stdmsks"] = {"SV1_DESI_TARGET": "STD_WD,STD_FAINT"}
         fdict["nskypet"] = "80"
         fdict["nstdpet"] = "40"
@@ -886,39 +933,45 @@ def main():
     # AR directories (already checked for desi or cori only)
     # AR folder architecture is now the same at NERSC/KPNO (https://github.com/desihub/fiberassign/issues/302)
     # AR DESI_ROOT : NERSC: '/global/cfs/cdirs/desi' ; KPNO: '/data/datasystems'
-    desiroot = os.getenv("DESI_ROOT") 
+    desiroot = os.getenv("DESI_ROOT")
     path_to_targets = os.path.join(os.getenv("DESI_TARGET"), "catalogs")
     path_to_svn_tiles = os.path.join(
-            os.getenv("DESI_TARGET"), "fiberassign/tiles/trunk"
-        )
+        os.getenv("DESI_TARGET"), "fiberassign/tiles/trunk"
+    )
 
     mydirs = {}
     # AR targ directory (now a list)
     if args.faflavor in ["sv1m31", "cmxorion", "cmxrosette", "sv1orion", "sv1rosette"]:
-        mydirs["targ"] = [os.path.join(
-            path_to_targets,
-            "gaiadr2",
-            args.dtver,
-            "targets",
-            fdict["survey"],
-            "resolve",
-            "supp",
-        )]
+        mydirs["targ"] = [
+            os.path.join(
+                path_to_targets,
+                "gaiadr2",
+                args.dtver,
+                "targets",
+                fdict["survey"],
+                "resolve",
+                "supp",
+            )
+        ]
     else:
-        mydirs["targ"] = [os.path.join(
-            path_to_targets,
-            args.dr,
-            args.dtver,
-            "targets",
-            fdict["survey"],
-            "resolve",
-            fdict["dtobscon"],
-        )]
+        mydirs["targ"] = [
+            os.path.join(
+                path_to_targets,
+                args.dr,
+                args.dtver,
+                "targets",
+                fdict["survey"],
+                "resolve",
+                fdict["dtobscon"],
+            )
+        ]
     # AR additional directory for cmx33
     if args.faflavor == "cmx33":
-        mydirs["targ"] += [os.path.join(
-                        path_to_targets, "gaiadr2", args.dtver, "targets/cmx/resolve/supp"
-                        )]
+        mydirs["targ"] += [
+            os.path.join(
+                path_to_targets, "gaiadr2", args.dtver, "targets/cmx/resolve/supp"
+            )
+        ]
     # AR secondary directory
     mydirs["scnd"] = os.path.join(
         path_to_targets,
@@ -1072,7 +1125,9 @@ def main():
         log.info("{:.1f}s\tstart generating {}-sky.fits".format(time() - start, root))
         # AR sky: read targets
         tiles = fits.open("{}-tiles.fits".format(root))[1].data
-        d = custom_read_targets_in_tiles([mydirs["sky"], mydirs["skysupp"]], tiles, log=log)
+        d = custom_read_targets_in_tiles(
+            [mydirs["sky"], mydirs["skysupp"]], tiles, log=log
+        )
         # AR sky: write fits
         if fdict["survey"] == "sv1":
             survey = "sv"
@@ -1093,7 +1148,7 @@ def main():
         log.info("{:.1f}s\tstart generating {}-gfa.fits".format(time() - start, root))
         # AR gfa: read targets
         tiles = fits.open("{}-tiles.fits".format(root))[1].data
-        d = custom_read_targets_in_tiles([mydirs["gfa"]], tiles, log=log) 
+        d = custom_read_targets_in_tiles([mydirs["gfa"]], tiles, log=log)
         log.info(
             "{:.1f}s\tkeeping {} targets to {}-gfa.fits".format(
                 time() - start, len(d), root
@@ -1123,7 +1178,7 @@ def main():
         print(mydirs["targ"])
         # AR std: read targets
         tiles = fits.open("{}-tiles.fits".format(root))[1].data
-        d = custom_read_targets_in_tiles(mydirs["targ"], tiles, log=log) 
+        d = custom_read_targets_in_tiles(mydirs["targ"], tiles, log=log)
         keep = sel_targs(d, fdict["stdmsks"], log=log)
         # AR std: removing overlap with science targets
         isscience = sel_targs(d, fdict["msks"])
@@ -1221,11 +1276,16 @@ def main():
         d = read_targets_in_tiles(fn, tiles=tiles, quick=False)
         # AR scnd: cutting on requested targets
         # AR scnd: beforehand cutting the masks on SV1_SCND_TARGET
-        keep = sel_targs(d, {"SV1_SCND_TARGET":fdict["msks"]["SV1_SCND_TARGET"]}, log=log)
+        keep = sel_targs(
+            d, {"SV1_SCND_TARGET": fdict["msks"]["SV1_SCND_TARGET"]}, log=log
+        )
         d = d[keep]
         log.info(
             "{:.1f}s\tkeeping {:.0f}/{:.0f} secondary targets after having cut on {}".format(
-                time() - start, keep.sum(), len(keep), {"SV1_SCND_TARGET":fdict["msks"]["SV1_SCND_TARGET"]}
+                time() - start,
+                keep.sum(),
+                len(keep),
+                {"SV1_SCND_TARGET": fdict["msks"]["SV1_SCND_TARGET"]},
             )
         )
         # AR scnd: removing targets from other tiles?
@@ -1352,11 +1412,18 @@ def main():
             for key in np.sort(list(mydirs.keys())):
                 if key == "targ":
                     # AR header keywords: TARG, TARG2, TARG3, etc
-                    suffixs = [""] + np.arange(2,len(mydirs["targ"])+1).astype(str).tolist()
-                    for targdir,suffix in zip(mydirs["targ"], suffixs):
-                        fd["PRIMARY"].write_key("targ{}".format(suffix), targdir.replace(desiroot, "DESIROOT"))
+                    suffixs = [""] + np.arange(2, len(mydirs["targ"]) + 1).astype(
+                        str
+                    ).tolist()
+                    for targdir, suffix in zip(mydirs["targ"], suffixs):
+                        fd["PRIMARY"].write_key(
+                            "targ{}".format(suffix),
+                            targdir.replace(desiroot, "DESIROOT"),
+                        )
                 else:
-                    fd["PRIMARY"].write_key(key, mydirs[key].replace(desiroot, "DESIROOT"))
+                    fd["PRIMARY"].write_key(
+                        key, mydirs[key].replace(desiroot, "DESIROOT")
+                    )
             for kwargs in args._get_kwargs():
                 if kwargs[0].lower() in [
                     "outdir",
@@ -1515,21 +1582,23 @@ def main():
             petbad = d["PETAL_LOC"][keep]
             # AR WD
             keep = np.zeros(len(d), dtype=bool)
-            for key in np.unique(list(fdict["msks"].keys()) + list(fdict["stdmsks"].keys())):
+            for key in np.unique(
+                list(fdict["msks"].keys()) + list(fdict["stdmsks"].keys())
+            ):
                 for msk in wd_msks[key]:
                     keep |= (d[key] & yaml_masks[key][msk]) > 0
-                    print(msk,((d[key] & yaml_masks[key][msk]) > 0).sum())
-            drawd, ddecwd = get_tpos(
-                tsky, d["TARGET_RA"][keep], d["TARGET_DEC"][keep]
-            )
+                    print(msk, ((d[key] & yaml_masks[key][msk]) > 0).sum())
+            drawd, ddecwd = get_tpos(tsky, d["TARGET_RA"][keep], d["TARGET_DEC"][keep])
             petwd = d["PETAL_LOC"][keep]
             mydict["NWD"] = keep.sum()
             # AR STD
             keep = np.zeros(len(d), dtype=bool)
-            for key in np.unique(list(fdict["msks"].keys()) + list(fdict["stdmsks"].keys())):
+            for key in np.unique(
+                list(fdict["msks"].keys()) + list(fdict["stdmsks"].keys())
+            ):
                 for msk in std_msks[key]:
                     keep |= (d[key] & yaml_masks[key][msk]) > 0
-                    print(msk,((d[key] & yaml_masks[key][msk]) > 0).sum())
+                    print(msk, ((d[key] & yaml_masks[key][msk]) > 0).sum())
             drastd, ddecstd = get_tpos(
                 tsky, d["TARGET_RA"][keep], d["TARGET_DEC"][keep]
             )
@@ -1555,8 +1624,7 @@ def main():
                 tmpmsks = [
                     msk
                     for msk in fdict["msks"][key].split(",")
-                    if msk not in wd_msks[key] and
-                    msk not in std_msks[key]
+                    if msk not in wd_msks[key] and msk not in std_msks[key]
                 ]
                 msks += tmpmsks
                 mskkeys += [key for msk in tmpmsks]
@@ -1672,7 +1740,7 @@ def main():
                 y,
                 "{:.0f}".format(len(petwd)),
                 fontsize=fs,
-                ha="center",                                                                                                                                                        
+                ha="center",
                 transform=ax.transAxes,
             )
             ax.text(
@@ -1704,10 +1772,10 @@ def main():
                 args.outdir, tileid, layer, tra, tdec, pixscale, size
             )
             # print(tmpstr)
-            #os.system(tmpstr)
-            #img = mpimg.imread("{}tmp-{}.jpeg".format(args.outdir, tileid))
-            #os.remove("{}tmp-{}.jpeg".format(args.outdir, tileid))
-            img = np.zeros((size, size, 3))
+            os.system(tmpstr)
+            img = mpimg.imread("{}tmp-{}.jpeg".format(args.outdir, tileid))
+            os.remove("{}tmp-{}.jpeg".format(args.outdir, tileid))
+            #img = np.zeros((size, size, 3))
 
             # AR SKY, BAD, WD, STD, TGT
             for iy, x, y, txt, alpha in zip(
@@ -1734,7 +1802,7 @@ def main():
                 # AR if no parent target, just skip
                 if mskpsel.sum() == 0:
                     continue
-                print(msk,mskpsel.sum())
+                print(msk, mskpsel.sum())
                 msksel = (mydict[mskkey] & yaml_masks[mskkey][msk]) > 0
                 fafrac = msksel.sum() / float(mskpsel.sum())
                 # famin = np.clip(fafrac-0.2,0,1)
@@ -1752,7 +1820,7 @@ def main():
                     band, famin, famax = "G", 0.0, 0.5
                 if msk in ["QSO", "SV0_QSO"]:
                     band, famin, famax = "R", 0.0, 0.5
-                # 
+                #
                 ax = plt.subplot(gs[ix, 1])
                 dohist = 0
                 if ((dp["FLUX_" + band] > 0) & (mskpsel)).sum() > 0:
@@ -1798,9 +1866,9 @@ def main():
                         [(-0.5, 2.5), (-0.5, 2.5)],
                         [(-0.5, 2.5), (-2, 5)],
                     ):
-                        keep = np.zeros(len(dp["TARGETID"]),dtype=bool)
-                        for band in [xbands[0],xbands[1],ybands[0],ybands[1]]:
-                            keep &= (dp["FLUX_{}".format(band)] > 0)
+                        keep = np.zeros(len(dp["TARGETID"]), dtype=bool)
+                        for band in [xbands[0], xbands[1], ybands[0], ybands[1]]:
+                            keep &= dp["FLUX_{}".format(band)] > 0
                         if keep.sum() == 0:
                             continue
                         ax = plt.subplot(gs[ix, iy])
@@ -2152,4 +2220,4 @@ if __name__ == "__main__":
 
     with stdouterr_redirected(to=logfn):
         main()
-    #main()
+    # main()

--- a/bin/fba_sv1
+++ b/bin/fba_sv1
@@ -8,7 +8,7 @@ from glob import glob
 from astropy.io import fits
 from astropy.table import Table
 import fitsio
-from desitarget.io import read_targets_in_tiles, write_targets, write_mtl
+from desitarget.io import read_targets_in_tiles, write_targets, write_mtl,decode_targetid,releasedict
 from desitarget.cmx import cmx_targetmask
 from desitarget.sv1 import sv1_targetmask
 from desitarget.targetmask import obsconditions
@@ -36,7 +36,9 @@ import matplotlib.image as mpimg
 # AR authorized args.faflavor
 faflavors_all = [
     "cmxm33",
+    "cmxorion",
     "sv1m31",
+    "sv1praesepe",
     "sv1elg",
     "sv1elgqso",
     "sv1lrgqso",
@@ -47,6 +49,10 @@ faflavors_all = [
     "1percdark",
     "1percbright",
 ]
+
+
+# AR authorized args.dr
+dr_all = ["dr8", "dr9"]
 
 
 # AR copied from make_mtl()
@@ -96,6 +102,32 @@ yaml_masks = {
     "SV1_MWS_TARGET": sv1_targetmask.mws_mask,
     "SV1_SCND_TARGET": sv1_targetmask.scnd_mask,
 }
+
+
+# AR like read_targets_in_tiles(), but allows two folders
+# AR targdirs : list of directories (currently 1 or 2, but keep possibility to use more)
+def custom_read_targets_in_tiles(targdirs, tiles, log=None):
+    # AR reading
+    if log is not None:
+        log.info(
+            "{:.1f}s\treading input targets from {}".format(time() - start, targdirs)
+                )
+    ds = [read_targets_in_tiles(targdir, tiles=tiles, quick=True) for targdir in targdirs]
+    # AR merging
+    d = np.concatenate(ds)
+    # AR remove duplicates based on TARGETID (so duplicates not identified if in mixed surveys)
+    ii_m1 = np.where(d["TARGETID"] == -1)[0]
+    ii_nm1 = np.where(d["TARGETID"] != -1)[0]
+    _, ii = np.unique(d["TARGETID"][ii_nm1], return_index=True)
+    ii_nm1 = ii_nm1[ii]
+    if len(ii_m1) + len(ii_nm1) != len(d):
+        log.info(
+            "{:.1f}s\tremoving {}/{} duplicates".format(
+                time() - start, len(d) - len(ii_m1) - len(ii_nm1), len(d)
+            )
+        )
+        d = d[ii_m1.tolist() + ii_nm1.tolist()]
+    return d
 
 
 # AR select targets using yaml bits
@@ -435,8 +467,24 @@ def custom_make_mtl(d, outfn, survey, scnd=False):
         d, scnd=scnd
     )  # AR : TBD : do we want to set obsconmask to 1? (see Ted s email)
     mtl["OBSCONDITIONS"] = obsconmask
+    # AR sanity check for using the mixed=True option
+    all_release = np.array(list(releasedict.keys()))
+    if args.dr == "dr8":
+        dr_release = all_release[(all_release>=8000) & (all_release<9000)]
+    if args.dr == "dr9":
+        dr_release = all_release[(all_release>=9000) & (all_release<10000)]
+    _, _, release, _, _, _ = decode_targetid(d["TARGETID"])
+    release = np.unique(release)
+    if release.max() > dr_release.max():
+        log.error(
+            "{:.1f}s\t; targets have data RELEASE ({}) larger than the data release ({}); exiting".format(
+                time() - start, release, dr_release
+            )
+        )
+        sys.exit()
+    # AR writing
     n, tmpfn = write_mtl(
-        args.outdir, mtl.as_array(), indir=args.outdir, survey=survey, ecsv=False
+        args.outdir, mtl.as_array(), indir=args.outdir, survey=survey, ecsv=False, mixed=True
     )
     if n:
         os.rename(tmpfn, outfn)
@@ -698,12 +746,40 @@ def main():
         fdict["stdmsks"] = {"CMX_TARGET": "SV0_WD,STD_BRIGHT"}
         fdict["nskypet"] = "80"
         fdict["nstdpet"] = "40"
+    elif args.faflavor == "cmxorion":  # AR ! using CMX_TARGET !
+        fdict["survey"] = "cmx"
+        fdict["dtobscon"] = "no-obscon"
+        fdict["obscon"] = "BRIGHT"
+        fdict["msks"] = {
+            "CMX_TARGET": "SV0_WD,ORI_STD_BRIGHT,ORI_QSO,ORI_ORI,ORI_HA"
+        }
+        fdict["stdmsks"] = {"CMX_TARGET": "STD_DITHER_GAIA"} # only STD targets in this tile... no WD
+        fdict["nskypet"] = "80"
+        fdict["nstdpet"] = "40"
+    elif args.faflavor == "cmxrosette":  # AR ! using CMX_TARGET !
+        fdict["survey"] = "cmx"
+        fdict["dtobscon"] = "no-obscon"
+        fdict["obscon"] = "BRIGHT"
+        fdict["msks"] = {
+            "CMX_TARGET": "SV0_WD,ROS_STD_BRIGHT,ROS_QSO,ROS_ROSM17,ROS_ROS1,ROS_HA,ROS_ROS2"
+        }
+        fdict["stdmsks"] = {"CMX_TARGET": "STD_DITHER_GAIA"} # only STD targets in this tile... no WD
+        fdict["nskypet"] = "80"
+        fdict["nstdpet"] = "40"
     elif args.faflavor == "sv1m31":
         fdict["survey"] = "sv1"
         fdict["dtobscon"] = "dark"
         fdict["obscon"] = "DARK|GRAY|BRIGHT"
         fdict["msks"] = {"SV1_SCND_TARGET": "M31_KNOWN,M31_QSO,M31_STAR"}
         fdict["stdmsks"] = {"SV1_MWS_TARGET": "GAIA_STD_WD,GAIA_STD_FAINT"}
+        fdict["nskypet"] = "80"
+        fdict["nstdpet"] = "40"
+    elif args.faflavor == "sv1praesepe":
+        fdict["survey"] = "sv1"
+        fdict["dtobscon"] = "bright"
+        fdict["obscon"] = "BRIGHT"
+        fdict["msks"] = {"SV1_MWS_TARGET": "MWS_WD,MWS_MAIN_BROAD,MWS_NEARBY", "SV1_SCND_TARGET": ",".join([key for key in yaml_masks["SV1_SCND_TARGET"].names() if key not in ["VETO", "LOW_Z"]])}
+        fdict["stdmsks"] = {"SV1_DESI_TARGET": "STD_WD,STD_FAINT"}
         fdict["nskypet"] = "80"
         fdict["nstdpet"] = "40"
     elif args.faflavor == "sv1elg":
@@ -795,8 +871,9 @@ def main():
         )
 
     mydirs = {}
-    if args.faflavor == "sv1m31":
-        mydirs["targ"] = os.path.join(
+    # AR targ directory (now a list)
+    if args.faflavor in ["sv1m31", "cmxorion", "cmxrosette"]:
+        mydirs["targ"] = [os.path.join(
             path_to_targets,
             "gaiadr2",
             args.dtver,
@@ -804,9 +881,9 @@ def main():
             fdict["survey"],
             "resolve",
             "supp",
-        )
+        )]
     else:
-        mydirs["targ"] = os.path.join(
+        mydirs["targ"] = [os.path.join(
             path_to_targets,
             args.dr,
             args.dtver,
@@ -814,7 +891,13 @@ def main():
             fdict["survey"],
             "resolve",
             fdict["dtobscon"],
-        )
+        )]
+    # AR additional directory for cmx33
+    if args.faflavor == "cmx33":
+        mydirs["targ"] += [os.path.join(
+                        path_to_targets, "gaiadr2", args.dtver, "targets/cmx/resolve/supp"
+                        )]
+    # AR secondary directory
     mydirs["scnd"] = os.path.join(
         path_to_targets,
         args.dr,
@@ -967,23 +1050,7 @@ def main():
         log.info("{:.1f}s\tstart generating {}-sky.fits".format(time() - start, root))
         # AR sky: read targets
         tiles = fits.open("{}-tiles.fits".format(root))[1].data
-        dsky = read_targets_in_tiles(mydirs["sky"], tiles=tiles, quick=True)
-        dsupp = read_targets_in_tiles(mydirs["skysupp"], tiles=tiles, quick=True)
-        # AR sky: merge + remove duplicates
-        d = np.concatenate([dsky, dsupp])
-        _, ii = np.unique(d["TARGETID"], return_index=True)
-        if len(ii) != len(d):
-            d = d[ii]
-            log.info(
-                "{:.1f}s\t{} duplicated TARGETID: dsky={}, dsupp={}, common={}".format(
-                    time() - start, len(dsky), len(dsupp), len(d)
-                )
-            )
-        log.info(
-            "{:.1f}s\tkeeping {} targets to {}-sky.fits".format(
-                time() - start, len(d), root
-            )
-        )
+        d = custom_read_targets_in_tiles([mydirs["sky"], mydirs["skysupp"]], tiles, log=log)
         # AR sky: write fits
         if fdict["survey"] == "sv1":
             survey = "sv"
@@ -1004,7 +1071,7 @@ def main():
         log.info("{:.1f}s\tstart generating {}-gfa.fits".format(time() - start, root))
         # AR gfa: read targets
         tiles = fits.open("{}-tiles.fits".format(root))[1].data
-        d = read_targets_in_tiles(mydirs["gfa"], tiles=tiles, quick=True)
+        d = custom_read_targets_in_tiles([mydirs["gfa"]], tiles, log=log) 
         log.info(
             "{:.1f}s\tkeeping {} targets to {}-gfa.fits".format(
                 time() - start, len(d), root
@@ -1031,9 +1098,10 @@ def main():
     # AR ! not using make_mtl !
     if dostd:
         log.info("{:.1f}s\tstart generating {}-std.fits".format(time() - start, root))
+        print(mydirs["targ"])
         # AR std: read targets
         tiles = fits.open("{}-tiles.fits".format(root))[1].data
-        d = read_targets_in_tiles(mydirs["targ"], tiles=tiles, quick=True)
+        d = custom_read_targets_in_tiles(mydirs["targ"], tiles, log=log) 
         keep = sel_targs(d, fdict["stdmsks"], log=log)
         # AR std: removing overlap with science targets
         isscience = sel_targs(d, fdict["msks"])
@@ -1064,40 +1132,7 @@ def main():
     if dotarg:
         log.info("{:.1f}s\tstart generating {}-targ.fits".format(time() - start, root))
         tiles = fits.open("{}-tiles.fits".format(root))[1].data
-        # AR targ: reading targets
-        # AR targ: M33
-        if args.faflavor == "cmxm33":
-            log.info(
-                "{:.1f}s\tcmxm33 also reading target from {}".format(
-                    time() - start,
-                    os.path.join(
-                        path_to_targets,
-                        "gaiadr2",
-                        args.dtver,
-                        "targets/cmx/resolve/supp",
-                    ),
-                )
-            )
-            ddark = read_targets_in_tiles(mydirs["targ"], tiles=tiles, quick=True)
-            dsupp = read_targets_in_tiles(
-                os.path.join(
-                    path_to_targets, "gaiadr2", args.dtver, "targets/cmx/resolve/supp"
-                ),
-                tiles=tiles,
-                quick=True,
-            )
-            # AR targ: M33 : merge + remove duplicates
-            d = np.concatenate([ddark, dsupp])
-            _, ii = np.unique(d["TARGETID"], return_index=True)
-            if len(ii) != len(d):
-                d = d[ii]
-                log.info(
-                    "{:.1f}s\t{} duplicated TARGETID: ddark={}, dsupp={}, common={}".format(
-                        time() - start, len(ddark), len(dsupp), len(d)
-                    )
-                )
-        else:
-            d = read_targets_in_tiles(mydirs["targ"], tiles=tiles, quick=True)
+        d = custom_read_targets_in_tiles(mydirs["targ"], tiles, log=log)
         # AR targ: cutting on requested targets
         keep = sel_targs(d, fdict["msks"], log=log)
         d = d[keep]
@@ -1163,11 +1198,12 @@ def main():
         )
         d = read_targets_in_tiles(fn, tiles=tiles, quick=False)
         # AR scnd: cutting on requested targets
-        keep = sel_targs(d, fdict["msks"], log=log)
+        # AR scnd: beforehand cutting the masks on SV1_SCND_TARGET
+        keep = sel_targs(d, {"SV1_SCND_TARGET":fdict["msks"]["SV1_SCND_TARGET"]}, log=log)
         d = d[keep]
         log.info(
             "{:.1f}s\tkeeping {:.0f}/{:.0f} secondary targets after having cut on {}".format(
-                time() - start, keep.sum(), len(keep), fdict["msks"]
+                time() - start, keep.sum(), len(keep), {"SV1_SCND_TARGET":fdict["msks"]["SV1_SCND_TARGET"]}
             )
         )
         # AR scnd: removing targets from other tiles?
@@ -1292,7 +1328,13 @@ def main():
             # AR folders, with replacing $DESI_ROOT by DESIROOT
             fd["PRIMARY"].write_key("DESIROOT", desiroot)
             for key in np.sort(list(mydirs.keys())):
-                fd["PRIMARY"].write_key(key, mydirs[key].replace(desiroot, "DESIROOT"))
+                if key == "targ":
+                    # AR header keywords: TARG, TARG2, TARG3, etc
+                    suffixs = [""] + np.arange(2,len(mydirs["targ"])+1).astype(str).tolist()
+                    for targdir,suffix in zip(mydirs["targ"], suffixs):
+                        fd["PRIMARY"].write_key("targ{}".format(suffix), targdir.replace(desiroot, "DESIROOT"))
+                else:
+                    fd["PRIMARY"].write_key(key, mydirs[key].replace(desiroot, "DESIROOT"))
             for kwargs in args._get_kwargs():
                 if kwargs[0].lower() in [
                     "outdir",
@@ -1410,6 +1452,7 @@ def main():
         for fn in ["{}-std.fits".format(root), "{}-scnd.fits".format(root)]:
             if os.path.isfile(fn):
                 fns += [fn]
+        print(fns)
         dp = {}
         for key in dpkeys:
             dp[key] = []
@@ -1419,7 +1462,10 @@ def main():
                 if key in d.dtype.names:
                     dp[key] += d[key].tolist()
                 else:
-                    dp[key] += [np.nan for i in d]
+                    if key in list(fdict["msks"].keys()):
+                        dp[key] += [0 for i in d]
+                    else:
+                        dp[key] += [np.nan for i in d]
         for key in dpkeys:
             dp[key] = np.array(dp[key])
         drap, ddecp = get_tpos(tsky, dp["RA"], dp["DEC"])
@@ -1659,11 +1705,11 @@ def main():
                     band, famin, famax = "G", 0.0, 0.5
                 if msk in ["QSO", "SV0_QSO"]:
                     band, famin, famax = "R", 0.0, 0.5
-                if "M33" in msk or "M31" in msk:
+                if "M33" in msk or "M31" in msk or "ORI_" or "MWS" in msk:
                     band, famin, famax = "G", 0.0, 0.5
                 # AR handling outside desi cases
                 # if (tile_in_desi == 1) & (args.faflavor != "cmxm33"):
-                if args.faflavor not in ["cmxm33", "sv1m31"]:
+                if args.faflavor not in ["cmxm33", "cmxorion", "cmxrosette", "sv1m31", "sv1praesepe"]:
                     ax = plt.subplot(gs[ix, 0])
                     keep = (dp["FLUX_" + band] > 0) & (mskpsel)
                     xp = (
@@ -1885,7 +1931,7 @@ def main():
 if __name__ == "__main__":
 
     # AR to speed up development/debugging
-    dotile, dosky, dostd, dogfa, dotarg, doscnd, dofa, dozip, doplot = (
+    dotile, dosky, dogfa, dostd, dotarg, doscnd, dofa, dozip, doplot = (
         False,
         False,
         False,
@@ -1898,8 +1944,8 @@ if __name__ == "__main__":
     )
     dotile = True
     dosky = True
-    dostd = True
     dogfa = True
+    dostd = True
     dotarg = True
     doscnd = True
     dofa = True
@@ -1959,18 +2005,19 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--rundate",
-        help="rundate for focalplane (default=2020-03-06T00:00:00)",
+        help="rundate for focalplane (default=2021-01-17T00:00:00)",
         type=str,
-        default="2020-03-06T00:00:00",
+        default="2021-01-17T00:00:00",
         required=False,
         metavar="RUNDATE",
     )
     parser.add_argument(
         "--dr",
-        help="legacypipe dr (default=dr9)",
+        help="legacypipe dr: {} (default=dr9)".format(", ".join(dr_all)),
         type=str,
         default="dr9",
         required=False,
+        choices=dr_all,
         metavar="DR",
     )
     parser.add_argument(
@@ -2044,4 +2091,4 @@ if __name__ == "__main__":
 
     with stdouterr_redirected(to=logfn):
         main()
-    # main()
+    #main()

--- a/bin/fba_sv1
+++ b/bin/fba_sv1
@@ -821,7 +821,7 @@ def main():
     elif args.faflavor == "sv1umaii":
         fdict["survey"] = "sv1"
         fdict["dtobscon"] = "dark"
-        fdict["obscon"] = "DARK|GRAY|BRIGHT"                                                                                                                                        
+        fdict["obscon"] = "DARK|GRAY|BRIGHT" 
         fdict["msks"] = {"SV1_DESI_TARGET": "MWS_ANY", "SV1_SCND_TARGET": "MWS_CALIB,BACKUP_CALIB,MWS_MAIN_CLUSTER_SV,MWS_RRLYR,BHB"}
         fdict["stdmsks"] = {"SV1_DESI_TARGET": "STD_WD,STD_FAINT"}
         fdict["nskypet"] = "80"
@@ -837,7 +837,7 @@ def main():
     elif args.faflavor == "sv1praesepe":
         fdict["survey"] = "sv1"
         fdict["dtobscon"] = "bright"
-        fdict["obscon"] = "BRIGHT"
+        fdict["obscon"] = "DARK|GRAY|BRIGHT"
         fdict["msks"] = {
             "SV1_MWS_TARGET": "MWS_WD,MWS_MAIN_BROAD,MWS_NEARBY",
             "SV1_SCND_TARGET": ",".join(


### PR DESCRIPTION
This PR adds several updates developed during the implementation of the orion/rosette/praesepe programs:
- default rundate updated to 2021-01-17T00:00:00
- new faflavors: "cmxorion" (not used, but kept in case), "sv1orion", "sv1rosette", "sv1praesepe", "sv1umaii"
- possibility to read multiple input directories
- custom_make_mtl: mixed=True
- secondary: cutting on SV1_SCND_TARGET masks only
- qa plots: all possible wd and std masks are now stored in the beginning in a dictionary + some updates
- adding UMAII
- black formatting
