### PR TITLE
Add PLATE_RA/DEC at end if needed

### DIFF
--- a/py/fiberassign/assign.py
+++ b/py/fiberassign/assign.py
@@ -1290,6 +1290,14 @@ def merge_results_tile(out_dtype, copy_fba, params):
             cols_to_keep.append(c)
     outdata = outdata[cols_to_keep]
 
+    #- HACK: add PLATE_RA, PLATE_DEC if they aren't already there
+    if ('PLATE_RA' not in outdata.dtype.names):
+        log.info('Adding PLATE_RA=TARGET_RA and PLATE_DEC=TARGET_DEC columns')
+        from numpy.lib.recfunctions import append_fields
+        ra = outdata['TARGET_RA']
+        dec = outdata['TARGET_DEC']
+        outdata = append_fields(outdata, ['PLATE_RA', 'PLATE_DEC'], [ra,dec])
+
     cols_to_keep = list()
     for c in tile_targets.dtype.names:
         if len(tile_targets[c].shape) < 2: #Don't propagate 2D target columns into TARGETS HDU


### PR DESCRIPTION
This PR adds PLATE_RA=TARGET_RA and PLATE_DEC=TARGET_DEC to the output files while merging other target columns, if prior plumbing hadn't already added those columns (like WIP PR #353).  This at least establishes the output format, even if deeper changes are needed to actually use PLATE_RA,PLATE_DEC (which are intended for eventual chromatic offsets).