### PR TITLE
remove -Wstrict-prototypes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -217,8 +217,10 @@ class BuildExt(build_ext):
         for ext in self.extensions:
             ext.extra_compile_args.extend(opts)
             ext.extra_link_args.extend(linkopts)
-        build_ext.build_extensions(self)
 
+        # remove -Wstrict-prototypes flag
+        self.compiler.compiler_so.remove("-Wstrict-prototypes")        
+        build_ext.build_extensions(self)
 
 ext_modules = [
     Extension(

--- a/setup.py
+++ b/setup.py
@@ -219,7 +219,9 @@ class BuildExt(build_ext):
             ext.extra_link_args.extend(linkopts)
 
         # remove -Wstrict-prototypes flag
-        self.compiler.compiler_so.remove("-Wstrict-prototypes")        
+        if '-Wstrict-prototypes' in self.compiler.compiler_so:
+            self.compiler.compiler_so.remove("-Wstrict-prototypes")
+
         build_ext.build_extensions(self)
 
 ext_modules = [


### PR DESCRIPTION
This branch corrects a distutils bug that adds spurious -Wstrict-prototypes flag when compiling c++ extensions, by removing the flag in setup.py. 