### PR TITLE
fix case if no ToO targets selected, for mv_temp2final()

### DIFF
--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -1300,6 +1300,7 @@ def create_too(
                 time() - start, step, outfn
             )
         )
+        return False
 
     return True
 


### PR DESCRIPTION
This PR fixes a bug introduced in https://github.com/desihub/fiberassign/commit/96ec11b404938557da1aa46cb3205491f2a94a1c#diff-d3786c9b9b38f305d8e88b7855796e1f5d9f2add6f9deecbf557b7eb959776a7.
In case a ToO.ecsv file is present, but no targets are selected, a "False" should be returned by create_too(), to warn mv_temp2final() that no TILEID-too.fits file is created.

Bug discovered thanks to the recent change in ToO.ecsv.