### PR TITLE
Svn keyword

### DIFF
--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -6,6 +6,7 @@ Utility functions for fba_launch
 from __future__ import absolute_import, division
 
 import os
+import subprocess
 import sys
 import numpy as np
 from astropy.io import fits
@@ -60,6 +61,27 @@ def assert_isoformat_utc(time_str):
         return False
     # AR/SB it parses as an ISO string, now just check UTC timezone +00:00 and not +0000
     return time_str.endswith("+00:00")
+
+
+def get_svn_version(svn_dir):
+    """
+    Gets the SVN revision number of an SVN folder.
+
+    Args:
+        svn_dir: SVN folder path (string)
+
+    Returns:
+        svnver: SVN revision number of svn_dir (int)
+
+    Notes:
+        Credits to SB
+    """
+    cmd = ['svn', 'info', '--show-item', 'revision', os.path.expandvars(svn_dir)]
+    try:
+        svn_ver = subprocess.check_output(cmd, stderr=subprocess.DEVNULL).strip().decode()
+    except subprocess.CalledProcessError:
+        svn_ver = 'unknown'
+    return svn_ver
 
 
 def custom_read_targets_in_tiles(
@@ -1414,6 +1436,9 @@ def update_fiberassign_header(
     fd["PRIMARY"].write_key("mintfrac", args.mintfrac)
     # AR fba_launch-like script name used to designed the tile
     fd["PRIMARY"].write_key("fascript", fascript)
+    # AR SVN revision number
+    fd["PRIMARY"].write_key("svndm", get_svn_version(os.path.join(os.getenv("DESIMODEL"), "data")))
+    fd["PRIMARY"].write_key("svnmtl", get_svn_version(os.path.join(os.getenv("DESI_SURVEYOPS"), "mtl")))
     fd.close()
 
 

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -76,11 +76,13 @@ def get_svn_version(svn_dir):
     Notes:
         Credits to SB
     """
-    cmd = ['svn', 'info', '--show-item', 'revision', os.path.expandvars(svn_dir)]
+    cmd = ["svn", "info", "--show-item", "revision", os.path.expandvars(svn_dir)]
     try:
-        svn_ver = subprocess.check_output(cmd, stderr=subprocess.DEVNULL).strip().decode()
+        svn_ver = (
+            subprocess.check_output(cmd, stderr=subprocess.DEVNULL).strip().decode()
+        )
     except subprocess.CalledProcessError:
-        svn_ver = 'unknown'
+        svn_ver = "unknown"
     return svn_ver
 
 
@@ -1419,11 +1421,11 @@ def update_fiberassign_header(
     )
     # AR some keywords
     fd["PRIMARY"].write_key("outdir", args.outdir)
-    fd["PRIMARY"].write_key("survey", hdr_survey) # AR not args.survey!
+    fd["PRIMARY"].write_key("survey", hdr_survey)  # AR not args.survey!
     fd["PRIMARY"].write_key("rundate", args.rundate)
     fd["PRIMARY"].write_key("pmcorr", args.pmcorr)
     fd["PRIMARY"].write_key("pmtime", args.pmtime_utc_str)
-    fd["PRIMARY"].write_key("faprgrm", hdr_faprgrm) # AR not args.program!
+    fd["PRIMARY"].write_key("faprgrm", hdr_faprgrm)  # AR not args.program!
     fd["PRIMARY"].write_key("mtltime", args.mtltime)
     fd["PRIMARY"].write_key("obscon", obscon)
     # AR informations for NTS
@@ -1437,8 +1439,12 @@ def update_fiberassign_header(
     # AR fba_launch-like script name used to designed the tile
     fd["PRIMARY"].write_key("fascript", fascript)
     # AR SVN revision number
-    fd["PRIMARY"].write_key("svndm", get_svn_version(os.path.join(os.getenv("DESIMODEL"), "data")))
-    fd["PRIMARY"].write_key("svnmtl", get_svn_version(os.path.join(os.getenv("DESI_SURVEYOPS"), "mtl")))
+    fd["PRIMARY"].write_key(
+        "svndm", get_svn_version(os.path.join(os.getenv("DESIMODEL"), "data"))
+    )
+    fd["PRIMARY"].write_key(
+        "svnmtl", get_svn_version(os.path.join(os.getenv("DESI_SURVEYOPS"), "mtl"))
+    )
     fd.close()
 
 
@@ -2683,7 +2689,9 @@ def make_qa(
 
     # AR plotted tracers
     # AR TBD: handle secondary?
-    trmskkeys, trmsks = get_qa_tracers(survey, program, log=log, step="doplot", start=start,)
+    trmskkeys, trmsks = get_qa_tracers(
+        survey, program, log=log, step="doplot", start=start,
+    )
 
     # AR storing parent/assigned quantities
     parent, assign, dras, ddecs, petals, nassign = get_parent_assign_quants(

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -5,13 +5,30 @@ Utility functions for fba_launch
 """
 from __future__ import absolute_import, division
 
+# system
 import os
 import subprocess
 import sys
+import tempfile
+import shutil
+
+# time
+from time import time
+from datetime import datetime
+
+#
 import numpy as np
+import fitsio
+
+# astropy
 from astropy.io import fits
 from astropy.table import Table
-import fitsio
+from astropy.time import Time
+from astropy import units
+from astropy.coordinates import SkyCoord, Distance
+from astropy.time import Time
+
+# desitarget
 import desitarget
 from desitarget.gaiamatch import gaia_psflike
 from desitarget.io import read_targets_in_tiles, write_targets, write_skies
@@ -19,22 +36,21 @@ from desitarget.mtl import inflate_ledger
 from desitarget.targetmask import desi_mask, obsconditions
 from desitarget.targets import set_obsconditions
 from desitarget.geomask import match
+
+# desimodel
 import desimodel
 from desimodel.footprint import is_point_in_desi
+
+# fiberassign
 import fiberassign
 from fiberassign.scripts.assign import parse_assign, run_assign_full
 from fiberassign.assign import merge_results, minimal_target_columns
-from time import time
-from datetime import datetime
-from astropy.time import Time
-import tempfile
-import shutil
 from fiberassign.utils import Logger
+
+# matplotlib
 import matplotlib.pyplot as plt
 from matplotlib import gridspec
 import matplotlib
-from astropy import units
-from astropy.coordinates import SkyCoord, Distance
 import matplotlib.image as mpimg
 
 # AR default REF_EPOCH for PMRA=PMDEC=REF_EPOCH=0 objects


### PR DESCRIPTION
This PR modifies fba_launch_io.py, to add the recording in the fiberassign-TILEID.fits.gz file of the SVN revision number of:
- SVNDM = $DESIMODEL/data
- SVNMTL = $DESI_SURVEYOPS/mtl

This is done with the definition of a new function get_svn_version().

Two unrelated improvements:
- re-organization of the imports
- black formatting
