### PR TITLE
Add NOWTIME keyword in fiberassign-TILEID.fits.gz header

### DIFF
--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -326,6 +326,7 @@ def main():
             ebv,
             obscon,
             fascript,
+            nowtime=utc_time_now_str,
             log=log,
             step="fa",
             start=start,

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -15,7 +15,7 @@ import re
 
 # time
 from time import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 #
 import numpy as np
@@ -1490,6 +1490,7 @@ def update_fiberassign_header(
     ebv,
     obscon,
     fascript,
+    nowtime=datetime.now(tz=timezone.utc).isoformat(timespec="seconds"),
     log=Logger.get(),
     step="",
     start=time(),
@@ -1519,6 +1520,7 @@ def update_fiberassign_header(
         ebv: median EBV over the tile targets (float)
         obscon: tile allowed observing conditions (string; e.g. "DARK|GRAY|BRIGHT|BACKUP")
         fascript: fba_launch-like script used to designed the tile; in case of different scripts for dedicated tiles
+        nowtime (optional, defaults to datetime.now(tz=timezone.utc).isoformat(timespec="seconds")): time when the code is run (string)
         log (optional, defaults to Logger.get()): Logger object
         step (optional, defaults to ""): corresponding step, for fba_launch log recording
             (e.g. dotiles, dosky, dogfa, domtl, doscnd, dotoo)
@@ -1575,6 +1577,7 @@ def update_fiberassign_header(
     # AR some keywords
     fd["PRIMARY"].write_key("outdir", args.outdir)
     fd["PRIMARY"].write_key("survey", hdr_survey)  # AR not args.survey!
+    fd["PRIMARY"].write_key("nowtime", nowtime)
     fd["PRIMARY"].write_key("rundate", args.rundate)
     fd["PRIMARY"].write_key("pmcorr", args.pmcorr)
     fd["PRIMARY"].write_key("pmtime", args.pmtime_utc_str)


### PR DESCRIPTION
This PR addresses https://github.com/desihub/fiberassign/issues/391.

It simply adds a new keyword, NOWTIME, in the fiberassign-TILEID.fits.gz header.