### PR TITLE
include desimeter in DEPNAM/DEPVER keywords

### DIFF
--- a/py/fiberassign/assign.py
+++ b/py/fiberassign/assign.py
@@ -269,8 +269,25 @@ def write_assignment_fits_tile(asgn, fulltarget, overwrite, params):
         header["FIELDNUM"] = 0
         header["FA_VER"] = __version__
         header["FA_SURV"] = tgs.survey()
-        #- code dependency versions (desitarget, desimodel, desimeter etc)
+
+        #- Add code dependency versions for default list of packages, then
+        #- call again for ones that are most critical to record just in
+        #- case they get dropped from the default list in the future.
+        #- (it won't add a second copy if they are already there)
         add_dependencies(header)
+        add_dependencies(
+            header,
+            module_names=[
+                "numpy",
+                "matplotlib",
+                "astropy",
+                "fitsio",
+                "desiutil",
+                "desimodel",
+                "desitarget",
+                "desimeter",
+            ]
+        )
 
         #- Keep SKYBRICKS_DIR used to lookup sky locations,
         #- shortening full path if possible

--- a/py/fiberassign/assign.py
+++ b/py/fiberassign/assign.py
@@ -269,18 +269,8 @@ def write_assignment_fits_tile(asgn, fulltarget, overwrite, params):
         header["FIELDNUM"] = 0
         header["FA_VER"] = __version__
         header["FA_SURV"] = tgs.survey()
-        add_dependencies(
-            header,
-            module_names=[
-                "numpy",
-                "matplotlib",
-                "astropy",
-                "fitsio",
-                "desiutil",
-                "desimodel",
-                "desitarget"
-            ]
-        )
+        #- code dependency versions (desitarget, desimodel, desimeter etc)
+        add_dependencies(header)
 
         #- Keep SKYBRICKS_DIR used to lookup sky locations,
         #- shortening full path if possible


### PR DESCRIPTION
This PR updates the call to `desiutil.depend.add_dependencies(header)` so that it will include the desimeter version too.  By default `add_dependencies` includes the desimeter version, but previously fiberassign was overriding the list of packages to consider and not including desimeter and thus that version was getting dropped.

As an extra level of paranoia, I added a call to `add_dependencies(header)` to pickup the default packages (including desimeter, and a few others that weren't already included like scipy), and then call it again with the packages that are most critical to record their versions just in case they get dropped from the default list in desiutil sometime in the future.

fixes #363

Resulting DEPNAM/DEPVER headers from a test run:
```
[cori08 test] fitsheader fiberassign-009999.fits.gz -e 1 | grep -e DEPNAM -e DEPVER
DEPNAM00= 'python  '                                                            
DEPVER00= '3.8.3   '                                                            
DEPNAM01= 'numpy   '                                                            
DEPVER01= '1.19.1  '                                                            
DEPNAM02= 'scipy   '                                                            
DEPVER02= '1.5.0   '                                                            
DEPNAM03= 'astropy '                                                            
DEPVER03= '4.0.1.post1'                                                         
DEPNAM04= 'yaml    '                                                            
DEPVER04= '5.3.1   '                                                            
DEPNAM05= 'matplotlib'                                                          
DEPVER05= '3.2.1   '                                                            
DEPNAM06= 'requests'                                                            
DEPVER06= '2.24.0  '                                                            
DEPNAM07= 'fitsio  '                                                            
DEPVER07= '1.1.2   '                                                            
DEPNAM08= 'healpy  '                                                            
DEPVER08= '1.14.0  '                                                            
DEPNAM09= 'desiutil'                                                            
DEPVER09= '3.2.1   '                                                            
DEPNAM10= 'desitarget'                                                          
DEPVER10= '1.0.1   '                                                            
DEPNAM11= 'desimodel'                                                           
DEPVER11= '0.15.0  '                                                            
DEPNAM12= 'desimeter'                                                           
DEPVER12= '0.6.6   '                                                            
DEPNAM13= 'fiberassign'                                                         
DEPVER13= '4.0.1.dev3108'                                                       
DEPNAM14= 'SKYBRICKS_DIR'                                                       
DEPVER14= '$DESI_ROOT/target/skybricks/v3'                                      
```