### PR TITLE
support skybricks/v3 lookup

### DIFF
--- a/etc/fiberassign.module
+++ b/etc/fiberassign.module
@@ -74,5 +74,5 @@ setenv [string toupper $product] $PRODUCT_DIR
 #
 # Add any non-standard Module code below this point.
 #
-setenv SKYBRICKS_DIR $env(DESI_ROOT)/target/skybricks/v2
+setenv SKYBRICKS_DIR $env(DESI_ROOT)/target/skybricks/v3
 

--- a/py/fiberassign/stucksky.py
+++ b/py/fiberassign/stucksky.py
@@ -65,12 +65,17 @@ class Skybricks(object):
             if len(I) == 0:
                 continue
 
-            # Read skybrick file
-            fn = os.path.join(self.skybricks_dir,
-                              'sky-%s.fits.gz' % self.skybricks['BRICKNAME'][i])
-            if not os.path.exists(fn):
-                log.warning('Missing "skybrick" file: %s' % fn)
+            # Read skybrick file, looking for fits.fz then fits.gz
+            for ext in ['fz', 'gz']:
+                fn = os.path.join(self.skybricks_dir,
+                        'sky-{}.fits.{}'.format(
+                            self.skybricks['BRICKNAME'][i], ext))
+                if os.path.exists(fn):
+                    break
+            else:
+                log.warning('Missing "skybrick" file: %s/.fz' % fn)
                 continue
+
             skymap,hdr = fitsio.read(fn, header=True)
             H,W = skymap.shape
             # create WCS object


### PR DESCRIPTION
This PR adds support for skybricks/v3 for checking if a stuck positioner is on a sky location using files in $DESI_ROOT/target/skybricks/v3 (available at both NERSC and KPNO).  The format changed from v2 (.fz instead of .gz for faster header reading), so this code supports both.

Editorial note: I will make a similar PR for desitarget.skybricks .  I was hoping to have fiberassign directly use the desitarget version, but given that desitarget/0.58.0 was just tagged and generated target files for the main survey, and almost immediately we needed an algorithmic update and a new tag, I'm waiting for the dust to settle on fiberassign before making semi-optional maintenance changes that would require cross-repo tag coordination.