### PR TITLE
Also use touching-tile ledgers to set default MTLTIME 

### DIFF
--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -70,6 +70,26 @@ def main():
     start = time()
     log.info("{:.1f}s\tstart\tTIMESTAMP={}".format(time() - start, Time.now().isot))
 
+    # AR mtltime
+    # AR if possible: setting to the latest timestamp for the program
+    # AR else: setting to utc_time_now_str
+    if args.mtltime is None:
+        log.info("")
+        log.info("")
+        log.info("{:.1f}s\tmtltime\tTIMESTAMP={}".format(time() - start, Time.now().isot))
+        args.mtltime = utc_time_now_str
+        timestamp = get_program_latest_timestamp(
+            args.survey,
+            args.program,
+            args.tilera,
+            args.tiledec,
+            log=log,
+            step="mtltime",
+            start=start,
+        )
+        if timestamp is not None:
+            args.mtltime = timestamp
+
     log.info("")
     log.info("")
     log.info("{:.1f}s\tsettings\tTIMESTAMP={}".format(time() - start, Time.now().isot))
@@ -653,14 +673,8 @@ if __name__ == "__main__":
     if args.pmtime_utc_str is None:
         args.pmtime_utc_str = utc_time_now_str
 
-    # AR mtltime
-    # AR if possible: setting to the latest timestamp for the program
-    # AR else: setting to utc_time_now_str
-    if args.mtltime is None:
-        args.mtltime = utc_time_now_str
-        timestamp = get_program_latest_timestamp(args.survey, args.program, args.tilera, args.tiledec)
-        if timestamp is not None:
-            args.mtltime = timestamp
+    # AR mtltime (2021-09-01): if set to None, now setting it inside main()
+    # AR          so that it is recorded in the fiberassign-TILEID.log file
 
     # AR goaltime
     if args.goaltime is None:

--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -89,6 +89,9 @@ def main():
         )
         if timestamp is not None:
             args.mtltime = timestamp
+            log.info("{:.1f}s\tmtltime\tsetting args.mtltime={}, based on the latest timestamp".format(time() - start, args.mtltime))
+        else:
+            log.info("{:.1f}s\tmtltime\tsetting args.mtltime={}, based on current time".format(time() - start, args.mtltime))
 
     log.info("")
     log.info("")

--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -658,7 +658,7 @@ if __name__ == "__main__":
     # AR else: setting to utc_time_now_str
     if args.mtltime is None:
         args.mtltime = utc_time_now_str
-        timestamp = get_program_latest_timestamp(args.program)
+        timestamp = get_program_latest_timestamp(args.survey, args.program, args.tilera, args.tiledec)
         if timestamp is not None:
             args.mtltime = timestamp
 

--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -71,7 +71,9 @@ def main():
     log.info("{:.1f}s\tstart\tTIMESTAMP={}".format(time() - start, Time.now().isot))
 
     # AR mtltime
-    # AR if possible: setting to the latest timestamp for the program
+    # AR if possible: setting to the latest of:
+    # AR - latest timestamp for the program
+    # AR - latest timestamp in the ledgers for pixels touching the tile
     # AR else: setting to utc_time_now_str
     if args.mtltime is None:
         log.info("")

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -133,6 +133,32 @@ def get_last_line(fn):
     return last_line
 
 
+def read_ecsv_keys(fn):
+    """
+    Returns the column content of an .ecsv file.
+
+    Args:
+        fn: filename with an .ecsv format (string)
+
+    Returns:
+        keys: list of the column names in fn (list)
+
+    Notes:
+        Gets the column names from the first line not starting with "#".
+    """
+    keys = []
+    with open(fn) as f:
+        for line in f:
+            if line[0] == "#":
+                continue
+            if len(line.strip()) == 0:
+                continue
+            keys = line.split()
+            break
+    f.close()
+    return keys
+
+
 def get_program_latest_timestamp(
     survey, program, tilera, tiledec, log=Logger.get(), step="", start=time(),
 ):
