### PR TITLE
Apply theta-phi offsets when computing locations of stuck positioners

### DIFF
--- a/py/fiberassign/assign.py
+++ b/py/fiberassign/assign.py
@@ -336,8 +336,8 @@ def write_assignment_fits_tile(asgn, fulltarget, overwrite, params):
                     # position in the hardware model.  Used this fixed fiber location.
                     xy = hw.thetaphi_to_xy(
                         hw.loc_pos_curved_mm[loc],
-                        hw.loc_theta_pos[loc],
-                        hw.loc_phi_pos[loc],
+                        hw.loc_theta_pos[loc] + hw.loc_theta_offset[loc],
+                        hw.loc_phi_pos  [loc] + hw.loc_phi_offset  [loc],
                         hw.loc_theta_arm[loc],
                         hw.loc_phi_arm[loc],
                         hw.loc_theta_offset[loc],
@@ -354,7 +354,7 @@ def write_assignment_fits_tile(asgn, fulltarget, overwrite, params):
                     # This is an unassigned, working positioner.  Place it in a folded
                     # state.
                     thmin = hw.loc_theta_min[loc] + hw.loc_theta_offset[loc] + 1e-6
-                    phmax = hw.loc_phi_max[loc] + hw.loc_phi_offset[loc] - 1e-6
+                    phmax = hw.loc_phi_max  [loc] + hw.loc_phi_offset  [loc] - 1e-6
                     if phmax > np.pi:
                         phmax = np.pi
                     xy = hw.thetaphi_to_xy(

--- a/py/fiberassign/assign.py
+++ b/py/fiberassign/assign.py
@@ -353,8 +353,8 @@ def write_assignment_fits_tile(asgn, fulltarget, overwrite, params):
                 else:
                     # This is an unassigned, working positioner.  Place it in a folded
                     # state.
-                    thmin = hw.loc_theta_min[loc] + hw.loc_theta_offset[loc]
-                    phmax = hw.loc_phi_max[loc] + hw.loc_phi_offset[loc]
+                    thmin = hw.loc_theta_min[loc] + hw.loc_theta_offset[loc] + 1e-6
+                    phmax = hw.loc_phi_max[loc] + hw.loc_phi_offset[loc] - 1e-6
                     if phmax > np.pi:
                         phmax = np.pi
                     xy = hw.thetaphi_to_xy(

--- a/py/fiberassign/assign.py
+++ b/py/fiberassign/assign.py
@@ -353,10 +353,8 @@ def write_assignment_fits_tile(asgn, fulltarget, overwrite, params):
                 else:
                     # This is an unassigned, working positioner.  Place it in a folded
                     # state.
-                    thmin = hw.loc_theta_min[loc] + hw.loc_theta_offset[loc] + 1e-6
-                    phmax = hw.loc_phi_max  [loc] + hw.loc_phi_offset  [loc] - 1e-6
-                    if phmax > np.pi:
-                        phmax = np.pi
+                    thmin =     hw.loc_theta_min[loc]         + hw.loc_theta_offset[loc] + 1e-6
+                    phmax = min(hw.loc_phi_max  [loc], np.pi) + hw.loc_phi_offset  [loc] - 1e-6
                     xy = hw.thetaphi_to_xy(
                         hw.loc_pos_curved_mm[loc],
                         thmin,

--- a/py/fiberassign/assign.py
+++ b/py/fiberassign/assign.py
@@ -345,7 +345,8 @@ def write_assignment_fits_tile(asgn, fulltarget, overwrite, params):
                         hw.loc_theta_min[loc],
                         hw.loc_phi_min[loc],
                         hw.loc_theta_max[loc],
-                        hw.loc_phi_max[loc]
+                        hw.loc_phi_max[loc],
+                        ignore_range=True
                     )
                     empty_x[iloc] = xy[0]
                     empty_y[iloc] = xy[1]

--- a/py/fiberassign/assign.py
+++ b/py/fiberassign/assign.py
@@ -1617,7 +1617,6 @@ def run(
         tiles = list(counts.keys())
         tiles.sort()
         for tile in tiles:
-            #print('Tile ', tile)
             msg = 'Tile %i: ' % tile
             if when is not None:
                 msg += when
@@ -1630,12 +1629,9 @@ def run(
                 if n is None:
                     log.warning('Key', k, 'missing from Assignment.get_counts return value')
                 else:
-                    #print('  %s: %i' % (k, n))
                     if n>0 or always:
                         ss.append('%s: %i' % (k,n))
-            log.debug(msg + ', '.join(ss))
-            #for k,v in tilecounts.items():
-            #    print('  %s: %i' % (k,v))
+            log.info(msg + ', '.join(ss))
 
     print_counts('Start: ')
 

--- a/py/fiberassign/assign.py
+++ b/py/fiberassign/assign.py
@@ -1582,16 +1582,12 @@ def merge_results(targetfiles, skyfiles, tiles, result_dir=".",
 
 def get_parked_thetaphi(theta_offset, theta_min, theta_max,
                         phi_offset,   phi_min,   phi_max):
-    # To avoid numerical issues when outside_theta_phi_range() detects
-    # whether this value is >= min; we're adding then subtracting
-    # theta_offset, so cancellation error is a possibility.
-    eta = 1e-9
+    # Arbitrarily,
+    theta = theta_offset + theta_min
 
-    theta = theta_offset + theta_min + eta
-
-    # 150 degrees (https://github.com/desihub/fiberassign/issues/194)
+    # Put phi arm at 150 degrees (https://github.com/desihub/fiberassign/issues/194)
     phi_target = 150.
-    phi_target = np.clip(np.deg2rad(phi_target), phi_min + eta, phi_max - eta)
+    phi_target = np.clip(np.deg2rad(phi_target), phi_min, phi_max)
     phi = phi_offset + phi_target
 
     return theta, phi

--- a/py/fiberassign/stucksky.py
+++ b/py/fiberassign/stucksky.py
@@ -64,7 +64,8 @@ def stuck_on_sky(hw, tiles):
                 hw.loc_theta_min[loc],
                 hw.loc_phi_min[loc],
                 hw.loc_theta_max[loc],
-                hw.loc_phi_max[loc]
+                hw.loc_phi_max[loc],
+                True
             )
             stuck_x[iloc] = loc_x
             stuck_y[iloc] = loc_y

--- a/py/fiberassign/stucksky.py
+++ b/py/fiberassign/stucksky.py
@@ -45,8 +45,8 @@ def stuck_on_sky(hw, tiles):
                      if (((hw.state[loc] & FIBER_STATE_STUCK) != 0) and
                          ((hw.state[loc] & FIBER_STATE_BROKEN) == 0) and
                          (hw.loc_device_type[loc] == 'POS'))]
-        stuck_theta = [hw.loc_theta_pos[x] for x in stuck_loc]
-        stuck_phi   = [hw.loc_phi_pos  [x] for x in stuck_loc]
+        stuck_theta = [hw.loc_theta_pos[loc] + hw.loc_theta_offset[loc] for loc in stuck_loc]
+        stuck_phi   = [hw.loc_phi_pos  [loc] + hw.loc_phi_offset  [loc] for loc in stuck_loc]
 
         # Convert positioner angle orientations to curved focal surface X / Y (not CS5)
         # Note:  we could add some methods to the python bindings to vectorize this or make it less clunky...

--- a/py/fiberassign/vis.py
+++ b/py/fiberassign/vis.py
@@ -283,20 +283,20 @@ def plot_assignment(ax, hw, targetprops, tile_assigned, linewidth=0.1,
                     lid, state[lid], theta, phi
                 ), flush=True)
                 failed = hw.loc_position_thetaphi(
-                    lid, theta_pos[lid], phi_pos[lid], shptheta, shpphi
+                    lid, theta, phi, shptheta, shpphi, True
                 )
             else:
                 # Plot the positioner in its home
                 # position with theta at its minimum value and phi
                 # at 180 degrees.
-                theta = theta_offset[lid] + theta_min[lid]
-                phi = phi_offset[lid] + phi_max[lid]
+                theta = theta_offset[lid] + theta_min[lid] + 1e-6
+                phi = phi_offset[lid] + phi_max[lid] - 1e-6
                 if phi > np.pi:
                     phi = np.pi
                 print("loc {}, state {} is unassigned, using {} / {}".format(
                     lid, state[lid], theta, phi
                 ), flush=True)
-                failed = hw.loc_position_thetaphi(lid, theta, phi, shptheta, shpphi)
+                failed = hw.loc_position_thetaphi(lid, theta, phi, shptheta, shpphi, True)
             if failed:
                 msg = "Positioner at location {} cannot move to its stuck or home position.  This should never happen!".format(lid)
                 log.warning(msg)

--- a/py/fiberassign/vis.py
+++ b/py/fiberassign/vis.py
@@ -33,7 +33,7 @@ from .targets import (Targets, load_target_table,
                       TARGET_TYPE_STANDARD, TARGET_TYPE_SAFE)
 
 from .assign import (read_assignment_fits_tile, result_tiles, result_path,
-                     avail_table_to_dict)
+                     avail_table_to_dict, get_parked_thetaphi)
 
 plt = None
 
@@ -286,14 +286,11 @@ def plot_assignment(ax, hw, targetprops, tile_assigned, linewidth=0.1,
                     lid, theta, phi, shptheta, shpphi, True
                 )
             else:
-                # Plot the positioner in its home
-                # position with theta at its minimum value and phi
-                # at 180 degrees.
-                # The 1e-6 values are to avoid numerical issues checking bounds
-                theta = theta_offset[lid] + theta_min[lid] + 1e-6
-                phi   = phi_offset  [lid] + phi_max  [lid] - 1e-6
-                if phi > np.pi:
-                    phi = np.pi
+                # Plot the positioner in its home (parked) position
+                theta,phi = get_parked_thetaphi(theta_offset[lid],
+                                                theta_min[lid], theta_max[lid],
+                                                phi_offset[lid],
+                                                phi_min[lid], phi_max[lid])
                 print("loc {}, state {} is unassigned, using {} / {}".format(
                     lid, state[lid], theta, phi
                 ), flush=True)

--- a/py/fiberassign/vis.py
+++ b/py/fiberassign/vis.py
@@ -277,8 +277,8 @@ def plot_assignment(ax, hw, targetprops, tile_assigned, linewidth=0.1,
             if (state[lid] & FIBER_STATE_STUCK) or (state[lid] & FIBER_STATE_BROKEN):
                 # The positioner is stuck or fiber broken.  Plot it at its current
                 # location.
-                theta = theta_pos[lid]
-                phi = phi_pos[lid]
+                theta = theta_pos[lid] + theta_offset[lid]
+                phi   = phi_pos  [lid] + phi_offset  [lid]
                 print("loc {}, state {} is stuck / broken, using {} / {}".format(
                     lid, state[lid], theta, phi
                 ), flush=True)
@@ -289,8 +289,9 @@ def plot_assignment(ax, hw, targetprops, tile_assigned, linewidth=0.1,
                 # Plot the positioner in its home
                 # position with theta at its minimum value and phi
                 # at 180 degrees.
+                # The 1e-6 values are to avoid numerical issues checking bounds
                 theta = theta_offset[lid] + theta_min[lid] + 1e-6
-                phi = phi_offset[lid] + phi_max[lid] - 1e-6
+                phi   = phi_offset  [lid] + phi_max  [lid] - 1e-6
                 if phi > np.pi:
                     phi = np.pi
                 print("loc {}, state {} is unassigned, using {} / {}".format(

--- a/src/_pyfiberassign.cpp
+++ b/src/_pyfiberassign.cpp
@@ -911,12 +911,14 @@ PYBIND11_MODULE(_internal, m) {
                 double theta_min,
                 double phi_min,
                 double theta_max,
-                double phi_max
+                double phi_max,
+                bool ignore_range=false
             ) {
                 std::pair <double, double> xy;
                 bool failed = self.thetaphi_to_xy(
                     xy, center, theta, phi, theta_arm, phi_arm, theta_zero,
-                    phi_zero, theta_min, phi_min, theta_max, phi_max
+                    phi_zero, theta_min, phi_min, theta_max, phi_max,
+                    ignore_range
                 );
                 if (failed) {
                     return py::make_tuple(py::none(), py::none());
@@ -927,7 +929,7 @@ PYBIND11_MODULE(_internal, m) {
             py::arg("theta"), py::arg("phi"), py::arg("theta_arm"), py::arg("phi_arm"),
             py::arg("theta_zero"), py::arg("phi_zero"),
             py::arg("theta_min"), py::arg("phi_min"),
-            py::arg("theta_max"), py::arg("phi_max"), R"(
+             py::arg("theta_max"), py::arg("phi_max"), py::arg("ignore_range")=false, R"(
             Compute the X / Y fiber location for positioner Theta / Phi angles.
 
             Note that all X/Y calculations involving positioners are performed
@@ -945,6 +947,7 @@ PYBIND11_MODULE(_internal, m) {
                 phi_min (float): The phi min relative to the offset.
                 theta_max (float): The theta max relative to the offset.
                 phi_max (float): The phi max relative to the offset.
+                ignore_range=False (bool): Ignore MIN/MAX_THETA/PHI and always return X,Y
 
             Returns:
                 (tuple): The X / Y location or (None, None) if the angles are

--- a/src/_pyfiberassign.cpp
+++ b/src/_pyfiberassign.cpp
@@ -995,7 +995,7 @@ PYBIND11_MODULE(_internal, m) {
         )")
         .def("loc_position_thetaphi", &fba::Hardware::loc_position_thetaphi,
             py::arg("loc"), py::arg("theta"), py::arg("phi"),
-            py::arg("shptheta"), py::arg("shpphi"), R"(
+             py::arg("shptheta"), py::arg("shpphi"), py::arg("ignore_range")=false, R"(
             Move a positioner to a given set of theta / phi angles.
 
             This takes the specified angles and computes the shapes of
@@ -1009,6 +1009,7 @@ PYBIND11_MODULE(_internal, m) {
                 phi (float): The phi angle.
                 shptheta (Shape):  The theta shape.
                 shpphi (Shape):  The phi shape.
+                ignore_range=false (bool): Ignore phi/theta min/max limits?
 
             Returns:
                 None

--- a/src/_pyfiberassign.cpp
+++ b/src/_pyfiberassign.cpp
@@ -1526,9 +1526,6 @@ PYBIND11_MODULE(_internal, m) {
         .def("tiles_assigned", &fba::Assignment::tiles_assigned, R"(
             Return an array of currently assigned tile IDs.
         )")
-        .def("print_status", &fba::Assignment::print_status, R"(
-            Prints a summary of counts of assignments per target class.
-        )")
         .def("get_counts", &fba::Assignment::get_counts, R"(
             Returns a summary of counts of assignments per target class.
             Return value is a dict: tile_id -> dict( type -> count ).

--- a/src/assign.cpp
+++ b/src/assign.cpp
@@ -143,30 +143,6 @@ fba::Assignment::Assignment(fba::Targets::pshr tgs,
     tm.report(logmsg.str().c_str());
 }
 
-void fba::Assignment::print_status(int32_t start_tile, int32_t stop_tile) {
-    int32_t tstart;
-    int32_t tstop;
-    if (start_tile < 0) {
-        tstart = 0;
-    } else {
-        tstart = tiles_->order.at(start_tile);
-    }
-    if (stop_tile < 0) {
-        tstop = tiles_->id.size() - 1;
-    } else {
-        tstop = tiles_->order.at(stop_tile);
-    }
-    for (int32_t t = tstart; t <= tstop; ++t) {
-        int32_t tile_id = tiles_->id[t];
-        std::cout << "Tile " << tile_id << std::endl;
-        std::cout << "  SCIENCE: " << nassign_tile[TARGET_TYPE_SCIENCE][tile_id] << std::endl;
-        std::cout << "  STANDARD: " << nassign_tile[TARGET_TYPE_STANDARD][tile_id] << std::endl;
-        std::cout << "  SKY: " << nassign_tile[TARGET_TYPE_SKY][tile_id] << std::endl;
-        std::cout << "  SAFE: " << nassign_tile[TARGET_TYPE_SAFE][tile_id] << std::endl;
-        std::cout << "  SUPPSKY: " << nassign_tile[TARGET_TYPE_SUPPSKY][tile_id] << std::endl;
-    }
-}
-
 std::map< int32_t, std::map< std::string, int32_t > >
 fba::Assignment::get_counts(int32_t start_tile, int32_t stop_tile) {
     int32_t tstart;

--- a/src/assign.cpp
+++ b/src/assign.cpp
@@ -1356,7 +1356,8 @@ bool fba::Assignment::ok_to_assign (fba::Hardware const * hw, int32_t tile,
                 tpos,
                 nb,
                 hw->loc_theta_offset.at(nb) + hw->loc_theta_pos.at(nb),
-                hw->loc_phi_offset.at(nb)   + hw->loc_phi_pos.at(nb)
+                hw->loc_phi_offset.at(nb)   + hw->loc_phi_pos.at(nb),
+                true
             );
         } else {
             // Neighbor is working, check for collisions with the neighbor in

--- a/src/assign.cpp
+++ b/src/assign.cpp
@@ -1337,8 +1337,8 @@ bool fba::Assignment::ok_to_assign (fba::Hardware const * hw, int32_t tile,
                 loc,
                 tpos,
                 nb,
-                hw->loc_theta_pos.at(nb),
-                hw->loc_phi_pos.at(nb)
+                hw->loc_theta_offset.at(nb) + hw->loc_theta_pos.at(nb),
+                hw->loc_phi_offset.at(nb)   + hw->loc_phi_pos.at(nb)
             );
         } else {
             // Neighbor is working, check for collisions with the neighbor in

--- a/src/assign.h
+++ b/src/assign.h
@@ -32,8 +32,6 @@ class Assignment : public std::enable_shared_from_this <Assignment> {
                    std::map<int32_t, std::map<int32_t, bool> > stuck_sky
                    = std::map<int32_t, std::map<int32_t,bool> >());
 
-        void print_status(int32_t start_tile = -1, int32_t stop_tile = -1);
-
         std::map< int32_t, std::map< std::string, int32_t > >
             get_counts(int32_t start_tile = -1, int32_t stop_tile = -1);
 

--- a/src/hardware.cpp
+++ b/src/hardware.cpp
@@ -618,7 +618,8 @@ bool fba::Hardware::move_positioner_thetaphi(
         fbg::shape & shptheta, fbg::shape & shpphi,
         fbg::dpair const & center, double theta, double phi,
         double theta_arm, double phi_arm, double theta_zero, double phi_zero,
-        double theta_min, double phi_min, double theta_max, double phi_max
+        double theta_min, double phi_min, double theta_max, double phi_max,
+        bool ignore_range
         ) const {
     // Check that requested angles are in range.
     if (
@@ -626,7 +627,8 @@ bool fba::Hardware::move_positioner_thetaphi(
             theta, phi, theta_zero, theta_min, theta_max, phi_zero, phi_min, phi_max
         )
     ) {
-        return true;
+        if (!ignore_range)
+            return true;
     }
 
     double ctheta = ::cos(theta);
@@ -864,7 +866,7 @@ bool fba::Hardware::loc_position_xy(
 
 bool fba::Hardware::loc_position_thetaphi(
     int32_t loc, double theta, double phi, fbg::shape & shptheta,
-    fbg::shape & shpphi) const {
+    fbg::shape & shpphi, bool ignore_range) const {
 
     // Start from exclusion polygon for this location.
     shptheta = loc_theta_excl.at(loc);
@@ -881,7 +883,8 @@ bool fba::Hardware::loc_position_thetaphi(
         loc_theta_min.at(loc),
         loc_phi_min.at(loc),
         loc_theta_max.at(loc),
-        loc_phi_max.at(loc));
+        loc_phi_max.at(loc),
+        ignore_range);
 
     return failed;
 }

--- a/src/hardware.cpp
+++ b/src/hardware.cpp
@@ -754,7 +754,8 @@ bool fba::Hardware::thetaphi_to_xy(
         fbg::dpair & position,
         fbg::dpair const & center, double const & theta, double const & phi,
         double theta_arm, double phi_arm, double theta_zero, double phi_zero,
-        double theta_min, double phi_min, double theta_max, double phi_max
+        double theta_min, double phi_min, double theta_max, double phi_max,
+        bool ignore_range
     ) const {
 
     // Check that requested angles are in range.
@@ -763,7 +764,8 @@ bool fba::Hardware::thetaphi_to_xy(
             theta, phi, theta_zero, theta_min, theta_max, phi_zero, phi_min, phi_max
         )
     ) {
-        return true;
+        if (!ignore_range)
+            return true;
     }
 
     double x_theta = center.first + theta_arm * ::cos(theta);

--- a/src/hardware.cpp
+++ b/src/hardware.cpp
@@ -132,6 +132,67 @@ fba::Hardware::Hardware(std::string const & timestr,
         loc_phi_max[location[i]] = phi_max[i] * M_PI / 180.0;
         loc_phi_pos[location[i]] = phi_pos[i] * M_PI / 180.0;
         loc_phi_arm[location[i]] = phi_arm[i];
+
+        if (state[location[i]] & (FIBER_STATE_STUCK | FIBER_STATE_BROKEN)) {
+            if ((loc_theta_pos[location[i]] < loc_theta_min[location[i]]) ||
+                (loc_theta_pos[location[i]] > loc_theta_max[location[i]])) {
+                logmsg.str("");
+                logmsg << "STUCK/BROKEN positioner (loc " << location[i]
+                       << ") theta value is outside of range: theta = "
+                       << loc_theta_pos[location[i]] << " vs range [" << loc_theta_min[location[i]]
+                       << ", " << loc_theta_max[location[i]] << "]; CLIPPING to valid range";
+                logger.info(logmsg.str().c_str());
+                loc_theta_pos[location[i]] = std::min(std::max(loc_theta_pos[location[i]],
+                                                               loc_theta_min[location[i]]),
+                                                      loc_theta_max[location[i]]);
+            }
+            if ((loc_phi_pos[location[i]] < loc_phi_min[location[i]]) ||
+                (loc_phi_pos[location[i]] > loc_phi_max[location[i]])) {
+                logmsg.str("");
+                logmsg << "STUCK/BROKEN positioner (loc " << location[i]
+                       << ") phi value is outside of range: phi = "
+                       << loc_phi_pos[location[i]] << " vs range [" << loc_phi_min[location[i]]
+                       << ", " << loc_phi_max[location[i]] << "]; CLIPPING to valid range";
+                logger.info(logmsg.str().c_str());
+                loc_phi_pos[location[i]] = std::min(std::max(loc_phi_pos[location[i]],
+                                                               loc_phi_min[location[i]]),
+                                                      loc_phi_max[location[i]]);
+            }
+        }
+        // RESTRICT but not stuck or broken (ie we'll still try to move it) -- CLIP theta/phi
+        // to allowed ranges!
+        if ((state[location[i]] & FIBER_STATE_RESTRICT) &&
+            (((state[location[i]] & (FIBER_STATE_STUCK | FIBER_STATE_BROKEN)) == 0))) {
+
+            if ((loc_theta_pos[location[i]] < loc_theta_min[location[i]]) ||
+                (loc_theta_pos[location[i]] > loc_theta_max[location[i]])) {
+                logmsg.str("");
+                logmsg << "RESTRICT positioner (loc " << location[i]
+                       << ") theta value is outside of range: theta = "
+                       << loc_theta_pos[location[i]] << " vs range [" << loc_theta_min[location[i]]
+                       << ", " << loc_theta_max[location[i]] << "]; CLIPPING to valid range!";
+                logger.info(logmsg.str().c_str());
+                loc_theta_pos[location[i]] = std::min(std::max(loc_theta_pos[location[i]],
+                                                               loc_theta_min[location[i]]),
+                                                      loc_theta_max[location[i]]);
+            }
+            if ((loc_phi_pos[location[i]] < loc_phi_min[location[i]]) ||
+                (loc_phi_pos[location[i]] > loc_phi_max[location[i]])) {
+                logmsg.str("");
+                logmsg << "RESTRICT positioner (loc " << location[i]
+                       << ") phi value is outside of range: phi = "
+                       << loc_phi_pos[location[i]] << " vs range [" << loc_phi_min[location[i]]
+                       << ", " << loc_phi_max[location[i]] << "]; CLIPPING to valid range!";
+                logger.info(logmsg.str().c_str());
+                loc_phi_pos[location[i]] = std::min(std::max(loc_phi_pos[location[i]],
+                                                               loc_phi_min[location[i]]),
+                                                      loc_phi_max[location[i]]);
+            }
+
+
+
+        }
+
         loc_theta_excl[location[i]] = excl_theta[i];
         loc_phi_excl[location[i]] = excl_phi[i];
         loc_gfa_excl[location[i]] = excl_gfa[i];

--- a/src/hardware.cpp
+++ b/src/hardware.cpp
@@ -138,8 +138,10 @@ fba::Hardware::Hardware(std::string const & timestr,
             if ((loc_theta_pos[loc] < loc_theta_min[loc]) ||
                 (loc_theta_pos[loc] > loc_theta_max[loc])) {
                 logmsg.str("");
-                logmsg << ("STUCK/BROKEN/RESTRICT positioner (loc " << loc
-                       << ") theta value is outside of range: theta = "
+                logmsg << ((state[loc] & FIBER_STATE_STUCK) ? "STUCK" : "     ") << " | "
+                       << ((state[loc] & FIBER_STATE_BROKEN) ? "BROKEN" : "      ") << " | "
+                       << ((state[loc] & FIBER_STATE_RESTRICT) ? "RESTRICT" : "        ")
+                       << " positioner (loc " << loc << ") theta value is outside of range: theta = "
                        << loc_theta_pos[loc] << " vs range [" << loc_theta_min[loc]
                        << ", " << loc_theta_max[loc] << "].";
                 logger.info(logmsg.str().c_str());
@@ -147,8 +149,10 @@ fba::Hardware::Hardware(std::string const & timestr,
             if ((loc_phi_pos[loc] < loc_phi_min[loc]) ||
                 (loc_phi_pos[loc] > loc_phi_max[loc])) {
                 logmsg.str("");
-                logmsg << "STUCK/BROKEN/RESTRICT positioner (loc " << loc
-                       << ") phi value is outside of range: phi = "
+                logmsg << ((state[loc] & FIBER_STATE_STUCK) ? "STUCK" : "     ") << " | "
+                       << ((state[loc] & FIBER_STATE_BROKEN) ? "BROKEN" : "      ") << " | "
+                       << ((state[loc] & FIBER_STATE_RESTRICT) ? "RESTRICT" : "        ")
+                       << " positioner (loc " << loc << ") phi value is outside of range: phi = "
                        << loc_phi_pos[loc] << " vs range [" << loc_phi_min[loc]
                        << ", " << loc_phi_max[loc] << "].";
                 logger.info(logmsg.str().c_str());
@@ -162,8 +166,7 @@ fba::Hardware::Hardware(std::string const & timestr,
     }
 
     logmsg.str("");
-    logmsg << "Focalplane has " << stcount
-        << " fibers that are stuck or broken";
+    logmsg << "Focalplane has " << stcount << " fibers that are stuck or broken";
     logger.info(logmsg.str().c_str());
 
     // Sort the locations

--- a/src/hardware.cpp
+++ b/src/hardware.cpp
@@ -105,59 +105,60 @@ fba::Hardware::Hardware(std::string const & timestr,
     int32_t stcount = 0;
 
     for (int32_t i = 0; i < nloc; ++i) {
-        locations.push_back(location[i]);
-        loc_petal[location[i]] = petal[i];
-        loc_device[location[i]] = device[i];
-        loc_device_type[location[i]] = device_type[i];
-        loc_fiber[location[i]] = fiber[i];
-        loc_slitblock[location[i]] = slitblock[i];
-        loc_blockfiber[location[i]] = blockfiber[i];
-        petal_locations[petal[i]].push_back(location[i]);
-        loc_pos_cs5_mm[location[i]] = std::make_pair(x_mm[i], y_mm[i]);
-        state[location[i]] = status[i];
+        int32_t loc = location[i];
+        locations.push_back(loc);
+        loc_petal[loc] = petal[i];
+        loc_device[loc] = device[i];
+        loc_device_type[loc] = device_type[i];
+        loc_fiber[loc] = fiber[i];
+        loc_slitblock[loc] = slitblock[i];
+        loc_blockfiber[loc] = blockfiber[i];
+        petal_locations[petal[i]].push_back(loc);
+        loc_pos_cs5_mm[loc] = std::make_pair(x_mm[i], y_mm[i]);
+        state[loc] = status[i];
         if ((status[i] & FIBER_STATE_STUCK) || (status[i] & FIBER_STATE_BROKEN)) {
             stcount++;
         }
-        neighbors[location[i]].clear();
-        petal_edge[location[i]] = false;
-        gfa_edge[location[i]] = false;
-        loc_theta_offset[location[i]] = theta_offset[i] * M_PI / 180.0;
-        loc_theta_min[location[i]] = theta_min[i] * M_PI / 180.0;
-        loc_theta_max[location[i]] = theta_max[i] * M_PI / 180.0;
-        loc_theta_pos[location[i]] = theta_pos[i] * M_PI / 180.0;
-        loc_theta_arm[location[i]] = theta_arm[i];
-        loc_phi_offset[location[i]] = phi_offset[i] * M_PI / 180.0;
-        loc_phi_min[location[i]] = phi_min[i] * M_PI / 180.0;
-        loc_phi_max[location[i]] = phi_max[i] * M_PI / 180.0;
-        loc_phi_pos[location[i]] = phi_pos[i] * M_PI / 180.0;
-        loc_phi_arm[location[i]] = phi_arm[i];
+        neighbors[loc].clear();
+        petal_edge[loc] = false;
+        gfa_edge[loc] = false;
+        loc_theta_offset[loc] = theta_offset[i] * M_PI / 180.0;
+        loc_theta_min[loc] = theta_min[i] * M_PI / 180.0;
+        loc_theta_max[loc] = theta_max[i] * M_PI / 180.0;
+        loc_theta_pos[loc] = theta_pos[i] * M_PI / 180.0;
+        loc_theta_arm[loc] = theta_arm[i];
+        loc_phi_offset[loc] = phi_offset[i] * M_PI / 180.0;
+        loc_phi_min[loc] = phi_min[i] * M_PI / 180.0;
+        loc_phi_max[loc] = phi_max[i] * M_PI / 180.0;
+        loc_phi_pos[loc] = phi_pos[i] * M_PI / 180.0;
+        loc_phi_arm[loc] = phi_arm[i];
 
         // Only STATE != 0 fibers seem to have the theta,phi values set; check these.
-        if (state[location[i]] & (FIBER_STATE_STUCK | FIBER_STATE_BROKEN | FIBER_STATE_RESTRICT)) {
-            if ((loc_theta_pos[location[i]] < loc_theta_min[location[i]]) ||
-                (loc_theta_pos[location[i]] > loc_theta_max[location[i]])) {
+        if (state[loc] & (FIBER_STATE_STUCK | FIBER_STATE_BROKEN | FIBER_STATE_RESTRICT)) {
+            if ((loc_theta_pos[loc] < loc_theta_min[loc]) ||
+                (loc_theta_pos[loc] > loc_theta_max[loc])) {
                 logmsg.str("");
-                logmsg << ("STUCK/BROKEN/RESTRICT positioner (loc " << location[i]
+                logmsg << ("STUCK/BROKEN/RESTRICT positioner (loc " << loc
                        << ") theta value is outside of range: theta = "
-                       << loc_theta_pos[location[i]] << " vs range [" << loc_theta_min[location[i]]
-                       << ", " << loc_theta_max[location[i]] << "].";
+                       << loc_theta_pos[loc] << " vs range [" << loc_theta_min[loc]
+                       << ", " << loc_theta_max[loc] << "].";
                 logger.info(logmsg.str().c_str());
             }
-            if ((loc_phi_pos[location[i]] < loc_phi_min[location[i]]) ||
-                (loc_phi_pos[location[i]] > loc_phi_max[location[i]])) {
+            if ((loc_phi_pos[loc] < loc_phi_min[loc]) ||
+                (loc_phi_pos[loc] > loc_phi_max[loc])) {
                 logmsg.str("");
-                logmsg << "STUCK/BROKEN/RESTRICT positioner (loc " << location[i]
+                logmsg << "STUCK/BROKEN/RESTRICT positioner (loc " << loc
                        << ") phi value is outside of range: phi = "
-                       << loc_phi_pos[location[i]] << " vs range [" << loc_phi_min[location[i]]
-                       << ", " << loc_phi_max[location[i]] << "].";
+                       << loc_phi_pos[loc] << " vs range [" << loc_phi_min[loc]
+                       << ", " << loc_phi_max[loc] << "].";
                 logger.info(logmsg.str().c_str());
             }
         }
 
-        loc_theta_excl[location[i]] = excl_theta[i];
-        loc_phi_excl[location[i]] = excl_phi[i];
-        loc_gfa_excl[location[i]] = excl_gfa[i];
-        loc_petal_excl[location[i]] = excl_petal[i];
+        loc_theta_excl[loc] = excl_theta[i];
+        loc_phi_excl[loc] = excl_phi[i];
+        loc_gfa_excl[loc] = excl_gfa[i];
+        loc_petal_excl[loc] = excl_petal[i];
     }
 
     logmsg.str("");

--- a/src/hardware.cpp
+++ b/src/hardware.cpp
@@ -1031,7 +1031,8 @@ bool fba::Hardware::collide_thetaphi(
 
 bool fba::Hardware::collide_xy_thetaphi(
         int32_t loc1, fbg::dpair const & xy1,
-        int32_t loc2, double theta2, double phi2) const {
+        int32_t loc2, double theta2, double phi2,
+        bool ignore_thetaphi_range) const {
 
     fbg::shape shptheta1(loc_theta_excl.at(loc1));
     fbg::shape shpphi1(loc_phi_excl.at(loc1));
@@ -1043,8 +1044,8 @@ bool fba::Hardware::collide_xy_thetaphi(
     fbg::shape shptheta2(loc_theta_excl.at(loc2));
     fbg::shape shpphi2(loc_phi_excl.at(loc2));
     bool failed2 = loc_position_thetaphi(loc2, theta2, phi2, shptheta2,
-                                         shpphi2);
-    if (failed2) {
+                                         shpphi2, ignore_thetaphi_range);
+    if (failed2 && !ignore_thetaphi_range) {
         return true;
     }
 

--- a/src/hardware.cpp
+++ b/src/hardware.cpp
@@ -612,10 +612,18 @@ bool _outside_theta_phi_range(
     // a clockwise rotation from theta_zero.
     double diff_hi = _angle_diff(theta, theta_zero);
     double diff_lo = _angle_diff(theta_zero, theta);
-    if (
-        ((diff_hi > theta_max) || (diff_hi < theta_min))
-        && ((-diff_lo > theta_max) || (-diff_lo < theta_min))
-    ) {
+
+    // Since calling code may add theta_offset (aka theta_zero here),
+    // which we then subtract off, we want to put a little margin on
+    // the min/max checks.  (In most cases where we are passing
+    // theta/phi values through from the desimodel inputs and we need
+    // to add offsets, we also ignore this range check, so this is
+    // maybe overly cautious.)
+    double eps = 1e-12;
+
+    if ((   ( diff_hi > (theta_max + eps)) || ( diff_hi < (theta_min - eps)))
+        && ((-diff_lo > (theta_max + eps)) || (-diff_lo < (theta_min - eps)))
+        ) {
         return true;
     }
 
@@ -625,10 +633,9 @@ bool _outside_theta_phi_range(
     // a negative phi_min indicates a clockwise rotation from phi_zero.
     diff_hi = _angle_diff(phi, phi_zero);
     diff_lo = _angle_diff(phi_zero, phi);
-    if (
-        ((diff_hi > phi_max) || (diff_hi < phi_min))
-        && ((-diff_lo > phi_max) || (-diff_lo < phi_min))
-    ) {
+    if ((   ( diff_hi > (phi_max + eps)) || ( diff_hi < (phi_min - eps)))
+        && ((-diff_lo > (phi_max + eps)) || (-diff_lo < (phi_min - eps)))
+        ) {
         return true;
     }
 

--- a/src/hardware.cpp
+++ b/src/hardware.cpp
@@ -132,64 +132,26 @@ fba::Hardware::Hardware(std::string const & timestr,
         loc_phi_pos[location[i]] = phi_pos[i] * M_PI / 180.0;
         loc_phi_arm[location[i]] = phi_arm[i];
 
-        if (state[location[i]] & (FIBER_STATE_STUCK | FIBER_STATE_BROKEN)) {
+        // Only STATE != 0 fibers seem to have the theta,phi values set; check these.
+        if (state[location[i]] & (FIBER_STATE_STUCK | FIBER_STATE_BROKEN | FIBER_STATE_RESTRICT)) {
             if ((loc_theta_pos[location[i]] < loc_theta_min[location[i]]) ||
                 (loc_theta_pos[location[i]] > loc_theta_max[location[i]])) {
                 logmsg.str("");
-                logmsg << "STUCK/BROKEN positioner (loc " << location[i]
+                logmsg << ("STUCK/BROKEN/RESTRICT positioner (loc " << location[i]
                        << ") theta value is outside of range: theta = "
                        << loc_theta_pos[location[i]] << " vs range [" << loc_theta_min[location[i]]
-                       << ", " << loc_theta_max[location[i]] << "]; CLIPPING to valid range";
+                       << ", " << loc_theta_max[location[i]] << "].";
                 logger.info(logmsg.str().c_str());
-                loc_theta_pos[location[i]] = std::min(std::max(loc_theta_pos[location[i]],
-                                                               loc_theta_min[location[i]]),
-                                                      loc_theta_max[location[i]]);
             }
             if ((loc_phi_pos[location[i]] < loc_phi_min[location[i]]) ||
                 (loc_phi_pos[location[i]] > loc_phi_max[location[i]])) {
                 logmsg.str("");
-                logmsg << "STUCK/BROKEN positioner (loc " << location[i]
+                logmsg << "STUCK/BROKEN/RESTRICT positioner (loc " << location[i]
                        << ") phi value is outside of range: phi = "
                        << loc_phi_pos[location[i]] << " vs range [" << loc_phi_min[location[i]]
-                       << ", " << loc_phi_max[location[i]] << "]; CLIPPING to valid range";
+                       << ", " << loc_phi_max[location[i]] << "].";
                 logger.info(logmsg.str().c_str());
-                loc_phi_pos[location[i]] = std::min(std::max(loc_phi_pos[location[i]],
-                                                               loc_phi_min[location[i]]),
-                                                      loc_phi_max[location[i]]);
             }
-        }
-        // RESTRICT but not stuck or broken (ie we'll still try to move it) -- CLIP theta/phi
-        // to allowed ranges!
-        if ((state[location[i]] & FIBER_STATE_RESTRICT) &&
-            (((state[location[i]] & (FIBER_STATE_STUCK | FIBER_STATE_BROKEN)) == 0))) {
-
-            if ((loc_theta_pos[location[i]] < loc_theta_min[location[i]]) ||
-                (loc_theta_pos[location[i]] > loc_theta_max[location[i]])) {
-                logmsg.str("");
-                logmsg << "RESTRICT positioner (loc " << location[i]
-                       << ") theta value is outside of range: theta = "
-                       << loc_theta_pos[location[i]] << " vs range [" << loc_theta_min[location[i]]
-                       << ", " << loc_theta_max[location[i]] << "]; CLIPPING to valid range!";
-                logger.info(logmsg.str().c_str());
-                loc_theta_pos[location[i]] = std::min(std::max(loc_theta_pos[location[i]],
-                                                               loc_theta_min[location[i]]),
-                                                      loc_theta_max[location[i]]);
-            }
-            if ((loc_phi_pos[location[i]] < loc_phi_min[location[i]]) ||
-                (loc_phi_pos[location[i]] > loc_phi_max[location[i]])) {
-                logmsg.str("");
-                logmsg << "RESTRICT positioner (loc " << location[i]
-                       << ") phi value is outside of range: phi = "
-                       << loc_phi_pos[location[i]] << " vs range [" << loc_phi_min[location[i]]
-                       << ", " << loc_phi_max[location[i]] << "]; CLIPPING to valid range!";
-                logger.info(logmsg.str().c_str());
-                loc_phi_pos[location[i]] = std::min(std::max(loc_phi_pos[location[i]],
-                                                               loc_phi_min[location[i]]),
-                                                      loc_phi_max[location[i]]);
-            }
-
-
-
         }
 
         loc_theta_excl[location[i]] = excl_theta[i];

--- a/src/hardware.h
+++ b/src/hardware.h
@@ -106,7 +106,8 @@ class Hardware : public std::enable_shared_from_this <Hardware> {
             fbg::dpair const & center, double theta, double phi,
             double theta_arm, double phi_arm, double theta_zero,
             double phi_zero, double theta_min, double phi_min,
-            double theta_max, double phi_max) const;
+            double theta_max, double phi_max,
+            bool ignore_range=false) const;
 
         bool xy_to_thetaphi(
                 double & theta, double & phi,
@@ -137,7 +138,7 @@ class Hardware : public std::enable_shared_from_this <Hardware> {
 
         bool loc_position_thetaphi(
             int32_t loc, double theta, double phi, fbg::shape & shptheta,
-            fbg::shape & shpphi) const;
+            fbg::shape & shpphi, bool ignore_range=false) const;
 
         bool collide_xy(int32_t loc1, fbg::dpair const & xy1,
                         int32_t loc2, fbg::dpair const & xy2) const;

--- a/src/hardware.h
+++ b/src/hardware.h
@@ -119,7 +119,8 @@ class Hardware : public std::enable_shared_from_this <Hardware> {
             fbg::dpair & position,
             fbg::dpair const & center, double const & theta, double const & phi,
             double theta_arm, double phi_arm, double theta_zero, double phi_zero,
-            double theta_min, double phi_min, double theta_max, double phi_max) const;
+            double theta_min, double phi_min, double theta_max, double phi_max,
+            bool ignore_range=false) const;
 
         bool position_xy_bad(int32_t loc, fbg::dpair const & xy) const;
 

--- a/src/hardware.h
+++ b/src/hardware.h
@@ -150,7 +150,8 @@ class Hardware : public std::enable_shared_from_this <Hardware> {
             int32_t loc2, double theta2, double phi2) const;
 
         bool collide_xy_thetaphi(int32_t loc1, fbg::dpair const & xy1,
-                                 int32_t loc2, double theta2, double phi2) const;
+                                 int32_t loc2, double theta2, double phi2,
+                                 bool ignore_thetaphi_range=false) const;
 
         std::vector <std::pair <bool, std::pair <fbg::shape, fbg::shape> > >
         loc_position_xy_multi(


### PR DESCRIPTION
The desimodel hardware parameters can contain some `theta, phi` values that are (usually only slightly) inconsistent with the `theta_min, theta_max, phi_min, phi_max`.  Previously, this would cause attempts to convert between theta,phi and x,y (esp. of stuck positioners, where the input `theta,phi` values are propagated) to fail, resulting in NaNs in output files, and false-positive collisions with neighbours.

We do a couple of things about this:

- first, we clip these values upon reading them from desimodel;
- second, we also add an `ignore_range` parameter to some of the `theta,phi -- x,y` conversion functions, that prevents it from failing if values are outside the min/max limits.

In addition, in a couple of places we have to add the theta,phi offsets when computing x,y positions.

I also factored out the `get_parked_thetaphi()` function, which computes which `theta,phi` angles we should request in order to "park" a positioner.  (In this instance, we're not trying to avoid collisions with neighbors, just placing the (most relevantly the phi angle) in a mostly retracted position.)
