### PR TITLE
Splitsteps

### DIFF
--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -154,6 +154,10 @@ def main():
             step="tile",
             start=start,
         )
+    else:
+        log.info("")
+        log.info("")
+        log.info("{:.1f}s\t{}\tnot executing, as per args.steps/args.nosteps".format(time() - start, "tile"))
 
     # AR sky
     if "sky" in steps:
@@ -167,6 +171,10 @@ def main():
             step="sky",
             start=start,
         )
+    else:
+        log.info("")
+        log.info("")
+        log.info("{:.1f}s\t{}\tnot executing, as per args.steps/args.nosteps".format(time() - start, "sky"))
 
     # AR gfa
     if "gfa" in steps:
@@ -183,6 +191,10 @@ def main():
             step="gfa",
             start=start,
         )
+    else:
+        log.info("")
+        log.info("")
+        log.info("{:.1f}s\t{}\tnot executing, as per args.steps/args.nosteps".format(time() - start, "gfa"))
 
     # AR mtl
     if "mtl" in steps:
@@ -201,27 +213,37 @@ def main():
             step="mtl",
             start=start,
         )
+    else:
+        log.info("")
+        log.info("")
+        log.info("{:.1f}s\t{}\tnot executing, as per args.steps/args.nosteps".format(time() - start, "mtl"))
 
     # AR secondary targets
     # AR if not backup
-    if ("scnd" in steps) & ("scnd" in list(mydirs.keys())):
-        create_mtl(
-            mytmpouts["tiles"],
-            mydirs["scndmtl"],
-            args.mtltime,
-            mydirs["scnd"],
-            args.survey,
-            args.gaiadr.replace("gaia", ""),
-            args.pmcorr,
-            mytmpouts["scnd"],
-            tmpoutdir=tmpoutdir,
-            pmtime_utc_str=args.pmtime_utc_str,
-            log=log,
-            step="scnd",
-            start=start,
-        )
+    if ("scnd" in steps):
+        if ("scnd" in list(mydirs.keys())):
+            create_mtl(
+                mytmpouts["tiles"],
+                mydirs["scndmtl"],
+                args.mtltime,
+                mydirs["scnd"],
+                args.survey,
+                args.gaiadr.replace("gaia", ""),
+                args.pmcorr,
+                mytmpouts["scnd"],
+                tmpoutdir=tmpoutdir,
+                pmtime_utc_str=args.pmtime_utc_str,
+                log=log,
+                step="scnd",
+                start=start,
+            )
+        else:
+            log.info("{:.1f}s\tscnd\tno secondary here".format(time() - start))
     else:
-        log.info("{:.1f}s\tdoscnd\tno secondary here".format(time() - start))
+        log.info("")
+        log.info("")
+        log.info("{:.1f}s\t{}\tnot executing, as per args.steps/args.nosteps".format(time() - start, "scnd"))
+
 
     # AR ToO targets
     # AR TBD: handling to MJD window boundaries as script argument?
@@ -241,6 +263,10 @@ def main():
             step="too",
             start=start,
         )
+    else:
+        log.info("")
+        log.info("")
+        log.info("{:.1f}s\t{}\tnot executing, as per args.steps/args.nosteps".format(time() - start, "too"))
 
     # AR fiberassign
     if "fa" in steps:
@@ -282,6 +308,10 @@ def main():
             step="fa",
             start=start,
         )
+    else:
+        log.info("")
+        log.info("")
+        log.info("{:.1f}s\t{}\tnot executing, as per args.steps/args.nosteps".format(time() - start, "fa"))
 
     # AR gzip all fiberassign files
     if "zip" in steps:
@@ -291,12 +321,20 @@ def main():
         # AR updating the path
         mytmpouts["fiberassign"] += ".gz"
         myouts["fiberassign"] += ".gz"
+    else:
+        log.info("")
+        log.info("")
+        log.info("{:.1f}s\t{}\tnot executing, as per args.steps/args.nosteps".format(time() - start, "zip"))
 
     # AR move tmpoutdir -> args.outdir
     if "move" in steps:
         mv_temp2final(
             mytmpouts, myouts, log=log, step="move", start=start,
         )
+    else:
+        log.info("")
+        log.info("")
+        log.info("{:.1f}s\t{}\tnot executing, as per args.steps/args.nosteps".format(time() - start, "move"))
 
     # AR QA plots
     if "qa" in steps:
@@ -329,6 +367,10 @@ def main():
             tmpoutdir=tmpoutdir,
             width_deg=4,
         )
+    else:
+        log.info("")
+        log.info("")
+        log.info("{:.1f}s\t{}\tnot executing, as per args.steps/args.nosteps".format(time() - start, "qa"))
 
     # AR do clean?
     if args.doclean == "y":

--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -310,6 +310,9 @@ def main():
             targfns.append(myouts["scnd"])
         if os.path.isfile(myouts["too"]):
             targfns.append(myouts["too"])
