### PR TITLE
Mtltime timestamp

### DIFF
--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -52,7 +52,12 @@ sbprofs_all = {
 
 # AR minimum exposure time fraction needed for this tile to be considered done
 # AR main: [desi-survey 2390] Minimum exposure time fraction and requested effective times
-mintfracs_all = {"sv1" : 0.9, "sv2" : 0.9, "sv3": 0.9, "main": 0.85, }
+mintfracs_all = {
+    "sv1": 0.9,
+    "sv2": 0.9,
+    "sv3": 0.9,
+    "main": 0.85,
+}
 
 
 def main():
@@ -73,7 +78,9 @@ def main():
     assert_env_vars(log=log, step="settings", start=start)
 
     # AR safe: TILEID already existing in SVN?
-    assert_svn_tileid(args.tileid, forcetileid=args.forcetileid, log=log, step="settings", start=start)
+    assert_svn_tileid(
+        args.tileid, forcetileid=args.forcetileid, log=log, step="settings", start=start
+    )
 
     # AR safe: argument dates correctly formatted?
     assert_arg_dates(args, log=log, step="settings", start=start)
@@ -119,7 +126,8 @@ def main():
         gaiadr=args.gaiadr,
         log=log,
         step="settings",
-        start=start,)
+        start=start,
+    )
 
     # AR tiles
     if dotile:
@@ -201,11 +209,7 @@ def main():
             start=start,
         )
     else:
-        log.info(
-            "{:.1f}s\tdoscnd\tno secondary here".format(
-                time() - start
-            )
-        )
+        log.info("{:.1f}s\tdoscnd\tno secondary here".format(time() - start))
 
     # AR ToO targets
     # AR TBD: handling to MJD window boundaries as script argument?
@@ -270,10 +274,7 @@ def main():
     # AR gzip all fiberassign files
     if dozip:
         secure_gzip(
-            mytmpouts["fiberassign"],
-            log=log,
-            step="dozip",
-            start=start,
+            mytmpouts["fiberassign"], log=log, step="dozip", start=start,
         )
         # AR updating the path
         mytmpouts["fiberassign"] += ".gz"
@@ -310,29 +311,18 @@ def main():
 
     # AR do clean?
     if args.doclean == "y":
-        rmv_nonsvn(
-            mytmpouts,
-            myouts,
-            log=log,
-            step="doclean",
-            start=start
-        )
+        rmv_nonsvn(mytmpouts, myouts, log=log, step="doclean", start=start)
 
     # AR move tmpoutdir -> args.outdir
     if domove:
         mv_temp2final(
-            mytmpouts,
-            myouts,
-            args.doclean,
-            log=log,
-            step="domove",
-            start=start,
+            mytmpouts, myouts, args.doclean, log=log, step="domove", start=start,
         )
 
     # AR and we re done
     log.info("")
     log.info("")
-    log.info("{:.1f}s\tend\tTIMESTAMP={}".format(time() - start, Time.now().isot))                                                                                               
+    log.info("{:.1f}s\tend\tTIMESTAMP={}".format(time() - start, Time.now().isot))
 
 
 if __name__ == "__main__":
@@ -522,9 +512,9 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--log-stdout",
-        action='store_true',
+        action="store_true",
         help="log to stdout instead of redirecting to a file",
-        )
+    )
     #
     args = parser.parse_args()
     log = Logger.get()
@@ -538,7 +528,7 @@ if __name__ == "__main__":
 
     # AR utc_time_now, rundate, pmtime
     utc_time_now = datetime.now(tz=timezone.utc)
-    utc_time_now_str = utc_time_now.isoformat(timespec='seconds')
+    utc_time_now_str = utc_time_now.isoformat(timespec="seconds")
     mjd_now = Time(utc_time_now).mjd
     if args.rundate is None:
         args.rundate = utc_time_now_str
@@ -612,4 +602,4 @@ if __name__ == "__main__":
     if len(tmpfiles) == 0:
         os.rmdir(tmpoutdir)
     else:
-        log.error('temp directory not empty: {}'.format(tmpfiles))
+        log.error("temp directory not empty: {}".format(tmpfiles))

