### PR TITLE
removal of MWS_FAINT_* targets for MTLTIME<20210524, for backwards co…

### DIFF
--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -1096,6 +1096,24 @@ def create_mtl(
         )
         d = d[keep]
 
+    # AR mtl: removing by hand MWS_FAINT_* for main if mtltime < 20210524
+    # AR mtl:   as those were not included in desitarget-1.0.0 main catalogs
+    # AR mtl: as 20210524 in during full moon with no obervations/updates,
+    # AR mtl:   no need to have something precise
+    mtltime_day = int(datetime.strptime(mtltime, "%Y-%m-%dT%H:%M:%S%z").strftime("%Y%m%d"))
+    mtltime_cut = 20210524
+    if (survey == "main") & (mtltime_day < mtltime_cut):
+        from desitarget.targetmask import mws_mask
+
+        keep = (d["MWS_TARGET"] & mws_mask["MWS_FAINT_BLUE"]) == 0
+        keep &= (d["MWS_TARGET"] & mws_mask["MWS_FAINT_RED"]) == 0
+        log.info(
+            "{:.1f}s\t{}\tremoving {}/{} MWS_FAINT_BLUE|MWS_FAINT_RED targets, as survey={} and mtltime<{}".format(
+                time() - start, step, len(d) - keep.sum(), len(d), survey, mtltime_cut
+            )
+        )
+        d = d[keep]
+
     # AR mtl: add columns not present in ledgers
     # AR mtl: need to provide exact list (if columns=None, inflate_ledger()
     # AR mtl:    overwrites existing columns)


### PR DESCRIPTION
…mpatibility

desitarget-1.0.0 catalogs, used for fiber assignment of the main survey untill 20210524, do not have MWS_FAINT_{BLUE,RED} targets included.
This PR is in the perspective of being able to reproduce what we ran with desitarget-1.0.0 with future desitarget catalogs, which will include MWS_FAINT_{BLUE,RED} targets.

When creating the target catalogs with fba_launch_io.create_mtl(), we manually remove any MWS_FAINT_{BLUE,RED} targets if MTLTIME < 20210524.

I think the code should run, though, there is currently no available target files to actually test that (with MTLTIME > 20210524 and with some MWS_FAINT_{BLUE,RED} targets).