+        # AR fiberassign, updating path
+        if "zip" not in steps:
+            myouts["fiberassign"] += ".gz"
 
         make_qa(
             myouts["png"],

--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -279,23 +279,29 @@ def main():
         mytmpouts["fiberassign"] += ".gz"
         myouts["fiberassign"] += ".gz"
 
+    # AR move tmpoutdir -> args.outdir
+    if domove:
+        mv_temp2final(
+            mytmpouts, myouts, args.doclean, log=log, step="domove", start=start,
+        )
+
     # AR QA plots
     if doqa:
 
         # AR used targfns
-        targfns = [mytmpouts["targ"]]
-        if os.path.isfile(mytmpouts["scnd"]):
-            targfns.append(mytmpouts["scnd"])
-        if os.path.isfile(mytmpouts["too"]):
-            targfns.append(mytmpouts["too"])
+        targfns = [myouts["targ"]]
+        if os.path.isfile(myouts["scnd"]):
+            targfns.append(myouts["scnd"])
+        if os.path.isfile(myouts["too"]):
+            targfns.append(myouts["too"])
 
         make_qa(
-            mytmpouts["png"],
+            myouts["png"],
             args.survey,
             args.program,
             faflavor,
             targfns,
-            mytmpouts["fiberassign"],
+            myouts["fiberassign"],
             args.tileid,
             args.tilera,
             args.tiledec,
@@ -308,12 +314,6 @@ def main():
     # AR do clean?
     if args.doclean == "y":
         rmv_nonsvn(mytmpouts, myouts, log=log, step="doclean", start=start)
-
-    # AR move tmpoutdir -> args.outdir
-    if domove:
-        mv_temp2final(
-            mytmpouts, myouts, args.doclean, log=log, step="domove", start=start,
-        )
 
     # AR and we re done
     log.info("")
@@ -606,9 +606,11 @@ if __name__ == "__main__":
     )
 
     # AR temporary output files
+    # AR    except for png, as doqa is after domove
     mytmpouts = {}
     for key in list(myouts.keys()):
-        mytmpouts[key] = myouts[key].replace(args.outdir, tmpoutdir)
+        if key != "png":
+            mytmpouts[key] = myouts[key].replace(args.outdir, tmpoutdir)
 
     # AR temporary log file
     if os.path.isfile(mytmpouts["log"]):

--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -31,6 +31,10 @@ from fiberassign.fba_launch_io import (
 )
 from argparse import ArgumentParser
 
+# AR allowed steps in fba_launch
+steps_all = ["tile", "sky", "gfa", "mtl", "scnd", "too", "fa", "zip", "qa", "move"]
+
+
 # AR goal effective time
 # AR https://desi.lbl.gov/svn/data/surveyops/trunk/ops/config-sv2.yaml
 # AR https://desi.lbl.gov/svn/data/surveyops/trunk/ops/config-sv3.yaml as of Apr. 5th
@@ -73,6 +77,15 @@ def main():
         [kwargs[0] + "=" + str(kwargs[1]) for kwargs in args._get_kwargs()]
     )
     log.info("{:.1f}s\tsettings\targs: {}".format(time() - start, tmpstr))
+
+    # AR steps to execute in fba_launch
+    steps = [step for step in args.steps.split(",")]
+    if args.nosteps is not None:
+        steps = [step for step in steps if step not in args.nosteps.split(",")]
+        log.info("{:.1f}s\tsettings\tsteps to exclude: {}".format(time() - start, args.nosteps.split(",")))
+    else:
+        log.info("{:.1f}s\tsettings\tsteps to exclude: -".format(time() - start))
+    log.info("{:.1f}s\tsettings\tsteps to execute: {}".format(time() - start, steps))
 
     # AR safe: DESI environment variables defined?
     assert_env_vars(log=log, step="settings", start=start)
@@ -129,7 +142,7 @@ def main():
     )
 
     # AR tiles
-    if dotile:
+    if "tile" in steps:
         create_tile(
             args.tileid,
             args.tilera,
@@ -138,12 +151,12 @@ def main():
             args.survey,
             obscon=obscon,
             log=log,
-            step="dotile",
+            step="tile",
             start=start,
         )
 
     # AR sky
-    if dosky:
+    if "sky" in steps:
         create_sky(
             mytmpouts["tiles"],
             mydirs["sky"],
@@ -151,12 +164,12 @@ def main():
             suppskydir=mydirs["skysupp"],
             tmpoutdir=tmpoutdir,
             log=log,
-            step="dosky",
+            step="sky",
             start=start,
         )
 
     # AR gfa
-    if dogfa:
+    if "gfa" in steps:
         create_targ_nomtl(
             mytmpouts["tiles"],
             mydirs["gfa"],
@@ -167,12 +180,12 @@ def main():
             tmpoutdir=tmpoutdir,
             pmtime_utc_str=args.pmtime_utc_str,
             log=log,
-            step="dogfa",
+            step="gfa",
             start=start,
         )
 
     # AR mtl
-    if domtl:
+    if "mtl" in steps:
         create_mtl(
             mytmpouts["tiles"],
             mydirs["mtl"],
@@ -185,13 +198,13 @@ def main():
             tmpoutdir=tmpoutdir,
             pmtime_utc_str=args.pmtime_utc_str,
             log=log,
-            step="domtl",
+            step="mtl",
             start=start,
         )
 
     # AR secondary targets
     # AR if not backup
-    if (doscnd) & ("scnd" in list(mydirs.keys())):
+    if ("scnd" in steps) & ("scnd" in list(mydirs.keys())):
         create_mtl(
             mytmpouts["tiles"],
             mydirs["scndmtl"],
@@ -204,7 +217,7 @@ def main():
             tmpoutdir=tmpoutdir,
             pmtime_utc_str=args.pmtime_utc_str,
             log=log,
-            step="doscnd",
+            step="scnd",
             start=start,
         )
     else:
