### PR TITLE
Change assignment of leftover fibers

### DIFF
--- a/py/fiberassign/assign.py
+++ b/py/fiberassign/assign.py
@@ -328,9 +328,6 @@ def write_assignment_fits_tile(asgn, fulltarget, overwrite, params):
                 ):
                     # This positioner is not moveable and therefore has a theta / phi
                     # position in the hardware model.  Used this fixed fiber location.
-                    print("loc {}, state {} is stuck / broken, using {} / {}".format(
-                        loc, hw.state[loc], hw.loc_theta_pos[loc], hw.loc_phi_pos[loc],
-                    ), flush=True)
                     xy = hw.thetaphi_to_xy(
                         hw.loc_pos_curved_mm[loc],
                         hw.loc_theta_pos[loc],
@@ -353,9 +350,6 @@ def write_assignment_fits_tile(asgn, fulltarget, overwrite, params):
                     phmax = hw.loc_phi_max[loc] + hw.loc_phi_offset[loc]
                     if phmax > np.pi:
                         phmax = np.pi
-                    print("loc {}, state {} is unassigned, using {} / {}".format(
-                        loc, hw.state[loc], thmin, phmax,
-                    ), flush=True)
                     xy = hw.thetaphi_to_xy(
                         hw.loc_pos_curved_mm[loc],
                         thmin,
@@ -1645,9 +1639,14 @@ def run(
     gt.stop("Force assignment of sufficient supp_sky")
 
     # If there are any unassigned fibers, try to place them somewhere.
-    # Assigning science again is a no-op, but...
+    # When assigning science targets to these unused fibers, also consider targets
+    # with no remaining observations.  Getting extra observations of science
+    # targets is preferred over additional standards and sky.  See desi-survey email
+    # list archive message 1865 and preceding discussion thread.
     gt.start("Assign remaining unassigned fibers")
-    asgn.assign_unused(TARGET_TYPE_SCIENCE, -1, "POS", start_tile, stop_tile)
+    asgn.assign_unused(
+        TARGET_TYPE_SCIENCE, -1, "POS", start_tile, stop_tile, use_zero_obsremain=True
+    )
     asgn.assign_unused(TARGET_TYPE_STANDARD, -1, "POS", start_tile, stop_tile)
     asgn.assign_unused(TARGET_TYPE_SKY, -1, "POS", start_tile, stop_tile)
     asgn.assign_unused(TARGET_TYPE_SUPPSKY, -1, "POS", start_tile, stop_tile)

--- a/py/fiberassign/assign.py
+++ b/py/fiberassign/assign.py
@@ -1565,7 +1565,8 @@ def run(
     sky_per_petal=40,
     start_tile=-1,
     stop_tile=-1,
-    redistribute=True
+    redistribute=True,
+    use_zero_obsremain=True
 ):
     """Run fiber assignment.
 
@@ -1645,7 +1646,12 @@ def run(
     # list archive message 1865 and preceding discussion thread.
     gt.start("Assign remaining unassigned fibers")
     asgn.assign_unused(
-        TARGET_TYPE_SCIENCE, -1, "POS", start_tile, stop_tile, use_zero_obsremain=True
+        TARGET_TYPE_SCIENCE,
+        -1,
+        "POS",
+        start_tile,
+        stop_tile,
+        use_zero_obsremain=use_zero_obsremain
     )
     asgn.assign_unused(TARGET_TYPE_STANDARD, -1, "POS", start_tile, stop_tile)
     asgn.assign_unused(TARGET_TYPE_SKY, -1, "POS", start_tile, stop_tile)

--- a/py/fiberassign/scripts/assign.py
+++ b/py/fiberassign/scripts/assign.py
@@ -166,6 +166,10 @@ def parse_assign(optlist=None):
                         action="store_true",
                         help="Disable redistribution of science targets.")
 
+    parser.add_argument("--no_zero_obsremain", required=False, default=False,
+                        action="store_true",
+                        help="Disable oversubscription of science targets with leftover fibers.")
+
     args = None
     if optlist is None:
         args = parser.parse_args()
@@ -360,7 +364,8 @@ def run_assign_full(args):
         asgn,
         args.standards_per_petal,
         args.sky_per_petal,
-        redistribute=(not args.no_redistribute)
+        redistribute=(not args.no_redistribute),
+        use_zero_obsremain=(not args.no_zero_obsremain)
     )
 
     gt.stop("run_assign_full calculation")
@@ -441,7 +446,8 @@ def run_assign_bytile(args):
             args.sky_per_petal,
             start_tile=tile_id,
             stop_tile=tile_id,
-            redistribute=(not args.no_redistribute)
+            redistribute=(not args.no_redistribute),
+            use_zero_obsremain=(not args.no_zero_obsremain)
         )
 
     gt.stop("run_assign_bytile calculation")

--- a/src/_pyfiberassign.cpp
+++ b/src/_pyfiberassign.cpp
@@ -1545,7 +1545,8 @@ PYBIND11_MODULE(_internal, m) {
              py::arg("tgtype")=TARGET_TYPE_SCIENCE,
              py::arg("max_per_petal")=-1,
              py::arg("pos_type")=std::string("POS"),
-             py::arg("start_tile")=-1, py::arg("stop_tile")=-1, R"(
+             py::arg("start_tile")=-1, py::arg("stop_tile")=-1,
+             py::arg("use_zero_obsremain")=false, R"(
             Assign targets to unused locations.
 
             This will attempt to assign targets of the specified type to
@@ -1562,6 +1563,8 @@ PYBIND11_MODULE(_internal, m) {
                     sequence of tiles.
                 stop_tile (int): Stop assignment at this tile ID (inclusive)
                     in the sequence of tiles.
+                use_zero_obsremain (bool): If True, and tgtype is science targets,
+                    then consider science targets with < 1 observation remaining.
 
             Returns:
                 None

--- a/src/assign.cpp
+++ b/src/assign.cpp
@@ -125,7 +125,8 @@ void fba::Assignment::tile_available(
     std::vector <int32_t> const & locs,
     std::map <int32_t, std::vector <target_weight> > & tile_target_avail,
     std::map <int64_t, std::vector <location_weight> > & tile_loc_avail,
-    std::vector <target_weight> & tile_target_weights
+    std::vector <target_weight> & tile_target_weights,
+    bool use_zero_obsremain
 ) const {
     // Reset output objects
     tile_target_avail.clear();
@@ -143,8 +144,13 @@ void fba::Assignment::tile_available(
                 // This is not the correct target type.
                 continue;
             }
-            if ((tgtype == TARGET_TYPE_SCIENCE) && (tg.obsremain <= 0)) {
-                // Done observing science observations for this target
+            if (
+                (tgtype == TARGET_TYPE_SCIENCE)
+                && (tg.obsremain <= 0)
+                && ! use_zero_obsremain
+            ) {
+                // Done observing science observations for this target, and we are
+                // not considering science targets with zero obs remaining.
                 continue;
             }
             // distance from target to positioner
@@ -229,7 +235,8 @@ bool fba::Assignment::petal_count_max(
 
 void fba::Assignment::assign_unused(uint8_t tgtype, int32_t max_per_petal,
                                     std::string const & pos_type,
-                                    int32_t start_tile, int32_t stop_tile) {
+                                    int32_t start_tile, int32_t stop_tile,
+                                    bool use_zero_obsremain) {
     fba::Timer tm;
     tm.start();
 
@@ -337,7 +344,8 @@ void fba::Assignment::assign_unused(uint8_t tgtype, int32_t max_per_petal,
             loc_unassigned,
             tile_target_avail,
             tile_loc_avail,
-            tile_target_weights
+            tile_target_weights,
+            use_zero_obsremain
         );
 
         // Sort targets by total priority from highest to lowest.
@@ -717,7 +725,8 @@ void fba::Assignment::assign_force(uint8_t tgtype, int32_t required_per_petal,
             loc_science,
             tile_target_avail,
             tile_loc_avail,
-            tile_target_weights
+            tile_target_weights,
+            false
         );
 
         gtm.stop(gtmname.str());

--- a/src/assign.h
+++ b/src/assign.h
@@ -32,7 +32,8 @@ class Assignment : public std::enable_shared_from_this <Assignment> {
 
         void assign_unused(uint8_t tgtype, int32_t max_per_petal = -1,
                            std::string const & pos_type = std::string("POS"),
-                           int32_t start_tile = -1, int32_t stop_tile = -1);
+                           int32_t start_tile = -1, int32_t stop_tile = -1,
+                           bool use_zero_obsremain = false);
 
         void assign_force(uint8_t tgtype, int32_t required_per_petal = 0,
                           int32_t start_tile = -1, int32_t stop_tile = -1);
@@ -79,7 +80,7 @@ class Assignment : public std::enable_shared_from_this <Assignment> {
             std::vector <int32_t> const & locs,
             std::map <int32_t, std::vector <target_weight> > & tile_target_avail,
             std::map <int64_t, std::vector <location_weight> > & tile_loc_avail,
-            std::vector <target_weight> & tile_target_weights
+            std::vector <target_weight> & tile_target_weights, bool use_zero_obsremain
         ) const;
 
         int32_t petal_count(


### PR DESCRIPTION
After assigning science targets which have remaining observations, and then ensuring that the per-petal quota of standards and sky are met, there may be some unassigned fibers.  These unassigned fibers are then assigned to science, standards, and sky if possible.

In the current main branch, science targets with less than one remaining obs are never considered for assignment, even in this "last ditch" effort to assign unused fibers.

This PR changes that behavior to allow assignment to science targets with less than one obs remaining during this final attempt to assign the leftover positioners.