@@ -281,32 +307,6 @@ def mv_write_targets_out(infn, targdir, outfn, log=Logger.get(), step="", start=
     tmpdirs = infn.replace(targdir, "").split("/")[:-1]
     for i in range(len(tmpdirs))[::-1]:
         os.rmdir(os.path.join(*[targdir] + tmpdirs[: i + 1]))
-
-
-def read_ecsv_keys(fn):
-    """
-    Returns the column content of an .ecsv file.
-
-    Args:
-        fn: filename with an .ecsv format (string)
-
-    Returns:
-        keys: list of the column names in fn (list)
-
-    Notes:
-        Gets the column names from the first line not starting with "#".
-    """
-    keys = []
-    with open(fn) as f:
-        for line in f:
-            if line[0] == "#":
-                continue
-            if len(line.strip()) == 0:
-                continue
-            keys = line.split()
-            break
-    f.close()
-    return keys
 
 
 def get_nowradec(ra, dec, pmra, pmdec, parallax, ref_year, pmtime_utc_str, scnd=False):

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -130,9 +130,7 @@ def get_program_latest_timestamp(
         else: None
 
     Notes:
-        if the per-tile MTL files does not exist or has zero entries,
-        TBD: currently add +1min because of a mismatch between the ledgers and the per-tile file.
-        TBD: still see if a +1min or +1s is desirable
+        20210831: remove the +1min (and added "leq=True" in the read_targets_.. routines for ledgers)
     """
     # AR check DESI_SURVEYOPS is defined
     assert_env_vars(
@@ -230,12 +228,7 @@ def get_program_latest_timestamp(
 
     # AR take the latest TIMESTAMP
     if len(tms) > 0:
-        tm = np.sort(tms)[-1]
-        tm = datetime.strptime(tm, "%Y-%m-%dT%H:%M:%S%z")
-        # AR TBD: we currently add one minute; can be removed once
-        # AR TBD  update is done on the desitarget side
-        tm += timedelta(minutes=1)
-        timestamp = tm.isoformat(timespec="seconds")
+        timestamp = np.sort(tms)[-1]
 
     log.info("{:.1f}s\t{}\tlatest timestamp : {}".format(time() - start, step, timestamp))
     return timestamp
@@ -1226,6 +1219,7 @@ def create_mtl(
 
         20210526 : implementation of using subpriority=False in write_targets
                     to avoid an over-writting of the SUBPRIORITY
+        20210831 : add "leq=True" in read_targets_in_tiles()
     """
     log.info("")
     log.info("")
@@ -1243,6 +1237,7 @@ def create_mtl(
         mtl=True,
         unique=True,
         isodate=mtltime,
+        leq=True,
     )
     log.info(
         "{:.1f}s\t{}\treading {} targets from {}".format(
@@ -1387,6 +1382,7 @@ def create_too(
 
         20210526 : implementation of using subpriority=False in write_targets
                     to avoid an over-writting of the SUBPRIORITY
+        TBD : add a MTLTIME cut when TIMESTAMP is available
     """
     log.info("")
     log.info("")

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -139,6 +139,9 @@ def get_program_latest_timestamp(
         required_env_vars=["DESI_SURVEYOPS"], log=log, step=step, start=start,
     )
 
+    # AR defaults to None (returned if no file or no selected rows)
+    timestamp = None
+
     tms = []
     # AR check if the per-tile file is here
     # AR no need to check the scnd-mtl-done-tiles.ecsv file,
@@ -147,6 +150,11 @@ def get_program_latest_timestamp(
     if os.path.isfile(fn):
         d = Table.read(fn)
         keep = d["PROGRAM"] == program.upper()
+        # AR add a cut on TILEID
+        if survey == "sv3":
+            keep &= (d["TILEID"] < 1000)
+        if survey == "main":
+            keep &= (d["TILEID"] >= 1000) & (d["TILEID"] < 59000)
         if keep.sum() > 0:
             d = d[keep]
             # AR taking the latest timestamp

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -789,9 +789,6 @@ def get_desitarget_paths(
         "resolve",
         program.lower(),
     )
-    mydirs["mtl"] = os.path.join(
-        os.getenv("DESI_SURVEYOPS"), "mtl", survey.lower(), program.lower(),
-    )
     # AR secondary (dark, bright; no secondary for backup)
     if program.lower() in ["dark", "bright"]:
         if survey.lower() == "main":
@@ -809,18 +806,6 @@ def get_desitarget_paths(
             program.lower(),
             basename,
         )
-        mydirs["scndmtl"] = os.path.join(
-            os.getenv("DESI_SURVEYOPS"),
-            "mtl",
-            survey.lower(),
-            "secondary",
-            program.lower(),
-        )
-
-    # AR ToO (same for dark, bright)
-    mydirs["too"] = os.path.join(
-        os.getenv("DESI_SURVEYOPS"), "mtl", survey.lower(), "ToO", "ToO.ecsv",
-    )
 
     # AR log
     for key in list(mydirs.keys()):
@@ -835,6 +820,17 @@ def get_desitarget_paths(
                     time() - start, step, key, mydirs[key]
                 )
             )
+
+    # AR ledgers
+    mydirs["mtl"], scndmtl, mydirs["too"] = get_ledger_paths(
+        survey.lower(),
+        program.lower(),
+        log=log,
+        step=step,
+        start=start,
+    )
+    if scndmtl is not None:
+        mydirs["scndmtl"] = scndmtl
 
     return mydirs
 

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -107,6 +107,25 @@ def get_svn_version(svn_dir):
     return svn_ver
 
 
+def get_last_line(fn):
+    """
+    Return the last line of a text file.
+
+    Args:
+        fn: file name (string)
+
+    Returns:
+        last_line: (string)
+    """
+    with open(fn, "rb") as f:
+        f.seek(-2, os.SEEK_END)
+        while f.read(1) != b"\n":
+            f.seek(-2, os.SEEK_CUR)
+        last_line = f.readline().decode().strip()
+    f.close()
+    return last_line
+
+
 def get_program_latest_timestamp(
     survey, program, tilera, tiledec, log=Logger.get(), step="", start=time(),
 ):
@@ -217,7 +236,7 @@ def get_program_latest_timestamp(
                 log.warning("{:.1f}s\t{}\t{}: no TIMESTAMP column; passing".format(time() - start, step, fn))
             else:
                 i = ii[0]
-                line = subprocess.check_output(["tail", "-n", "1", fn], stderr=subprocess.DEVNULL).strip().decode()
+                line = get_last_line(fn)
                 tm = line.split()[i]
                 # AR does not end with +NN:MM timezone?
                 if re.search('\+\d{2}:\d{2}$', tm) is None:

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -176,9 +176,6 @@ def get_program_latest_timestamp(
             d = d[keep]
             # AR taking the latest timestamp
             tm = np.unique(d["TIMESTAMP"])[-1]
-            # AR does not end with +NN:MM timezone?
-            if re.search('\+\d{2}:\d{2}$', tm) is None:
-                tm = "{}+00:00".format(tm)
             log.info("{:.1f}s\t{}\tlatest TIMESTAMP from {}: {}".format(time() - start, step, fn, tm))
             tms.append(tm)
 
@@ -238,9 +235,6 @@ def get_program_latest_timestamp(
                 i = ii[0]
                 line = get_last_line(fn)
                 tm = line.split()[i]
-                # AR does not end with +NN:MM timezone?
-                if re.search('\+\d{2}:\d{2}$', tm) is None:
-                    tm = "{}+00:00".format(tm)
                 log.info("{:.1f}s\t{}\t{} last-line TIMESTAMP : {}".format(time() - start, step, fn, tm)) 
                 tms.append(tm)
         else:
@@ -249,6 +243,9 @@ def get_program_latest_timestamp(
     # AR take the latest TIMESTAMP
     if len(tms) > 0:
         timestamp = np.sort(tms)[-1]
+        # AR does not end with +NN:MM timezone?
+        if re.search('\+\d{2}:\d{2}$', timestamp) is None:
+            timestamp = "{}+00:00".format(timestamp)
 
     log.info("{:.1f}s\t{}\tlatest timestamp : {}".format(time() - start, step, timestamp))
     return timestamp

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -160,6 +160,7 @@ def get_program_latest_timestamp(
             # AR does not end with +NN:MM timezone?
             if re.search('\+\d{2}:\d{2}$', tm) is None:
                 tm = "{}+00:00".format(tm)
+            log.info("{:.1f}s\t{}\tlatest TIMESTAMP from {}: {}".format(time() - start, step, fn, tm))
             tms.append(tm)
 
     # AR now checking the healpix pixels touching the tile

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -268,15 +268,19 @@ def read_ecsv_keys(fn):
 
     Returns:
         keys: list of the column names in fn (list)
+
+    Notes:
+        Gets the column names from the first line not starting with "#".
     """
     keys = []
     with open(fn) as f:
         for line in f:
-            if "#" not in line:
-                break
-            else:
-                if line[:10] == "# - {name:":
-                    keys.append(line.replace(":", ",").split(",")[1].strip())
+            if line[0] == "#":
+                continue
+            if len(line.strip()) == 0:
+                continue
+            keys = line.split()
+            break
     f.close()
     return keys
 

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -185,6 +185,28 @@ def mv_write_targets_out(infn, targdir, outfn, log=Logger.get(), step="", start=
         os.rmdir(os.path.join(*[targdir] + tmpdirs[: i + 1]))
 
 
+def read_ecsv_keys(fn):
+    """
+    Returns the column content of an .ecsv file.
+
+    Args:
+        fn: filename with an .ecsv format (string)
+
+    Returns:
+        keys: list of the column names in fn (list)
+    """
+    keys = []
+    with open(fn) as f:
+        for line in f:
+            if "#" not in line:
+                break
+            else:
+                if line[:10] == "# - {name:":
+                    keys.append(line.replace(":", ",").split(",")[1].strip())
+    f.close()
+    return keys
+
+
 def get_nowradec(ra, dec, pmra, pmdec, parallax, ref_year, pmtime_utc_str, scnd=False):
     """
     Apply proper motion correction

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -780,12 +780,13 @@ def get_ledger_paths(
                 time() - start, step, name, path,
             )
         )
-        if not os.path.exists(path):
-            log.warning(
-                "{:.1f}s\t{}\tdirectory for {}: {} does not exist".format(
-                    time() - start, step, name, path,
+        if path is not None:
+            if not os.path.exists(path):
+                log.warning(
+                    "{:.1f}s\t{}\tdirectory for {}: {} does not exist".format(
+                        time() - start, step, name, path,
+                    )
                 )
-            )
     #
     return mtl, scndmtl, too
 

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -116,6 +116,13 @@ def get_last_line(fn):
 
     Returns:
         last_line: (string)
+
+    Notes:
+        Fails if fn has one line only; we do not protect for that case,
+            as this function is intended to be used in get_program_latest_timestamp()
+            to read *ecsv ledgers, which will always have more than one line,
+            and we want the fastest function possible, to use in fiberassign on-the-fly.
+        Copied from https://stackoverflow.com/questions/46258499/how-to-read-the-last-line-of-a-file-in-python.
     """
     with open(fn, "rb") as f:
         f.seek(-2, os.SEEK_END)


### PR DESCRIPTION
This PR addresses https://github.com/desihub/fiberassign/issues/387.

Up to now, the default MTLTIME is set to the latest TIMESTAMP in `mtl-done-tiles.ecsv`.
This PR modifies the default MTLTIME to the latest of:
- latest TIMESTAMP in `mtl-done-tiles.ecsv`;
- latest TIMESTAMP in the primary+secondary ledgers touching the considered tile, along with the ToO ledger.

The core changes are in the `fba_launch_io.get_program_latest_timestamp()` function.

**Changes on the way**
We now remove the +1min in the "latest timestamp + 1min" MTLTIME defintion, with taking advantage of the desitarget.io.read_targets_in_tiles(..., leq=True,...) option enabled.
We also introduce few new utility functions in fba_launch_io.py:
- `get_last_line()`: quick way to get the last line of a text file (based on python f.seek approach);
- `read_ecsv_keys()`: obtain the keys from an .ecsv file (to get which column in the ledgers corresponds to TIMESTAMP);
- `get_ledger_paths()`: factoring out a part of the get_desitarget_paths() function, which returns the ledgers-relevant paths.

**Small Questions**
- should the `get_program_latest_timestamp()` function be renamed? as it now is relevant for a given tile
- in `get_program_latest_timestamp()`, I ve added a cut on TILEID for distinguishing SV3/Main when looking up `mtl-done-tiles.ecsv`; it should not change anything (as SV3 is done), but it looks cleaner to me; that could be removed.
