### PR TITLE
Set default RUNDATE to the latest TIME in the desi-state*.ecsv files

### DIFF
--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -13,6 +13,7 @@ from desiutil.redirect import stdouterr_redirected
 from fiberassign.fba_launch_io import (
     get_program_latest_timestamp,
     assert_env_vars,
+    get_latest_rundate,
     assert_svn_tileid,
     assert_arg_dates,
     print_config_infos,
@@ -69,6 +70,15 @@ def main():
     #
     start = time()
     log.info("{:.1f}s\tstart\tTIMESTAMP={}".format(time() - start, Time.now().isot))
+
+    # AR rundate: if None, set to the latest time
+    # AR    in the latest desi-state*ecsv file
+    if args.rundate is None:
+        log.info("")
+        log.info("")
+        log.info("{:.1f}s\trundate\tTIMESTAMP={}".format(time() - start, Time.now().isot))
+        args.rundate = get_latest_rundate(log=log, step="rundate", start=start)
+        log.info("{:.1f}s\trundate\tsetting args.rundate={}".format(time() - start, args.rundate))
 
     log.info("")
     log.info("")
@@ -648,10 +658,11 @@ if __name__ == "__main__":
     utc_time_now = datetime.now(tz=timezone.utc)
     utc_time_now_str = utc_time_now.isoformat(timespec="seconds")
     mjd_now = Time(utc_time_now).mjd
-    if args.rundate is None:
-        args.rundate = utc_time_now_str
     if args.pmtime_utc_str is None:
         args.pmtime_utc_str = utc_time_now_str
+
+    # AR rundate (2021-09-01): if set to None, now setting it inside main()
+    #          so that it is recorded in the fiberassign-TILEID.log file
 
     # AR mtltime
     # AR if possible: setting to the latest timestamp for the program

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -12,6 +12,7 @@ import sys
 import tempfile
 import shutil
 import re
+from glob import glob
 
 # time
 from time import time
@@ -41,6 +42,7 @@ from desitarget.geomask import match
 # desimodel
 import desimodel
 from desimodel.footprint import is_point_in_desi
+from desimodel.io import datadir
 
 # desimeter
 import desimeter
@@ -105,6 +107,37 @@ def get_svn_version(svn_dir):
         svn_ver = "unknown"
 
     return svn_ver
+
+
+def get_latest_rundate(log=Logger.get(), step="", start=time()):
+    """
+    Returns the latest TIME value of the latest desi-state_*ecsv file in $DESIMODEL.
+
+    Args:
+        log (optional, defaults to Logger.get()): Logger object
+        step (optional, defaults to ""): corresponding step, for fba_launch log recording
+            (e.g. dotiles, dosky, dogfa, domtl, doscnd, dotoo)
+        start(optional, defaults to time()): start time for log (in seconds; output of time.time()
+
+    Notes:
+        If not UTC-formatted, we add "+00:00".
+    """
+    # AR need DESIMODEL to be defined
+    if os.getenv("DESIMODEL") is None:
+        log.error("DESIMODEL environment variable is not defined; exiting")
+        sys.exit(1)
+    # AR take the latest desi-state_*ecsv file
+    fn = sorted(glob(os.path.join(datadir(), "focalplane", "desi-state_*ecsv")))[-1]
+    log.info("{:.1f}s\t{}\tusing {} to get the latest rundate".format(time() - start, step, fn))
+    d = Table.read(fn, include_names = ["TIME"])
+    # AR take the latest timestamp (should be the last line, but safe here)
+    rundate = np.unique(d["TIME"])[-1]
+    # AR if not UTC formatted, we add +00:00
+    if not assert_isoformat_utc(rundate):
+        rundate += "+00:00"
+    log.info("{:.1f}s\t{}\tlatest rundate: {}".format(time() - start, step, rundate))
+    return rundate
+
 
 
 def get_program_latest_timestamp(


### PR DESCRIPTION
This PR addresses https://github.com/desihub/fiberassign/issues/389.

We now set the default RUNDATE value to the latest TIME in the latest, on-disk desi-state_*.ecsv file, instead of using the time when the tile is designed.
