### PR TITLE
Add per-slitblock sky fiber limits

### DIFF
--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -1063,6 +1063,12 @@ def main():
             "--gfafile",
             mytmpouts["gfa"],
         ]
+        if args.sky_per_slitblock:
+            opts += [
+                "--sky_per_slitblock",
+                str(args.sky_per_slitblock),
+            ]
+
         log.info(
             "{:.1f}s\tdofa\ttileid={:06d}: running raw fiber assignment (run_assign_full) with opts={}".format(
                 time() - start, args.tileid, " ; ".join(opts)
@@ -2052,6 +2058,13 @@ if __name__ == "__main__":
         help="required number of sky targets per petal (default=40)",
         type=str,
         default="40",
+        required=False,
+    )
+    parser.add_argument(
+        "--sky_per_slitblock",
+        help="Required number of sky targets per fiber slitblock",
+        type=int,
+        default=0,
         required=False,
     )
     parser.add_argument(

--- a/py/fiberassign/assign.py
+++ b/py/fiberassign/assign.py
@@ -1612,7 +1612,7 @@ def run(
 
     # First-pass assignment of science targets
     gt.start("Assign unused fibers to science targets")
-    asgn.assign_unused(TARGET_TYPE_SCIENCE, -1, "POS", start_tile, stop_tile)
+    asgn.assign_unused(TARGET_TYPE_SCIENCE, -1, -1, "POS", start_tile, stop_tile)
     gt.stop("Assign unused fibers to science targets")
 
     # Redistribute science targets across available petals
@@ -1715,8 +1715,8 @@ def run(
 
     # Assign sky monitor fibers
     gt.start("Assign sky monitor fibers")
-    asgn.assign_unused(TARGET_TYPE_SKY, -1, -1 "ETC", start_tile, stop_tile)
-    asgn.assign_unused(TARGET_TYPE_SUPPSKY, -1, -1 "ETC", start_tile, stop_tile)
+    asgn.assign_unused(TARGET_TYPE_SKY, -1, -1, "ETC", start_tile, stop_tile)
+    asgn.assign_unused(TARGET_TYPE_SUPPSKY, -1, -1, "ETC", start_tile, stop_tile)
     asgn.assign_unused(TARGET_TYPE_SAFE, -1, -1, "ETC", start_tile, stop_tile)
     gt.stop("Assign sky monitor fibers")
 

--- a/py/fiberassign/assign.py
+++ b/py/fiberassign/assign.py
@@ -1579,6 +1579,7 @@ def run(
     asgn,
     std_per_petal=10,
     sky_per_petal=40,
+    sky_per_slitblock=0,
     start_tile=-1,
     stop_tile=-1,
     redistribute=True,
@@ -1597,6 +1598,7 @@ def run(
         asgn (Assignment):  The assignment class
         std_per_petal (int):  The number of standards to assign per petal
         sky_per_petal (int):  The number of sky to assign per petal
+        sky_per_slitblock (int):  The number of sky to assign per slitblock
         start_tile (int):  If specified, the first tile ID to assign.
         stop_tile (int):  If specified, the last tile ID to assign.
         redistribute (bool):  If True, attempt to shift science targets to unassigned
@@ -1622,37 +1624,68 @@ def run(
     # Assign standards, up to some limit
     gt.start("Assign unused fibers to standards")
     asgn.assign_unused(
-        TARGET_TYPE_STANDARD, std_per_petal, "POS", start_tile, stop_tile
+        TARGET_TYPE_STANDARD, std_per_petal, -1, "POS", start_tile, stop_tile
     )
     gt.stop("Assign unused fibers to standards")
 
+    def do_assign_unused_sky(ttype):
+        if sky_per_petal > 0 and sky_per_slitblock > 0:
+            # Assign using the slitblock requirement first, because it is
+            # more specific
+            asgn.assign_unused(
+                ttype, -1, sky_per_slitblock, "POS",
+                start_tile, stop_tile
+            )
+            # Then assign using the petal requirement, because it may(should) require
+            # more fibers overall.
+            asgn.assign_unused(
+                ttype, sky_per_petal, -1, "POS",
+                start_tile, stop_tile
+            )
+        else:
+            asgn.assign_unused(
+                ttype, sky_per_petal, sky_per_slitblock, "POS",
+                start_tile, stop_tile
+            )
+
     # Assign sky to unused fibers, up to some limit
     gt.start("Assign unused fibers to sky")
-    asgn.assign_unused(
-        TARGET_TYPE_SKY, sky_per_petal, "POS", start_tile, stop_tile
-    )
+    do_assign_unused_sky(TARGET_TYPE_SKY)
     gt.stop("Assign unused fibers to sky")
 
     # Assign suppsky to unused fibers, up to some limit
     gt.start("Assign unused fibers to supp_sky")
-    asgn.assign_unused(
-        TARGET_TYPE_SUPPSKY, sky_per_petal, "POS", start_tile, stop_tile
-    )
+    do_assign_unused_sky(TARGET_TYPE_SUPPSKY)
     gt.stop("Assign unused fibers to supp_sky")
 
     # Force assignment if needed
     gt.start("Force assignment of sufficient standards")
     asgn.assign_force(
-        TARGET_TYPE_STANDARD, std_per_petal, start_tile, stop_tile
+        TARGET_TYPE_STANDARD, std_per_petal, -1, start_tile, stop_tile
     )
     gt.stop("Force assignment of sufficient standards")
 
+    def do_assign_forced_sky(ttype):
+        # This function really feels redundant with do_assign_unused_sky, but
+        # when I tried to make a single function to do both calls, I had to call
+        # f(*(preargs + pos_arg + postargs)) and it looked too mysterious.
+        if sky_per_petal > 0 and sky_per_slitblock > 0:
+            # Slitblock first
+            asgn.assign_force(
+                ttype, -1, sky_per_slitblock, start_tile, stop_tile)
+            # Then petal
+            asgn.assign_force(
+                ttype, sky_per_petal, -1, start_tile, stop_tile)
+        else:
+            asgn.assign_force(
+                ttype, sky_per_petal, sky_per_slitblock, start_tile, stop_tile)
+
     gt.start("Force assignment of sufficient sky")
-    asgn.assign_force(TARGET_TYPE_SKY, sky_per_petal, start_tile, stop_tile)
+    do_assign_forced_sky(TARGET_TYPE_SKY)
     gt.stop("Force assignment of sufficient sky")
 
     gt.start("Force assignment of sufficient supp_sky")
-    asgn.assign_force(TARGET_TYPE_SUPPSKY, sky_per_petal, start_tile, stop_tile)
+    do_assign_forced_sky(TARGET_TYPE_SUPPSKY)
     gt.stop("Force assignment of sufficient supp_sky")
 
     # If there are any unassigned fibers, try to place them somewhere.
@@ -1664,26 +1697,27 @@ def run(
     asgn.assign_unused(
         TARGET_TYPE_SCIENCE,
         -1,
+        -1,
         "POS",
         start_tile,
         stop_tile,
         use_zero_obsremain=use_zero_obsremain
     )
-    asgn.assign_unused(TARGET_TYPE_STANDARD, -1, "POS", start_tile, stop_tile)
-    asgn.assign_unused(TARGET_TYPE_SKY, -1, "POS", start_tile, stop_tile)
-    asgn.assign_unused(TARGET_TYPE_SUPPSKY, -1, "POS", start_tile, stop_tile)
+    asgn.assign_unused(TARGET_TYPE_STANDARD, -1, -1, "POS", start_tile, stop_tile)
+    asgn.assign_unused(TARGET_TYPE_SKY, -1, -1, "POS", start_tile, stop_tile)
+    asgn.assign_unused(TARGET_TYPE_SUPPSKY, -1, -1, "POS", start_tile, stop_tile)
 
     # Assign safe location to unused fibers (no maximum).  There should
     # always be at least one safe location (i.e. "BAD_SKY") for each fiber.
     # So after this is run every fiber should be assigned to something.
-    asgn.assign_unused(TARGET_TYPE_SAFE, -1, "POS", start_tile, stop_tile)
+    asgn.assign_unused(TARGET_TYPE_SAFE, -1, -1, "POS", start_tile, stop_tile)
     gt.stop("Assign remaining unassigned fibers")
 
     # Assign sky monitor fibers
     gt.start("Assign sky monitor fibers")
-    asgn.assign_unused(TARGET_TYPE_SKY, -1, "ETC", start_tile, stop_tile)
-    asgn.assign_unused(TARGET_TYPE_SUPPSKY, -1, "ETC", start_tile, stop_tile)
-    asgn.assign_unused(TARGET_TYPE_SAFE, -1, "ETC", start_tile, stop_tile)
+    asgn.assign_unused(TARGET_TYPE_SKY, -1, -1 "ETC", start_tile, stop_tile)
+    asgn.assign_unused(TARGET_TYPE_SUPPSKY, -1, -1 "ETC", start_tile, stop_tile)
+    asgn.assign_unused(TARGET_TYPE_SAFE, -1, -1, "ETC", start_tile, stop_tile)
     gt.stop("Assign sky monitor fibers")
 
     return asgn

--- a/py/fiberassign/scripts/assign.py
+++ b/py/fiberassign/scripts/assign.py
@@ -119,6 +119,10 @@ def parse_assign(optlist=None):
                         default=40, help="Required number of sky targets per"
                         " petal")
 
+    parser.add_argument("--sky_per_slitblock", type=int, required=False,
+                        default=0, help="Required number of sky targets per"
+                        " fiber slitblock")
+
     parser.add_argument("--write_all_targets", required=False, default=False,
                         action="store_true",
                         help="When writing target properties, write data "
@@ -371,6 +375,7 @@ def run_assign_full(args):
         asgn,
         args.standards_per_petal,
         args.sky_per_petal,
+        args.sky_per_slitblock,
         redistribute=(not args.no_redistribute),
         use_zero_obsremain=(not args.no_zero_obsremain)
     )
@@ -458,6 +463,7 @@ def run_assign_bytile(args):
             asgn,
             args.standards_per_petal,
             args.sky_per_petal,
+            args.sky_per_slitblock,
             start_tile=tile_id,
             stop_tile=tile_id,
             redistribute=(not args.no_redistribute),

--- a/py/fiberassign/stucksky.py
+++ b/py/fiberassign/stucksky.py
@@ -14,9 +14,10 @@ def stuck_on_sky(hw, tiles):
     from fiberassign.hardware import FIBER_STATE_STUCK, FIBER_STATE_BROKEN
     from fiberassign.utils import Logger
 
+    log = Logger.get()
+
     skybricks_dir = os.environ.get('SKYBRICKS_DIR', None)
     if skybricks_dir is None:
-        log = Logger.get()
         log.warning('Environment variable SKYBRICKS_DIR is not set; not looking up whether '
                     'stuck positioners land on good sky')
         return
@@ -80,8 +81,6 @@ def stuck_on_sky(hw, tiles):
         loc_ra  = np.array([r for r,d in loc_radec])
         loc_dec = np.array([d for r,d in loc_radec])
 
-        print('Tile', tile_ra, tile_dec)
-        
         good_sky = np.zeros(len(loc_ra), bool)
         # Check possibly-overlapping skybricks.
         for i in sky_inds:
@@ -90,15 +89,14 @@ def stuck_on_sky(hw, tiles):
                 (loc_ra  <  skybricks['RA2'][i]) *
                 (loc_dec >= skybricks['DEC1'][i]) *
                 (loc_dec <  skybricks['DEC2'][i]))
-            print(len(loc_in), 'fibers overlap brick', skybricks['BRICKNAME'][i])
+            log.debug('%i fibers overlap sky brick %s' % (len(loc_in), skybricks['BRICKNAME'][i]))
             if len(loc_in) == 0:
                 continue
 
             fn = os.path.join(skybricks_dir,
                               'sky-%s.fits.gz' % skybricks['BRICKNAME'][i])
-            # FIXME -- debugging
             if not os.path.exists(fn):
-                print('Missing:', fn)
+                log.warning('Sky bricks: missing file %s' % fn)
                 continue
 
             skymap,hdr = fitsio.read(fn, header=True)

--- a/py/fiberassign/stucksky.py
+++ b/py/fiberassign/stucksky.py
@@ -41,8 +41,8 @@ def stuck_on_sky(hw, tiles):
     
         # Stuck locations and their angles
         stuck_loc = [loc for loc in hw.locations
-                     if ((hw.state[loc] & FIBER_STATE_STUCK != 0) and
-                         (hw.state[loc] & FIBER_STATE_BROKEN == 0) and
+                     if (((hw.state[loc] & FIBER_STATE_STUCK) != 0) and
+                         ((hw.state[loc] & FIBER_STATE_BROKEN) == 0) and
                          (hw.loc_device_type[loc] == 'POS'))]
         stuck_theta = [hw.loc_theta_pos[x] for x in stuck_loc]
         stuck_phi   = [hw.loc_phi_pos  [x] for x in stuck_loc]

--- a/py/fiberassign/test/test_assign.py
+++ b/py/fiberassign/test/test_assign.py
@@ -55,6 +55,9 @@ from .simulate import (test_subdir_create, sim_tiles, sim_targets,
 class TestAssign(unittest.TestCase):
 
     def setUp(self):
+        self.saved_skybricks = os.environ.get('STUCKSKY_DIR')
+        if self.saved_skybricks is not None:
+            del os.environ['SKYBRICKS_DIR']
         self.density_science = 5000
         self.density_standards = 5000
         self.density_sky = 100
@@ -62,7 +65,8 @@ class TestAssign(unittest.TestCase):
         pass
 
     def tearDown(self):
-        pass
+        if self.saved_skybricks is not None:
+            os.environ['STUCKSKY_DIR'] = self.saved_skybricks
 
     def test_io(self):
         np.random.seed(123456789)

--- a/src/_pyfiberassign.cpp
+++ b/src/_pyfiberassign.cpp
@@ -1546,6 +1546,7 @@ PYBIND11_MODULE(_internal, m) {
         .def("assign_unused", &fba::Assignment::assign_unused,
              py::arg("tgtype")=TARGET_TYPE_SCIENCE,
              py::arg("max_per_petal")=-1,
+             py::arg("max_per_slitblock")=-1,
              py::arg("pos_type")=std::string("POS"),
              py::arg("start_tile")=-1, py::arg("stop_tile")=-1,
              py::arg("use_zero_obsremain")=false, R"(
@@ -1559,6 +1560,8 @@ PYBIND11_MODULE(_internal, m) {
                     of the predefined TARGET_TYPE_* module attributes.
                 max_per_petal (int): Limit the assignment to this many objects
                     per petal.  Default is no limit.
+                max_per_slitblock (int): Limit the assignment to this many objects
+                    per slitblock.  Default is no limit.
                 pos_type (str): Only consider this positioner device type.
                     Default is "POS".
                 start_tile (int): Start assignment at this tile ID in the
@@ -1575,6 +1578,7 @@ PYBIND11_MODULE(_internal, m) {
         .def("assign_force", &fba::Assignment::assign_force,
              py::arg("tgtype")=TARGET_TYPE_SCIENCE,
              py::arg("required_per_petal")=0,
+             py::arg("required_per_slitblock")=0,
              py::arg("start_tile")=-1, py::arg("stop_tile")=-1, R"(
             Force assignment of targets to unused locations.
 
@@ -1586,6 +1590,8 @@ PYBIND11_MODULE(_internal, m) {
                 tgtype (int): The target type to assign, which must be one
                     of the predefined TARGET_TYPE_* module attributes.
                 required_per_petal (int): Bump science targets until this
+                    limit is reached.
+                required_per_slitblock (int): Bump science targets until this
                     limit is reached.
                 start_tile (int): Start assignment at this tile ID in the
                     sequence of tiles.

--- a/src/assign.cpp
+++ b/src/assign.cpp
@@ -35,9 +35,7 @@ fba::Assignment::Assignment(fba::Targets::pshr tgs,
 
     // Get the hardware and tile configuration
     tiles_ = tgsavail_->tiles();
-    std::cout << "get hardware" << std::endl;
     hw_ = tgsavail_->hardware();
-    std::cout << "get hardware done. nslitblock " << hw_->nslitblock << std::endl;
 
     // Initialize assignment counts
 
@@ -96,7 +94,7 @@ fba::Assignment::Assignment(fba::Targets::pshr tgs,
                 nassign_slitblock.at(tp).at(tile_id).at(petal).at(slitblock)++;
                 logmsg.str("");
                 logmsg << "tile " << tile_id << " loc " << loc
-                       << " on petal " << petal << " and slitblock "
+                       << " on petal " << petal << ", slitblock "
                        << slitblock << " is STUCK on a good sky.";
                 logger.debug(logmsg.str().c_str());
             }

--- a/src/assign.cpp
+++ b/src/assign.cpp
@@ -474,7 +474,7 @@ void fba::Assignment::assign_unused(uint8_t tgtype, int32_t max_per_petal,
                 // The petal of this location
                 int32_t p = hw_->loc_petal.at(loc);
                 // Check petal count limits
-                if (petal_count_max(tgtype, max_per_petal, tile_id, p)) {
+                if (max_per_petal && petal_count_max(tgtype, max_per_petal, tile_id, p)) {
                     continue;
                 }
 
@@ -859,7 +859,8 @@ void fba::Assignment::assign_force(uint8_t tgtype, int32_t required_per_petal,
             unique_petal.insert(p);
 
             // Check petal count limits
-            if (petal_count_max(tgtype, required_per_petal, tile_id, p)) {
+            if ((required_per_petal > 0) &&
+                petal_count_max(tgtype, required_per_petal, tile_id, p)) {
                 continue;
             }
 

--- a/src/assign.cpp
+++ b/src/assign.cpp
@@ -868,7 +868,8 @@ void fba::Assignment::assign_force(uint8_t tgtype, int32_t required_per_petal,
             int32_t s = hw_->loc_slitblock.at(tgloc);
             unique_slitblock.insert(std::make_pair(p, s));
             // Check slitblock count limits
-            if (slitblock_count_max(tgtype, required_per_slitblock, tile_id, p, s)) {
+            if ((required_per_slitblock > 0) &&
+                slitblock_count_max(tgtype, required_per_slitblock, tile_id, p, s)) {
                 continue;
             }
 

--- a/src/assign.cpp
+++ b/src/assign.cpp
@@ -1035,14 +1035,14 @@ void fba::Assignment::assign_force(uint8_t tgtype, int32_t required_per_petal,
     gtm.stop(gtmname.str());
 
     logmsg.str("");
-    if (required_per_petal && required_per_slitblock) {
+    if ((required_per_petal > 0) && (required_per_slitblock > 0)) {
         logmsg << "Force assignment of " << required_per_petal << " "
                << tgstr << " targets per petal and " << required_per_slitblock
                << " per slitblock";
-    } else if (required_per_petal) {
+    } else if (required_per_petal > 0) {
         logmsg << "Force assignment of " << required_per_petal << " "
                << tgstr << " targets per petal";
-    } else if (required_per_slitblock) {
+    } else if (required_per_slitblock > 0) {
         logmsg << "Force assignment of " << required_per_slitblock << " "
                << tgstr << " targets per slitblock";
     }

--- a/src/assign.h
+++ b/src/assign.h
@@ -31,14 +31,15 @@ class Assignment : public std::enable_shared_from_this <Assignment> {
                    LocationsAvailable::pshr locavail,
                    std::map<int32_t, std::map<int32_t, bool> > stuck_sky
                    = std::map<int32_t, std::map<int32_t,bool> >());
-                   
 
         void assign_unused(uint8_t tgtype, int32_t max_per_petal = -1,
+                           int32_t max_per_slitblock = -1,
                            std::string const & pos_type = std::string("POS"),
                            int32_t start_tile = -1, int32_t stop_tile = -1,
                            bool use_zero_obsremain = false);
 
         void assign_force(uint8_t tgtype, int32_t required_per_petal = 0,
+                          int32_t required_per_slitblock = 0,
                           int32_t start_tile = -1, int32_t stop_tile = -1);
 
         void redistribute_science(int32_t start_tile = -1,
@@ -97,6 +98,19 @@ class Assignment : public std::enable_shared_from_this <Assignment> {
             int32_t max_per_petal,
             int32_t tile,
             int32_t petal
+        ) const;
+
+        int32_t slitblock_count(
+            uint8_t tgtype,
+            int32_t tile,
+            int32_t slitblock
+        ) const;
+
+        bool slitblock_count_max(
+            uint8_t tgtype,
+            int32_t max_per_slitblock,
+            int32_t tile,
+            int32_t slitblock
         ) const;
 
         bool ok_to_assign(
@@ -158,8 +172,12 @@ class Assignment : public std::enable_shared_from_this <Assignment> {
         // The number of assigned locations per tile and spectrograph (petal)
         // For each target class.
         std::map <uint8_t, std::map <int32_t, int32_t> > nassign_tile;
+        // [target_type][tile_id][petal_id] = count
         std::map <uint8_t,
             std::map <int32_t, std::map <int32_t, int32_t> > > nassign_petal;
+        // [target_type][tile_id][slitblock_id] = count
+        std::map <uint8_t,
+            std::map <int32_t, std::map <int32_t, int32_t> > > nassign_slitblock;
 
         // shared handle to the hardware configuration.
         Hardware::pshr hw_;

--- a/src/assign.h
+++ b/src/assign.h
@@ -103,6 +103,7 @@ class Assignment : public std::enable_shared_from_this <Assignment> {
         int32_t slitblock_count(
             uint8_t tgtype,
             int32_t tile,
+            int32_t petal,
             int32_t slitblock
         ) const;
 
@@ -110,6 +111,7 @@ class Assignment : public std::enable_shared_from_this <Assignment> {
             uint8_t tgtype,
             int32_t max_per_slitblock,
             int32_t tile,
+            int32_t petal,
             int32_t slitblock
         ) const;
 
@@ -175,9 +177,10 @@ class Assignment : public std::enable_shared_from_this <Assignment> {
         // [target_type][tile_id][petal_id] = count
         std::map <uint8_t,
             std::map <int32_t, std::map <int32_t, int32_t> > > nassign_petal;
-        // [target_type][tile_id][slitblock_id] = count
+        // [target_type][tile_id][petal_id][slitblock_id] = count
         std::map <uint8_t,
-            std::map <int32_t, std::map <int32_t, int32_t> > > nassign_slitblock;
+            std::map <int32_t,
+            std::map <int32_t, std::map <int32_t, int32_t> > > > nassign_slitblock;
 
         // shared handle to the hardware configuration.
         Hardware::pshr hw_;

--- a/src/hardware.cpp
+++ b/src/hardware.cpp
@@ -112,6 +112,7 @@ fba::Hardware::Hardware(std::string const & timestr,
         loc_fiber[location[i]] = fiber[i];
         loc_slitblock[location[i]] = slitblock[i];
         loc_blockfiber[location[i]] = blockfiber[i];
+        //std::cout << device_type[i] << " " << i << ": petal " << petal[i] << " slitblock " << slitblock[i] << std::endl;
         petal_locations[petal[i]].push_back(location[i]);
         loc_pos_cs5_mm[location[i]] = std::make_pair(x_mm[i], y_mm[i]);
         state[location[i]] = status[i];

--- a/src/hardware.cpp
+++ b/src/hardware.cpp
@@ -64,6 +64,14 @@ fba::Hardware::Hardware(std::string const & timestr,
     }
     npetal = static_cast <size_t> (maxpetal + 1);
 
+    int32_t maxslitblock = 0;
+    for (auto const & p : slitblock) {
+        if (p > maxslitblock) {
+            maxslitblock = p;
+        }
+    }
+    nslitblock = static_cast <size_t> (maxslitblock + 1);
+
     loc_pos_cs5_mm.clear();
     loc_pos_curved_mm.clear();
     loc_petal.clear();

--- a/src/hardware.cpp
+++ b/src/hardware.cpp
@@ -112,7 +112,6 @@ fba::Hardware::Hardware(std::string const & timestr,
         loc_fiber[location[i]] = fiber[i];
         loc_slitblock[location[i]] = slitblock[i];
         loc_blockfiber[location[i]] = blockfiber[i];
-        //std::cout << device_type[i] << " " << i << ": petal " << petal[i] << " slitblock " << slitblock[i] << std::endl;
         petal_locations[petal[i]].push_back(location[i]);
         loc_pos_cs5_mm[location[i]] = std::make_pair(x_mm[i], y_mm[i]);
         state[location[i]] = status[i];

--- a/src/hardware.h
+++ b/src/hardware.h
@@ -187,6 +187,9 @@ class Hardware : public std::enable_shared_from_this <Hardware> {
         // The number of petals
         int32_t npetal;
 
+        // The number of slitblocks
+        int32_t nslitblock;
+
         // The number of science fibers (device == "POS") per petal.
         int32_t nfiber_petal;
 


### PR DESCRIPTION
Largely a mechanical change of adding per-slitblock counting in addition to the existing per-petal counting, used to enforce sky fiber spatial uniformity on the focal plane.
