### PR TITLE
Restore NUMOBS_INIT from columns loaded from target files.

### DIFF
--- a/py/fiberassign/assign.py
+++ b/py/fiberassign/assign.py
@@ -872,7 +872,8 @@ minimal_target_columns = OrderedDict([
     #('SCND_TARGET', '>i8'),
     ('SUBPRIORITY', '>f8'),
     ('OBSCONDITIONS', '>i8'),
-    ('PRIORITY_INIT', '>i8')
+    ('PRIORITY_INIT', '>i8'),
+    ('NUMOBS_INIT', '>i8')
 ])
 
 merged_fiberassign_swap = {


### PR DESCRIPTION
This restores loading NUMOBS_INIT from the target files, but it does not affect the output TARGETS table, since those columns are a more restrictive set that do not include this column.  Essentially, this change just attempts to avoid confusion and does not change the output format.