@@ -212,7 +225,7 @@ def main():
 
     # AR ToO targets
     # AR TBD: handling to MJD window boundaries as script argument?
-    if dotoo:
+    if "too" in steps:
         create_too(
             mytmpouts["tiles"],
             mydirs["too"],
@@ -225,17 +238,17 @@ def main():
             tmpoutdir=tmpoutdir,
             pmtime_utc_str=args.pmtime_utc_str,
             log=log,
-            step="dotoo",
+            step="too",
             start=start,
         )
 
     # AR fiberassign
-    if dofa:
+    if "fa" in steps:
         # AR prepare targfns
         targfns = [mytmpouts["targ"]]
-        if (doscnd) & (os.path.isfile(mytmpouts["scnd"])):
+        if ("scnd" in steps) & (os.path.isfile(mytmpouts["scnd"])):
             targfns.append(mytmpouts["scnd"])
-        if (dotoo) & (os.path.isfile(mytmpouts["too"])):
+        if ("too" in steps) & (os.path.isfile(mytmpouts["too"])):
             targfns.append(mytmpouts["too"])
 
         # AR launch_onetile_fa
@@ -248,7 +261,7 @@ def main():
             skyfn=mytmpouts["sky"],
             gfafn=mytmpouts["gfa"],
             log=log,
-            step="dofa",
+            step="fa",
             start=start,
         )
 
@@ -266,31 +279,31 @@ def main():
             obscon,
             fascript,
             log=log,
-            step="dofa",
+            step="fa",
             start=start,
         )
 
     # AR gzip all fiberassign files
-    if dozip:
+    if "zip" in steps:
         secure_gzip(
-            mytmpouts["fiberassign"], log=log, step="dozip", start=start,
+            mytmpouts["fiberassign"], log=log, step="zip", start=start,
         )
         # AR updating the path
         mytmpouts["fiberassign"] += ".gz"
         myouts["fiberassign"] += ".gz"
 
     # AR move tmpoutdir -> args.outdir
-    if domove:
+    if "move" in steps:
         mv_temp2final(
-            mytmpouts, myouts, log=log, step="domove", start=start,
+            mytmpouts, myouts, log=log, step="move", start=start,
         )
 
     # AR QA plots
-    if doqa:
+    if "qa" in steps:
 
         log.info("")
         log.info("")
-        log.info("{:.1f}s\t{}\tTIMESTAMP={}".format(time() - start, "doqa", Time.now().isot))
+        log.info("{:.1f}s\t{}\tTIMESTAMP={}".format(time() - start, "qa", Time.now().isot))
         # AR used targfns
         targfns = [myouts["targ"]]
         if os.path.isfile(myouts["scnd"]):
@@ -316,7 +329,7 @@ def main():
 
     # AR do clean?
     if args.doclean == "y":
-        rmv_nonsvn(myouts, log=log, step="doclean", start=start)
+        rmv_nonsvn(myouts, log=log, step="clean", start=start)
 
     # AR and we re done
     log.info("")
@@ -537,6 +550,20 @@ if __name__ == "__main__":
         default=None,
         required=False,
     )
+    parser.add_argument(
+        "--steps",
+        help="comma-separated list of steps to accomplish, amongst {} (defaults to {} if args.nosteps=None)".format(steps_all, ",".join(steps_all)),
+        type=str,
+        default=None,
+        required=False,
+    )
+    parser.add_argument(
+        "--nosteps",
+        help="comma-separated list of steps *not* to accomplish, amongst {} (default=None)".format(steps_all),
+        type=str,
+        default=None,
+        required=False,
+    )
 
     args = parser.parse_args()
     log = Logger.get()
@@ -583,6 +610,12 @@ if __name__ == "__main__":
         args.hdr_survey = args.survey
     if args.hdr_faprgrm is None:
         args.hdr_faprgrm = args.program.lower()
+
+    # AR steps/nosteps
+    if args.steps is not None and args.nosteps is not None:
+        sys.exit("only *one* of args.steps and args.nosteps has to be set to None; exiting")
+    if args.steps is None:
+        args.steps = ",".join(steps_all)
 
     # AR create a temporary directory for generated files
     tmpoutdir = tempfile.mkdtemp()

--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -276,6 +276,16 @@ def main():
             targfns.append(mytmpouts["scnd"])
         if ("too" in steps) & (os.path.isfile(mytmpouts["too"])):
             targfns.append(mytmpouts["too"])
