### PR TITLE
Gaia-based FLUX_R for GFA_TARGETS extension

### DIFF
--- a/py/fiberassign/gfa.py
+++ b/py/fiberassign/gfa.py
@@ -170,7 +170,7 @@ def get_gfa_targets(tiles, gfafile,faintlim=99):
         t["FOCUS_FLAG"] = flag
 
         # patch in Gaia-based synthetic r flux for use by ETC
-        t["FLUX_R"] = gaia_synth_r_flux(tab)
+        t["FLUX_R"] = gaia_synth_r_flux(t)
 
         gfa_targets.append(t)
 


### PR DESCRIPTION
@araichoor This updates the GFA_TARGETS catalog FLUX_R column so that it contains a Gaia-based r-band flux rather than a Legacy Survey r-band flux. The reason for doing this is to provide the best possible magnitudes to the ETC for its transparency measurements. Legacy Survey FLUX_R was found to have problematic saturation for relatively bright guide stars in a way that could not be reliably flagged, so we are switching to a setup that uniformly uses a Gaia-based r-band flux for all GFA_TARGETS rows. In detail the Gaia to r-band transformation (created by Rongpu) was trained on Gaia DR2 and DECam r-band.