### PR TITLE
Proper handling of --worldreadable in fba_rerun

### DIFF
--- a/bin/fba_rerun
+++ b/bin/fba_rerun
@@ -82,7 +82,7 @@ def main():
         # AR handling of the "action_store=True" arguments..
         # AR - if True, we keep the argument name
         # AR - if False, we remove
-        if key in ["--log_stdout"]:
+        if key in ["--log_stdout", "--worldreadable"]:
             if val == "False":
                 continue
             else:


### PR DESCRIPTION
This PR properly handles in fba_rerun the fba_launch --worldreadable argument, introduced in 1ff4135748d3ecbd9b92adcfb701fe25aef8ec38.