### PR TITLE
add timeout to wget for QA cutout

### DIFF
--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -2128,6 +2128,7 @@ def get_viewer_cutout(
     width_deg=4,
     pixscale=10,
     dr="dr9",
+    timeout=15,
 ):
     """
     Downloads a cutout of the tile region from legacysurvey.org/viewer.
@@ -2140,6 +2141,7 @@ def get_viewer_cutout(
         width_deg (optional, defaults to 4): width of the cutout in degrees (float)
         pixscale (optional, defaults to 10): pixel scale of the cutout
         dr (optional, default do "dr9"): imaging data release
+        timeout (optional, defaults to 15): time (in seconds) after which we quit the wget cal (int)
 
     Returns:
         img: output of mpimg.imread() reading of the cutout (np.array of floats)
@@ -2148,8 +2150,8 @@ def get_viewer_cutout(
     tmpfn = "{}tmp-{}.jpeg".format(tmpoutdir, tileid)
     size = int(width_deg * 3600.0 / pixscale)
     layer = "ls-{}".format(dr)
-    tmpstr = 'wget -q -O {} "http://legacysurvey.org/viewer-dev/jpeg-cutout/?layer={}&ra={:.5f}&dec={:.5f}&pixscale={:.0f}&size={:.0f}"'.format(
-        tmpfn, layer, tilera, tiledec, pixscale, size
+    tmpstr = 'timeout {} wget -q -O {} "http://legacysurvey.org/viewer-dev/jpeg-cutout/?layer={}&ra={:.5f}&dec={:.5f}&pixscale={:.0f}&size={:.0f}"'.format(
+        tmpfn, timout, layer, tilera, tiledec, pixscale, size
     )
     # print(tmpstr)
     os.system(tmpstr)

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -2869,6 +2869,10 @@ def make_qa(
         width_deg=width_deg,
         pixscale=10,
         dr="dr9",
+        timeout=15,
+        log=log,
+        step=step,
+        start=start,
     )
 
     # AR SKY, BAD, WD, STD, TGT

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -2144,7 +2144,7 @@ def get_viewer_cutout(
         width_deg (optional, defaults to 4): width of the cutout in degrees (float)
         pixscale (optional, defaults to 10): pixel scale of the cutout
         dr (optional, default do "dr9"): imaging data release
-        timeout (optional, defaults to 15): time (in seconds) after which we quit the wget cal (int)
+        timeout (optional, defaults to 15): time (in seconds) after which we quit the wget call (int)
         log (optional, defaults to Logger.get()): Logger object
         step (optional, defaults to ""): corresponding step, for fba_launch log recording
             (e.g. dotiles, dosky, dogfa, domtl, doscnd, dotoo)

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -2155,9 +2155,10 @@ def get_viewer_cutout(
     os.system(tmpstr)
     try:
         img = mpimg.imread(tmpfn)
-        os.remove(tmpfn)
     except:
         img = np.zeros((size, size, 3))
+    if os.path.isfile(tmpfn):
+        os.remove(tmpfn)
     return img
 
 

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -2145,16 +2145,17 @@ def get_viewer_cutout(
         img: output of mpimg.imread() reading of the cutout (np.array of floats)
     """
     # AR cutout
+    tmpfn = "{}tmp-{}.jpeg".format(tmpoutdir, tileid)
     size = int(width_deg * 3600.0 / pixscale)
     layer = "ls-{}".format(dr)
-    tmpstr = 'wget -q -O {}tmp-{}.jpeg "http://legacysurvey.org/viewer-dev/jpeg-cutout/?layer={}&ra={:.5f}&dec={:.5f}&pixscale={:.0f}&size={:.0f}"'.format(
-        tmpoutdir, tileid, layer, tilera, tiledec, pixscale, size
+    tmpstr = 'wget -q -O {} "http://legacysurvey.org/viewer-dev/jpeg-cutout/?layer={}&ra={:.5f}&dec={:.5f}&pixscale={:.0f}&size={:.0f}"'.format(
+        tmpfn, layer, tilera, tiledec, pixscale, size
     )
     # print(tmpstr)
     os.system(tmpstr)
     try:
-        img = mpimg.imread("{}tmp-{}.jpeg".format(tmpoutdir, tileid))
-        os.remove("{}tmp-{}.jpeg".format(tmpoutdir, tileid))
+        img = mpimg.imread(tmpfn)
+        os.remove(tmpfn)
     except:
         img = np.zeros((size, size, 3))
     return img


### PR DESCRIPTION
Adds a timeout for the wget call to the imaging viewer cutout service when making fiberassign QA.