### PR TITLE
support matplotlib 3.3.4

### DIFF
--- a/py/fiberassign/vis.py
+++ b/py/fiberassign/vis.py
@@ -47,9 +47,9 @@ def set_matplotlib_pdf_backend():
         return
     try:
         import matplotlib
-        matplotlib.use("pdf", warn=False)
+        matplotlib.use("pdf")
         import matplotlib.pyplot as plt
-    except:
+    except ValueError:
         warnings.warn(
             """Couldn't set the PDF matplotlib backend,
 positioner plots may be low resolution.


### PR DESCRIPTION
fiberassign visualization was failing with matplotlib 3.3.4 due to it's use of a deprecated (and now gone) parameter "warn" in `matplotlib.use(backend)`.  Ironically, fiberassign was setting `warn=False` which was the default anyway, so in matplotlib 3.2.1 which we have been using, it had no effect anyway.  This PR branch passes tests at NERSC under both matplotlib 3.3.4 and 3.2.1 .

I also changed the generic `except:` to `except ValueError:` (which is what is raised if a backend isn't installed), since in this failure case the missing `warn` parameter was being caught and obfuscating why the pdf backend wouldn't load.  This change is not strictly necessary to support matplotlib 3.3.4.

I'll leave this PR open for a bit in case @tskisner remembers why the `warn=False` option was needed in the first place, and/or whether there is another case/exception where the pdf backend couldn't be loaded even though installed, e.g. due to a different backend being loaded first (I wasn't able to create a case like that testing at NERSC).