### PR TITLE
Report counts of assigned fibers as fiber-assignment proceeds

### DIFF
--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -108,7 +108,7 @@ def custom_read_targets_in_tiles(
     return d
 
 
-# AR moves the file created by write_targets to outidr
+# AR moves the file created by write_targets to outdir
 # AR removes folders created by write_targets
 # AR - infn : filename output by write_targets()
 # AR - targdir : folder provided as write_targets() input

--- a/py/fiberassign/assign.py
+++ b/py/fiberassign/assign.py
@@ -1617,7 +1617,6 @@ def run(
         tiles = list(counts.keys())
         tiles.sort()
         for tile in tiles:
-            #print('Tile ', tile)
             msg = 'Tile %i: ' % tile
             if when is not None:
                 msg += when
@@ -1630,12 +1629,9 @@ def run(
                 if n is None:
                     log.warning('Key', k, 'missing from Assignment.get_counts return value')
                 else:
-                    #print('  %s: %i' % (k, n))
                     if n>0 or always:
                         ss.append('%s: %i' % (k,n))
-            log.debug(msg + ', '.join(ss))
-            #for k,v in tilecounts.items():
-            #    print('  %s: %i' % (k,v))
+            log.info(msg + ', '.join(ss))
 
     print_counts('Start: ')
 

--- a/py/fiberassign/assign.py
+++ b/py/fiberassign/assign.py
@@ -1610,10 +1610,16 @@ def run(
     """
     gt = GlobalTimers.get()
 
+    print('Start:')
+    asgn.print_status(start_tile, stop_tile)
+
     # First-pass assignment of science targets
     gt.start("Assign unused fibers to science targets")
     asgn.assign_unused(TARGET_TYPE_SCIENCE, -1, -1, "POS", start_tile, stop_tile)
     gt.stop("Assign unused fibers to science targets")
+
+    print('After assigning unused fibers to science targets:')
+    asgn.print_status(start_tile, stop_tile)
 
     # Redistribute science targets across available petals
     if redistribute:
@@ -1621,12 +1627,18 @@ def run(
         asgn.redistribute_science(start_tile, stop_tile)
         gt.stop("Redistribute science targets")
 
+        print('After redistributing science targets:')
+        asgn.print_status(start_tile, stop_tile)
+
     # Assign standards, up to some limit
     gt.start("Assign unused fibers to standards")
     asgn.assign_unused(
         TARGET_TYPE_STANDARD, std_per_petal, -1, "POS", start_tile, stop_tile
     )
     gt.stop("Assign unused fibers to standards")
+
+    print('After assigning standards:')
+    asgn.print_status(start_tile, stop_tile)
 
     def do_assign_unused_sky(ttype):
         if sky_per_petal > 0 and sky_per_slitblock > 0:
@@ -1636,17 +1648,24 @@ def run(
                 ttype, -1, sky_per_slitblock, "POS",
                 start_tile, stop_tile
             )
+            print('After assigning [supp]sky per-slitblock:')
+            asgn.print_status(start_tile, stop_tile)
+
             # Then assign using the petal requirement, because it may(should) require
             # more fibers overall.
             asgn.assign_unused(
                 ttype, sky_per_petal, -1, "POS",
                 start_tile, stop_tile
             )
+            print('After assigning [supp]sky per-petal:')
+            asgn.print_status(start_tile, stop_tile)
         else:
             asgn.assign_unused(
                 ttype, sky_per_petal, sky_per_slitblock, "POS",
                 start_tile, stop_tile
             )
+            print('After assigning [supp]sky:')
+            asgn.print_status(start_tile, stop_tile)
 
     # Assign sky to unused fibers, up to some limit
     gt.start("Assign unused fibers to sky")
@@ -1665,6 +1684,9 @@ def run(
     )
     gt.stop("Force assignment of sufficient standards")
 
+    print('After force-assigning standards:')
+    asgn.print_status(start_tile, stop_tile)
+
     def do_assign_forced_sky(ttype):
         # This function really feels redundant with do_assign_unused_sky, but
         # when I tried to make a single function to do both calls, I had to call
@@ -1673,12 +1695,18 @@ def run(
             # Slitblock first
             asgn.assign_force(
                 ttype, -1, sky_per_slitblock, start_tile, stop_tile)
+            print('After force-assigning [supp]sky per-slitblock:')
+            asgn.print_status(start_tile, stop_tile)
             # Then petal
             asgn.assign_force(
                 ttype, sky_per_petal, -1, start_tile, stop_tile)
+            print('After force-assigning [supp]sky per-petal:')
+            asgn.print_status(start_tile, stop_tile)
         else:
             asgn.assign_force(
                 ttype, sky_per_petal, sky_per_slitblock, start_tile, stop_tile)
+            print('After force-assigning [supp]sky:')
+            asgn.print_status(start_tile, stop_tile)
 
     gt.start("Force assignment of sufficient sky")
     do_assign_forced_sky(TARGET_TYPE_SKY)
@@ -1703,6 +1731,10 @@ def run(
         stop_tile,
         use_zero_obsremain=use_zero_obsremain
     )
+
+    print('After assigning reobservations of science targets:')
+    asgn.print_status(start_tile, stop_tile)
+
     asgn.assign_unused(TARGET_TYPE_STANDARD, -1, -1, "POS", start_tile, stop_tile)
     asgn.assign_unused(TARGET_TYPE_SKY, -1, -1, "POS", start_tile, stop_tile)
     asgn.assign_unused(TARGET_TYPE_SUPPSKY, -1, -1, "POS", start_tile, stop_tile)
@@ -1712,6 +1744,9 @@ def run(
     # So after this is run every fiber should be assigned to something.
     asgn.assign_unused(TARGET_TYPE_SAFE, -1, -1, "POS", start_tile, stop_tile)
     gt.stop("Assign remaining unassigned fibers")
+
+    print('Final assignments:')
+    asgn.print_status(start_tile, stop_tile)
 
     # Assign sky monitor fibers
     gt.start("Assign sky monitor fibers")

--- a/src/_pyfiberassign.cpp
+++ b/src/_pyfiberassign.cpp
@@ -1526,6 +1526,9 @@ PYBIND11_MODULE(_internal, m) {
         .def("tiles_assigned", &fba::Assignment::tiles_assigned, R"(
             Return an array of currently assigned tile IDs.
         )")
+        .def("print_status", &fba::Assignment::print_status, R"(
+            Prints a summary of counts of assignments per target class.
+        )")
         .def("tile_location_target", &fba::Assignment::tile_location_target,
             py::return_value_policy::reference_internal, py::arg("tile"), R"(
             Return the assignment for a given tile.

--- a/src/_pyfiberassign.cpp
+++ b/src/_pyfiberassign.cpp
@@ -1526,9 +1526,6 @@ PYBIND11_MODULE(_internal, m) {
         .def("tiles_assigned", &fba::Assignment::tiles_assigned, R"(
             Return an array of currently assigned tile IDs.
         )")
-        .def("print_status", &fba::Assignment::print_status, R"(
-            Prints a summary of counts of assignments per target class.
-        )")
         .def("get_counts", &fba::Assignment::get_counts, R"(
             Returns a summary of counts of assignments per target class.
             Return value is a dict: tile_id -> dict( type -> count ).

--- a/src/_pyfiberassign.cpp
+++ b/src/_pyfiberassign.cpp
@@ -1529,6 +1529,10 @@ PYBIND11_MODULE(_internal, m) {
         .def("print_status", &fba::Assignment::print_status, R"(
             Prints a summary of counts of assignments per target class.
         )")
+        .def("get_counts", &fba::Assignment::get_counts, R"(
+            Returns a summary of counts of assignments per target class.
+            Return value is a dict: tile_id -> dict( type -> count ).
+        )")
         .def("tile_location_target", &fba::Assignment::tile_location_target,
             py::return_value_policy::reference_internal, py::arg("tile"), R"(
             Return the assignment for a given tile.

--- a/src/assign.cpp
+++ b/src/assign.cpp
@@ -143,30 +143,6 @@ fba::Assignment::Assignment(fba::Targets::pshr tgs,
     tm.report(logmsg.str().c_str());
 }
 
-void fba::Assignment::print_status(int32_t start_tile, int32_t stop_tile) {
-    int32_t tstart;
-    int32_t tstop;
-    if (start_tile < 0) {
-        tstart = 0;
-    } else {
-        tstart = tiles_->order.at(start_tile);
-    }
-    if (stop_tile < 0) {
-        tstop = tiles_->id.size() - 1;
-    } else {
-        tstop = tiles_->order.at(stop_tile);
-    }
-    for (int32_t t = tstart; t <= tstop; ++t) {
-        int32_t tile_id = tiles_->id[t];
-        std::cout << "Tile " << tile_id << std::endl;
-        std::cout << "  SCIENCE: " << nassign_tile[TARGET_TYPE_SCIENCE][tile_id] << std::endl;
-        std::cout << "  STANDARD: " << nassign_tile[TARGET_TYPE_STANDARD][tile_id] << std::endl;
-        std::cout << "  SKY: " << nassign_tile[TARGET_TYPE_SKY][tile_id] << std::endl;
-        std::cout << "  SAFE: " << nassign_tile[TARGET_TYPE_SAFE][tile_id] << std::endl;
-        std::cout << "  SUPPSKY: " << nassign_tile[TARGET_TYPE_SUPPSKY][tile_id] << std::endl;
-    }
-}
-
 std::map< int32_t, std::map< std::string, int32_t > >
 fba::Assignment::get_counts(int32_t start_tile, int32_t stop_tile) {
     int32_t tstart;

--- a/src/assign.cpp
+++ b/src/assign.cpp
@@ -143,6 +143,29 @@ fba::Assignment::Assignment(fba::Targets::pshr tgs,
     tm.report(logmsg.str().c_str());
 }
 
+void fba::Assignment::print_status(int32_t start_tile, int32_t stop_tile) {
+    int32_t tstart;
+    int32_t tstop;
+    if (start_tile < 0) {
+        tstart = 0;
+    } else {
+        tstart = tiles_->order.at(start_tile);
+    }
+    if (stop_tile < 0) {
+        tstop = tiles_->id.size() - 1;
+    } else {
+        tstop = tiles_->order.at(stop_tile);
+    }
+    for (int32_t t = tstart; t <= tstop; ++t) {
+        int32_t tile_id = tiles_->id[t];
+        std::cout << "Tile " << tile_id << std::endl;
+        std::cout << "  SCIENCE: " << nassign_tile[TARGET_TYPE_SCIENCE][tile_id] << std::endl;
+        std::cout << "  STANDARD: " << nassign_tile[TARGET_TYPE_STANDARD][tile_id] << std::endl;
+        std::cout << "  SKY: " << nassign_tile[TARGET_TYPE_SKY][tile_id] << std::endl;
+        std::cout << "  SAFE: " << nassign_tile[TARGET_TYPE_SAFE][tile_id] << std::endl;
+        std::cout << "  SUPPSKY: " << nassign_tile[TARGET_TYPE_SUPPSKY][tile_id] << std::endl;
+    }
+}
 
 std::vector <int32_t> fba::Assignment::tiles_assigned() const {
     std::vector <int32_t> ret;

--- a/src/assign.cpp
+++ b/src/assign.cpp
@@ -167,6 +167,47 @@ void fba::Assignment::print_status(int32_t start_tile, int32_t stop_tile) {
     }
 }
 
+std::map< int32_t, std::map< std::string, int32_t > >
+fba::Assignment::get_counts(int32_t start_tile, int32_t stop_tile) {
+    int32_t tstart;
+    int32_t tstop;
+    std::map< int32_t, std::map< std::string, int32_t > > counts;
+
+    if (start_tile < 0) {
+        tstart = 0;
+    } else {
+        tstart = tiles_->order.at(start_tile);
+    }
+    if (stop_tile < 0) {
+        tstop = tiles_->id.size() - 1;
+    } else {
+        tstop = tiles_->order.at(stop_tile);
+    }
+    for (int32_t t = tstart; t <= tstop; ++t) {
+        int32_t tile_id = tiles_->id[t];
+
+        counts[tile_id].clear();
+
+        int n_sci_not_std = 0;
+        // count targets that are SCIENCE and not STANDARD
+        for (auto const & it : loc_target[tile_id]) {
+            int64_t target_id = it.second;
+            auto &tgobj = tgs_->data.at(target_id);
+            bool is_sci = tgobj.is_type(TARGET_TYPE_SCIENCE);
+            bool is_std = tgobj.is_type(TARGET_TYPE_STANDARD);
+            if (is_sci && !is_std)
+                n_sci_not_std++;
+        }
+        counts[tile_id]["SCIENCE"] = nassign_tile[TARGET_TYPE_SCIENCE][tile_id];
+        counts[tile_id]["SCIENCE not STANDARD"] = n_sci_not_std;
+        counts[tile_id]["STANDARD"] = nassign_tile[TARGET_TYPE_STANDARD][tile_id];
+        counts[tile_id]["SKY"] = nassign_tile[TARGET_TYPE_SKY][tile_id];
+        counts[tile_id]["SUPPSKY"] = nassign_tile[TARGET_TYPE_SUPPSKY][tile_id];
+        counts[tile_id]["SAFE"] = nassign_tile[TARGET_TYPE_SAFE][tile_id];
+    }
+    return counts;
+}
+
 std::vector <int32_t> fba::Assignment::tiles_assigned() const {
     std::vector <int32_t> ret;
     for (auto const & it : loc_target) {

--- a/src/assign.h
+++ b/src/assign.h
@@ -34,6 +34,9 @@ class Assignment : public std::enable_shared_from_this <Assignment> {
 
         void print_status(int32_t start_tile = -1, int32_t stop_tile = -1);
 
+        std::map< int32_t, std::map< std::string, int32_t > >
+            get_counts(int32_t start_tile = -1, int32_t stop_tile = -1);
+
         void assign_unused(uint8_t tgtype, int32_t max_per_petal = -1,
                            int32_t max_per_slitblock = -1,
                            std::string const & pos_type = std::string("POS"),

--- a/src/assign.h
+++ b/src/assign.h
@@ -32,6 +32,8 @@ class Assignment : public std::enable_shared_from_this <Assignment> {
                    std::map<int32_t, std::map<int32_t, bool> > stuck_sky
                    = std::map<int32_t, std::map<int32_t,bool> >());
 
+        void print_status(int32_t start_tile = -1, int32_t stop_tile = -1);
+
         void assign_unused(uint8_t tgtype, int32_t max_per_petal = -1,
                            int32_t max_per_slitblock = -1,
                            std::string const & pos_type = std::string("POS"),

--- a/src/assign.h
+++ b/src/assign.h
@@ -32,8 +32,6 @@ class Assignment : public std::enable_shared_from_this <Assignment> {
                    std::map<int32_t, std::map<int32_t, bool> > stuck_sky
                    = std::map<int32_t, std::map<int32_t,bool> >());
 
-        void print_status(int32_t start_tile = -1, int32_t stop_tile = -1);
-
         std::map< int32_t, std::map< std::string, int32_t > >
             get_counts(int32_t start_tile = -1, int32_t stop_tile = -1);
 


### PR DESCRIPTION
This just adds some logging that I have found useful in developing (and explaining) the stuck-positioners-on-sky work.

```
INFO: Tile 100000: After assigning unused fibers to science targets: SCIENCE: 4060, SCIENCE not STANDARD: 4059, STANDARD: 1, SKY: 604
...
INFO: Tile 100000: After force-assigning standards: SCIENCE: 4063, SCIENCE not STANDARD: 3963, STANDARD: 100, SKY: 606
INFO: Tile 100000: After force-assigning [supp]sky per-slitblock: SCIENCE: 4056, SCIENCE not STANDARD: 3956, STANDARD: 100, SKY: 613
...
INFO: Tile 100000: Final assignments: SCIENCE: 4056, SCIENCE not STANDARD: 3956, STANDARD: 100, SKY: 655, SAFE: 2
```