--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -11,6 +11,7 @@ import tempfile
 import shutil
 from desiutil.redirect import stdouterr_redirected
 from fiberassign.fba_launch_io import (
+    get_program_latest_timestamp,
     assert_env_vars,
     assert_svn_tileid,
     assert_arg_dates,
@@ -449,7 +450,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--mtltime",
-        help="yyyy-mm-ddThh:mm:ss+00:00 MTL isodate, with UTC timezone formatting (default=current UTC time)",
+        help="yyyy-mm-ddThh:mm:ss+00:00 MTL isodate, with UTC timezone formatting (default=latest MTL timestamp for args.program if available, if not current UTC time)",
         type=str,
         default=None,
         required=False,
@@ -541,10 +542,17 @@ if __name__ == "__main__":
     mjd_now = Time(utc_time_now).mjd
     if args.rundate is None:
         args.rundate = utc_time_now_str
-    if args.mtltime is None:
-        args.mtltime = utc_time_now_str
     if args.pmtime_utc_str is None:
         args.pmtime_utc_str = utc_time_now_str
+
+    # AR mtltime
+    # AR if possible: setting to the latest timestamp for the program
+    # AR else: setting to utc_time_now_str
+    if args.mtltime is None:
+        args.mtltime = utc_time_now_str
+        timestamp = get_program_latest_timestamp(args.program)
+        if timestamp is not None:
+            args.mtltime = timestamp
 
     # AR goaltime
     if args.goaltime is None:

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -11,6 +11,7 @@ import subprocess
 import sys
 import tempfile
 import shutil
+import re
 
 # time
 from time import time
@@ -141,7 +142,10 @@ def get_program_latest_timestamp(
         if keep.sum() > 0:
             d = d[d["PROGRAM"] == program]
             # AR taking the latest timestamp
-            tm = "{}+00:00".format(np.unique(d["TIMESTAMP"])[-1])
+            tm = np.unique(d["TIMESTAMP"])[-1]
+            # AR does not end with +NN:MM timezone?
+            if re.search('\+\d{2}:\d{2}$', tm) is None:
+                tm = "{}+00:00".format(tm)
             tm = datetime.strptime(tm, "%Y-%m-%dT%H:%M:%S%z")
             # AR TBD: we currently add one minute; can be removed once
             # AR TBD  update is done on the desitarget side

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -140,7 +140,7 @@ def get_program_latest_timestamp(
         d = Table.read(fn)
         keep = d["PROGRAM"] == program.upper()
         if keep.sum() > 0:
-            d = d[d["PROGRAM"] == program]
+            d = d[keep]
             # AR taking the latest timestamp
             tm = np.unique(d["TIMESTAMP"])[-1]
             # AR does not end with +NN:MM timezone?

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -132,6 +132,9 @@ def get_program_latest_timestamp(
         required_env_vars=["DESI_SURVEYOPS"], log=log, step=step, start=start,
     )
 
+    # AR defaults to None (returned if no file or no selected rows)
+    timestamp = None
+
     # AR check if the per-tile file is here
     # AR no need to check the scnd-mtl-done-tiles.ecsv file,
     # AR     as we restrict to a given program ([desi-survey 2434])
@@ -151,10 +154,7 @@ def get_program_latest_timestamp(
             # AR TBD  update is done on the desitarget side
             tm += timedelta(minutes=1)
             timestamp = tm.isoformat(timespec="seconds")
-            return timestamp
-    # AR if no file or no selected rows, we default to None
-    else:
-        None
+    return timestamp
 
 
 def custom_read_targets_in_tiles(


### PR DESCRIPTION
This PR now defaults the args.mtltime fba_launch argument to the latest timestamp in the $DESI_SURVEYOPS/mtl-done-tiles.ecsv file for the considered args.program.
If no value is found, we default to the current time.

We currently add +1min to the MTL latest timestamp to account for current discrepancy between mtl-done-tiles.ecsv and the ledgers.
To be seen how to change that once the fix is done in desitarget

Besides, we did a black formatting of fba_launch.