+        # AR sky?
+        if "sky" in steps:
+            skyfn = mytmpouts["sky"]
+        else:
+            skyfn = None
+        # AR gfa?
+        if "gfa" in steps:
+            gfafn = mytmpouts["gfa"]
+        else:
+            gfafn = None
 
         # AR launch_onetile_fa
         launch_onetile_fa(
@@ -284,8 +294,8 @@ def main():
             targfns,
             mytmpouts["fba"],
             mytmpouts["fiberassign"],
-            skyfn=mytmpouts["sky"],
-            gfafn=mytmpouts["gfa"],
+            skyfn=skyfn,
+            gfafn=gfafn,
             log=log,
             step="fa",
             start=start,

--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -394,30 +394,6 @@ def main():
 
 if __name__ == "__main__":
 
-    # AR to speed up development/debugging
-    dotile, dosky, dogfa, domtl, doscnd, dotoo, dofa, dozip, doqa, domove = (
-        False,
-        False,
-        False,
-        False,
-        False,
-        False,
-        False,
-        False,
-        False,
-        False,
-    )
-    dotile = True
-    dosky = True
-    dogfa = True
-    domtl = True
-    doscnd = True
-    dotoo = True
-    dofa = True
-    dozip = True
-    doqa = True
-    domove = True
-
     # AR reading arguments
     parser = ArgumentParser()
     parser.add_argument(

--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -644,9 +644,26 @@ if __name__ == "__main__":
 
     # AR steps/nosteps
     if args.steps is not None and args.nosteps is not None:
-        sys.exit("only *one* of args.steps and args.nosteps has to be set to None; exiting")
+        log.error("only *one* of args.steps and args.nosteps has to be set to None; exiting")
+        sys.exit(1)
     if args.steps is None:
         args.steps = ",".join(steps_all)
+        if args.nosteps is not None:
+            wrong_nosteps = [step for step in args.nosteps.split(",") if step not in steps_all]
+            if len(wrong_nosteps) > 0:
+                log.error("args.nosteps have the following not authorized steps : {}; exiting".format(
+                    wrong_nosteps
+                    )
+                )
+                sys.exit(1)
+    else:
+        wrong_steps = [step for step in args.steps.split(",") if step not in steps_all]
+        if len(wrong_steps) > 0:
+            log.error("args.steps have the following not authorized steps : {}; exiting".format(
+                wrong_steps
+                )
+            )
+            sys.exit(1)
 
     # AR create a temporary directory for generated files
     tmpoutdir = tempfile.mkdtemp()

--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -282,7 +282,7 @@ def main():
     # AR move tmpoutdir -> args.outdir
     if domove:
         mv_temp2final(
-            mytmpouts, myouts, args.doclean, log=log, step="domove", start=start,
+            mytmpouts, myouts, log=log, step="domove", start=start,
         )
 
     # AR QA plots
@@ -313,7 +313,7 @@ def main():
 
     # AR do clean?
     if args.doclean == "y":
-        rmv_nonsvn(mytmpouts, myouts, log=log, step="doclean", start=start)
+        rmv_nonsvn(myouts, log=log, step="doclean", start=start)
 
     # AR and we re done
     log.info("")
@@ -509,7 +509,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--doclean",
-        help="delete TILEID-{tiles,sky,std,gfa,targ,scnd,too}.fits files (y/n)",
+        help="delete TILEID-{tiles,sky,std,gfa,targ,scnd,too}.fits files (y/n); if doclean=y",
         type=str,
         default="n",
         required=False,

--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -556,7 +556,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--doclean",
-        help="delete TILEID-{tiles,sky,std,gfa,targ,scnd,too}.fits files (y/n); if doclean=y",
+        help="delete TILEID-{tiles,sky,std,gfa,targ,scnd,too}.fits files (y/n)",
         type=str,
         default="n",
         required=False,

--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -32,7 +32,7 @@ from fiberassign.fba_launch_io import (
 from argparse import ArgumentParser
 
 # AR allowed steps in fba_launch
-steps_all = ["tile", "sky", "gfa", "mtl", "scnd", "too", "fa", "zip", "qa", "move"]
+steps_all = ["tile", "sky", "gfa", "mtl", "scnd", "too", "fa", "zip", "move", "qa"]
 
 
 # AR goal effective time

--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -32,7 +32,7 @@ from fiberassign.fba_launch_io import (
 from argparse import ArgumentParser
 
 # AR allowed steps in fba_launch
-steps_all = ["tile", "sky", "gfa", "mtl", "scnd", "too", "fa", "zip", "move", "qa"]
+steps_all = ["tile", "sky", "gfa", "targ", "scnd", "too", "fa", "zip", "move", "qa"]
 
 
 # AR goal effective time
@@ -196,8 +196,8 @@ def main():
         log.info("")
         log.info("{:.1f}s\t{}\tnot executing, as per args.steps/args.nosteps".format(time() - start, "gfa"))
 
-    # AR mtl
-    if "mtl" in steps:
+    # AR targ
+    if "targ" in steps:
         create_mtl(
             mytmpouts["tiles"],
             mydirs["mtl"],
@@ -210,13 +210,13 @@ def main():
             tmpoutdir=tmpoutdir,
             pmtime_utc_str=args.pmtime_utc_str,
             log=log,
-            step="mtl",
+            step="targ",
             start=start,
         )
     else:
         log.info("")
         log.info("")
-        log.info("{:.1f}s\t{}\tnot executing, as per args.steps/args.nosteps".format(time() - start, "mtl"))
+        log.info("{:.1f}s\t{}\tnot executing, as per args.steps/args.nosteps".format(time() - start, "targ"))
 
     # AR secondary targets
     # AR if not backup

--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -32,7 +32,7 @@ from fiberassign.fba_launch_io import (
 from argparse import ArgumentParser
 
 # AR allowed steps in fba_launch
-steps_all = ["tile", "sky", "gfa", "targ", "scnd", "too", "fa", "zip", "move", "qa"]
+steps_all = ["tiles", "sky", "gfa", "targ", "scnd", "too", "fa", "zip", "move", "qa"]
 
 
 # AR goal effective time
@@ -142,7 +142,7 @@ def main():
     )
 
     # AR tiles
-    if "tile" in steps:
+    if "tiles" in steps:
         create_tile(
             args.tileid,
             args.tilera,
@@ -151,13 +151,13 @@ def main():
             args.survey,
             obscon=obscon,
             log=log,
-            step="tile",
+            step="tiles",
             start=start,
         )
     else:
         log.info("")
         log.info("")
-        log.info("{:.1f}s\t{}\tnot executing, as per args.steps/args.nosteps".format(time() - start, "tile"))
+        log.info("{:.1f}s\t{}\tnot executing, as per args.steps/args.nosteps".format(time() - start, "tiles"))
 
     # AR sky
     if "sky" in steps:

--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -399,6 +399,14 @@ def main():
         rmv_nonsvn(myouts, log=log, step="clean", start=start)
 
     # AR and we re done
+    if not args.log_stdout:
+        log.info("")
+        log.info("")
+        log.info(
+            "{:.1f}s\t{}\tmoving {} to {}".format(
+                time() - start, "log", mytmpouts["log"], myouts["log"]
+            )
+        )
     log.info("")
     log.info("")
     log.info("{:.1f}s\tend\tTIMESTAMP={}".format(time() - start, Time.now().isot))

--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -590,7 +590,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--nosteps",
-        help="comma-separated list of steps *not* to accomplish, amongst {} (default=None)".format(steps_all),
+        help="comma-separated list of steps *not* to accomplish, amongst {} (default=None); cannot be used if some args.steps values are also provided".format(steps_all),
         type=str,
         default=None,
         required=False,

--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -87,6 +87,15 @@ def main():
         log.info("{:.1f}s\tsettings\tsteps to exclude: -".format(time() - start))
     log.info("{:.1f}s\tsettings\tsteps to execute: {}".format(time() - start, steps))
 
+    # AR files we expect to be created, given args.steps, for the "move" step
+    expected_files = {}
+    for step in steps:
+        if step not in ["zip", "move", "qa"]:
+            if step == "fa":
+                expected_files["fba"], expected_files["fiberassign"] = True, True
+            else:
+                expected_files[step] = True
+
     # AR safe: DESI environment variables defined?
     assert_env_vars(log=log, step="settings", start=start)
 
@@ -238,6 +247,7 @@ def main():
                 start=start,
             )
         else:
+            expected_files["scnd"] = False
             log.info("{:.1f}s\tscnd\tno secondary here".format(time() - start))
     else:
         log.info("")
@@ -248,7 +258,7 @@ def main():
     # AR ToO targets
     # AR TBD: handling to MJD window boundaries as script argument?
     if "too" in steps:
-        create_too(
+        expected_files["too"] = create_too(
             mytmpouts["tiles"],
             mydirs["too"],
             mjd_now - 1,
@@ -338,8 +348,10 @@ def main():
 
     # AR move tmpoutdir -> args.outdir
     if "move" in steps:
+        # AR files we expect to be created
+        expected_keys = [key for key in list(expected_files.keys()) if expected_files[key]]
         mv_temp2final(
-            mytmpouts, myouts, log=log, step="move", start=start,
+            mytmpouts, myouts, expected_keys, log=log, step="move", start=start,
         )
     else:
         log.info("")

--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -288,6 +288,9 @@ def main():
     # AR QA plots
     if doqa:
 
+        log.info("")
+        log.info("")
+        log.info("{:.1f}s\t{}\tTIMESTAMP={}".format(time() - start, "doqa", Time.now().isot))
         # AR used targfns
         targfns = [myouts["targ"]]
         if os.path.isfile(myouts["scnd"]):

--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -303,9 +303,6 @@ def main():
             args.rundate,
             tmpoutdir=tmpoutdir,
             width_deg=4,
-            log=log,
-            step="doqa",
-            start=start,
         )
 
     # AR do clean?

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -2930,16 +2930,14 @@ def make_qa(
     plt.close()
 
 
-def rmv_nonsvn(mytmpouts, myouts, log=Logger.get(), step="", start=time()):
+def rmv_nonsvn(myouts, log=Logger.get(), step="", start=time()):
     """
     Remove fba_launch non-SVN products
     
     Args:
-        mytmpouts: dictionary with the temporary files location (dictionary);
-            concerns the following keys:
-                "tiles", "sky", "gfa", "targ", "scnd", "too", "fba"
         myouts: dictionary with the fba_launch args.outdir location (dictionary);
-            contains same keys as mytmpouts
+            must contain the following keys:
+                "tiles", "sky", "gfa", "targ", "scnd", "too", "fba"
         log (optional, defaults to Logger.get()): Logger object
         step (optional, defaults to ""): corresponding step, for fba_launch log recording
             (e.g. dotiles, dosky, dogfa, domtl, doscnd, dotoo)
@@ -2949,16 +2947,16 @@ def rmv_nonsvn(mytmpouts, myouts, log=Logger.get(), step="", start=time()):
     log.info("")
     log.info("{:.1f}s\t{}\tTIMESTAMP={}".format(time() - start, step, Time.now().isot))
     for key in ["tiles", "sky", "gfa", "targ", "scnd", "too", "fba"]:
-        if os.path.isfile(mytmpouts[key]):
-            os.remove(mytmpouts[key])
+        if os.path.isfile(myouts[key]):
+            os.remove(myouts[key])
             log.info(
                 "{:.1f}s\t{}\tdeleting file {}".format(
-                    time() - start, step, mytmpouts[key]
+                    time() - start, step, myouts[key]
                 )
             )
 
 
-def mv_temp2final(mytmpouts, myouts, doclean, log=Logger.get(), step="", start=time()):
+def mv_temp2final(mytmpouts, myouts, log=Logger.get(), step="", start=time()):
     """
     Moves the fba_launch outputs from the temporary location to the args.outdir location.   
 
@@ -2969,8 +2967,6 @@ def mv_temp2final(mytmpouts, myouts, doclean, log=Logger.get(), step="", start=t
                 if doclean="n", also: "tiles", "sky", "gfa", "targ", "scnd", "too", "fba"
         myouts: dictionary with the fba_launch args.outdir location (dictionary);
             contains same keys as mytmpouts
-        doclean: remove non-SVN files? "y" or "n" (string);
-            args.clean fba_launch argument
         log (optional, defaults to Logger.get()): Logger object
         step (optional, defaults to ""): corresponding step, for fba_launch log recording
             (e.g. dotiles, dosky, dogfa, domtl, doscnd, dotoo)
@@ -2983,21 +2979,20 @@ def mv_temp2final(mytmpouts, myouts, doclean, log=Logger.get(), step="", start=t
     log.info("")
     log.info("{:.1f}s\t{}\tTIMESTAMP={}".format(time() - start, step, Time.now().isot))
     # AR optional files
-    if doclean == "n":
-        for key in ["tiles", "sky", "gfa", "targ", "scnd", "too", "fba"]:
-            if os.path.isfile(mytmpouts[key]):
-                _ = shutil.move(mytmpouts[key], myouts[key])
-                log.info(
-                    "{:.1f}s\t{}\tmoving file {} to {}".format(
-                        time() - start, step, mytmpouts[key], myouts[key]
-                    )
+    for key in ["tiles", "sky", "gfa", "targ", "scnd", "too", "fba"]:
+        if os.path.isfile(mytmpouts[key]):
+            _ = shutil.move(mytmpouts[key], myouts[key])
+            log.info(
+                "{:.1f}s\t{}\tmoving file {} to {}".format(
+                    time() - start, step, mytmpouts[key], myouts[key]
                 )
-            else:
-                log.info(
-                    "{:.1f}s\t{}\tno file {}".format(
-                        time() - start, step, mytmpouts[key]
-                    )
+            )
+        else:
+            log.info(
+                "{:.1f}s\t{}\tno file {}".format(
+                    time() - start, step, mytmpouts[key]
                 )
+            )
     # AR fiberassign-TILEID.fits.gz
     # AR fiberassign-TILEID.png is created after the call to mv_temp2final
     for key in ["fiberassign"]:

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -1456,7 +1456,7 @@ def launch_onetile_fa(
 
     # AR storing parent/assigned quantities
     parent, assign, dras, ddecs, petals, nassign = get_parent_assign_quants(
-        args.survey, targfns, fiberassignfn, tilera, tiledec, log=log, step=step, start=start
+        args.survey, targfns, fiberassignfn, tilera, tiledec,
     )
     # AR stats : assigned / parent
     print_assgn_parent_stats(args.survey, parent, assign, log=log, step=step, start=start)
@@ -1617,14 +1617,14 @@ def secure_gzip(
 
 
 def get_dt_masks(
-    survey, log=Logger.get(), step="", start=time(),
+    survey, log=None, step="", start=time(),
 ):
     """
     Get the desitarget masks for a survey.
     
     Args:
         survey: survey name: "sv1", "sv2", "sv3" or "main") (string)
-        log (optional, defaults to Logger.get()): Logger object
+        log (optional, defaults to None): Logger object
         step (optional, defaults to ""): corresponding step, for fba_launch log recording
             (e.g. dotiles, dosky, dogfa, domtl, doscnd, dotoo)
         start(optional, defaults to time()): start time for log (in seconds; output of time.time()
@@ -1652,11 +1652,14 @@ def get_dt_masks(
         from desitarget import targetmask
         from fiberassign.targets import default_main_stdmask
     else:
-        log.error(
-            "{:.1f}s\t{}\tsurvey={} is not in sv1, sv2, sv3 or main; exiting".format(
-                time() - start, step, survey
+        if log is not None:
+            log.error(
+                "{:.1f}s\t{}\tsurvey={} is not in sv1, sv2, sv3 or main; exiting".format(
+                    time() - start, step, survey
+                )
             )
-        )
+        else:
+            print("survey={} is not in sv1, sv2, sv3 or main; exiting".format(survey))
         sys.exit(1)
 
     # AR YAML masks
@@ -1683,7 +1686,7 @@ def get_dt_masks(
 
 
 def get_qa_tracers(
-    survey, program, log=Logger.get(), step="", start=time(),
+    survey, program, log=None, step="", start=time(),
 ):
     """
     Returns the tracers for which we provide QA plots of fiber assignment.
@@ -1691,7 +1694,7 @@ def get_qa_tracers(
     Args:
         survey: survey name: "sv1", "sv2", "sv3" or "main") (string)
         program: "DARK", "BRIGHT", or "BACKUP" (string)
-        log (optional, defaults to Logger.get()): Logger object                                                                                                                                            
+        log (optional, defaults to None): Logger object
         step (optional, defaults to ""): corresponding step, for fba_launch log recording
             (e.g. dotiles, dosky, dogfa, domtl, doscnd, dotoo)
         start(optional, defaults to time()): start time for log (in seconds; output of time.time()
@@ -1715,11 +1718,14 @@ def get_qa_tracers(
         trmskkeys = ["MWS_TARGET", "MWS_TARGET", "MWS_TARGET"]
         trmsks = ["BACKUP_BRIGHT", "BACKUP_FAINT", "BACKUP_VERY_FAINT"]
     else:
-        log.error(
-            "{:.1f}s\t{}\tprogram={} not in DARK, BRIGHT, or BACKUP; exiting".format(
-                time() - start, step, program
+        if log is not None:
+            log.error(
+                "{:.1f}s\t{}\tprogram={} not in DARK, BRIGHT, or BACKUP; exiting".format(
+                    time() - start, step, program
+                )
             )
-        )
+        else:
+            print("program={} not in DARK, BRIGHT, or BACKUP; exiting".format(program))
         sys.exit(1)
 
     return trmskkeys, trmsks
@@ -1731,9 +1737,6 @@ def get_parent_assign_quants(
     fiberassignfn,
     tilera,
     tiledec,
-    log=Logger.get(),
-    step="",
-    start=time(),
 ):
     """
     Stores the parent and assigned targets properties (desitarget columns).
@@ -1744,10 +1747,6 @@ def get_parent_assign_quants(
         fiberassignfn: path to the output fiberassign-TILEID.fits file (string)
         tilera: tile center R.A. (float)
         tiledec: tile center Dec. (float)
-        log (optional, defaults to Logger.get()): Logger object                                                                                                                                            
-        step (optional, defaults to ""): corresponding step, for fba_launch log recording
-            (e.g. dotiles, dosky, dogfa, domtl, doscnd, dotoo)
-        start(optional, defaults to time()): start time for log (in seconds; output of time.time()
 
     Returns:
         parent: dictionary of the parent target sample, with each key being some desitarget column
@@ -1767,9 +1766,7 @@ def get_parent_assign_quants(
     parent, assign, dras, ddecs, petals, nassign = {}, {}, {}, {}, {}, {}
 
     # AR YAML and WD and STD masks
-    yaml_masks, wd_mskkeys, wd_msks, std_mskkeys, std_msks = get_dt_masks(
-        survey, log=log, step=step, start=start,
-    )
+    yaml_masks, wd_mskkeys, wd_msks, std_mskkeys, std_msks = get_dt_masks(survey)
 
     # AR keys we use (plus few for assign)
     keys = [
@@ -1980,9 +1977,6 @@ def qa_print_infos(
     rundate,
     parent,
     assign,
-    log=Logger.get(),
-    step="",
-    start=time(),
 ):
     """
     Print general fiber assignment infos on the QA plot.
@@ -1999,21 +1993,13 @@ def qa_print_infos(
         rundate: used rundate (string)
         parent: dictionary for the parent target sample (output by get_parent_assign_quants())
         assign: dictionary for the assigned target sample (output by get_parent_assign_quants()) 
-        log (optional, defaults to Logger.get()): Logger object                                                                                                                                            
-        step (optional, defaults to ""): corresponding step, for fba_launch log recording
-            (e.g. dotiles, dosky, dogfa, domtl, doscnd, dotoo)
-        start(optional, defaults to time()): start time for log (in seconds; output of time.time()
     """
     # AR hard-setting the plotted tracers
     # AR TBD: handle secondaries
-    trmskkeys, trmsks = get_qa_tracers(
-        survey, program, log=Logger.get(), step="", start=time(),
-    )
+    trmskkeys, trmsks = get_qa_tracers(survey, program)
 
     # AR masks
-    yaml_masks, wd_mskkeys, wd_msks, std_mskkeys, std_msks = get_dt_masks(
-        survey, log=log, step=step, start=start,
-    )
+    yaml_masks, wd_mskkeys, wd_msks, std_mskkeys, std_msks = get_dt_masks(survey)
 
     # AR infos : general
     x, y, dy, fs = 0.05, 0.95, -0.1, 10
@@ -2165,9 +2151,6 @@ def get_viewer_cutout(
     pixscale=10,
     dr="dr9",
     timeout=15,
-    log=Logger.get(),
-    step="",
-    start=time(),
 ):
     """
     Downloads a cutout of the tile region from legacysurvey.org/viewer.
@@ -2201,11 +2184,7 @@ def get_viewer_cutout(
     try:
         subprocess.check_call(tmpstr, stderr=subprocess.DEVNULL, shell=True)
     except subprocess.CalledProcessError:
-        log.warning(
-            "{:.1f}s\t{}\tno cutout from viewer after {}s, stopping the wget call".format(
-                time() - start, step, timeout
-            )
-        )
+        print("no cutout from viewer after {}s, stopping the wget call".format(timeout))
 
     try:
         img = mpimg.imread(tmpfn)
@@ -2813,9 +2792,6 @@ def make_qa(
     rundate,
     tmpoutdir=tempfile.mkdtemp(),
     width_deg=4,
-    log=Logger.get(),
-    step="",
-    start=time(),
 ):
     """
     Make fba_launch QA plot.
@@ -2833,32 +2809,17 @@ def make_qa(
         rundate: used rundate (string)
         tmpoutdir (optional, defaults to a temporary directory): temporary directory (to download the cutout)
         width_deg (optional, defaults to 4): width of the cutout in degrees (np.array of floats)
-        log (optional, defaults to Logger.get()): Logger object
-        step (optional, defaults to ""): corresponding step, for fba_launch log recording
-            (e.g. dotiles, dosky, dogfa, domtl, doscnd, dotoo)
-        start(optional, defaults to time()): start time for log (in seconds; output of time.time()
     """
-    log.info("")
-    log.info("")
-    log.info("{:.1f}s\t{}\tTIMESTAMP={}".format(time() - start, step, Time.now().isot))
     # AR WD and STD used masks
-    _, wd_mskkeys, wd_msks, std_mskkeys, std_msks = get_dt_masks(
-        survey, log=log, step=step, start=start,
-    )
-    log.info("{:.1f}s\t{}\twd_mskkeys = {}".format(time() - start, step, wd_mskkeys))
-    log.info("{:.1f}s\t{}\twd_msks = {}".format(time() - start, step, wd_msks))
-    log.info("{:.1f}s\t{}\tstd_mskkeys = {}".format(time() - start, step, std_mskkeys))
-    log.info("{:.1f}s\t{}\tstd_msks = {}".format(time() - start, step, std_msks))
+    _, wd_mskkeys, wd_msks, std_mskkeys, std_msks = get_dt_masks(survey)
 
     # AR plotted tracers
     # AR TBD: handle secondary?
-    trmskkeys, trmsks = get_qa_tracers(
-        survey, program, log=log, step="doplot", start=start,
-    )
+    trmskkeys, trmsks = get_qa_tracers(survey, program)
 
     # AR storing parent/assigned quantities
     parent, assign, dras, ddecs, petals, nassign = get_parent_assign_quants(
-        survey, targfns, fiberassignfn, tilera, tiledec, log=log, step=step, start=start
+        survey, targfns, fiberassignfn, tilera, tiledec
     )
 
     # AR start plotting
@@ -2881,9 +2842,6 @@ def make_qa(
         rundate,
         parent,
         assign,
-        log=log,
-        step=step,
-        start=start,
     )
 
     # AR stats per petal
@@ -2903,9 +2861,6 @@ def make_qa(
         pixscale=10,
         dr="dr9",
         timeout=15,
-        log=log,
-        step=step,
-        start=start,
     )
 
     # AR SKY, BAD, WD, STD, TGT

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -1423,7 +1423,10 @@ def launch_onetile_fa(
     ag = {}
     ag["tiles"] = [tileid]
     ag["columns"] = None
-    ag["targets"] = [gfafn] + targfns
+    if gfafn is not None:
+        ag["targets"] = [gfafn] + targfns
+    else:
+        ag["targets"] = targfns
     if skyfn is not None:
         ag["sky"] = [skyfn]
     else:

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -2999,12 +2999,3 @@ def mv_temp2final(mytmpouts, myouts, expected_keys, log=Logger.get(), step="", s
             )
             sys.exit(1)
 
-    # AR actually here not moving the log file
-    # AR moving it after the main() in fba_launch
-    key = "log"
-    log.info(
-        "{:.1f}s\t{}\tmoving {} to {}".format(
-            time() - start, step, mytmpouts[key], myouts[key]
-        )
-    )
-

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -2965,7 +2965,7 @@ def mv_temp2final(mytmpouts, myouts, doclean, log=Logger.get(), step="", start=t
     Args:
         mytmpouts: dictionary with the temporary files location (dictionary);
             contains the following keys:
-                "fiberassign", "png", "log"
+                "fiberassign", "log"
                 if doclean="n", also: "tiles", "sky", "gfa", "targ", "scnd", "too", "fba"
         myouts: dictionary with the fba_launch args.outdir location (dictionary);
             contains same keys as mytmpouts
@@ -2998,8 +2998,9 @@ def mv_temp2final(mytmpouts, myouts, doclean, log=Logger.get(), step="", start=t
                         time() - start, step, mytmpouts[key]
                     )
                 )
-    # AR SVN-checked files
-    for key in ["fiberassign", "png"]:
+    # AR fiberassign-TILEID.fits.gz
+    # AR fiberassign-TILEID.png is created after the call to mv_temp2final
+    for key in ["fiberassign"]:
         _ = shutil.move(mytmpouts[key], myouts[key])
         log.info(
             "{:.1f}s\t{}\tmoving {} to {}".format(


### PR DESCRIPTION
This PR puts as arguments the steps to be run in fba_launch (dotile, dosky, dogfa, domtl, doscnd, dotoo, dofa, dozip, doqa, domove).
Previously, those steps (initially introduced to allow debugging) were hard-coded.
Now, those are controlled by two arguments, as suggested by @schlafly:
  --steps : defaulting to all steps
 --nosteps : defaulting to None
Only one can be set a time.

This does not change at all the fiber assignment, but offers more flexibility.
Noticely, in prevision of running fiberassign on-the-fly, this would allow to execute a first call generating fiberassign-TILEID.fits.gz; and a second call to make the QA png file would be done just after, but wouldn t delay the operations.
It would look like:
```
fba_launch --nosteps qa [...] # call to generate fiberassign-TILEID.fits.gz
fba_launch --steps qa --log-stdout [...] # call to generate the QA png file, redirecting to stdout to not overwrite the log file from the first call
```

To achieve that we moved the fiber assignment statistics report from the make_qa() function to the launch_onetile_fa() function, and disabled all log printing in make_qa().
We also allow to run e.g. with no gfa or no sky, which could be useful for testing.