### PR TITLE
MTLTIME argument in create_too()

### DIFF
--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -269,6 +269,7 @@ def main():
             args.gaiadr.replace("gaia", ""),
             args.pmcorr,
             mytmpouts["too"],
+            mtltime=args.mtltime,
             tmpoutdir=tmpoutdir,
             pmtime_utc_str=args.pmtime_utc_str,
             log=log,

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -1247,7 +1247,7 @@ def create_too(
     comments = ["in tiles"]
     # AR cutting on MJD
     keep &= (d["MJD_BEGIN"] < mjd_max) & (d["MJD_END"] > mjd_min)
-    comments.append("MJD_BEGIN<{} and MJD_END>{}".format(mjd_min, mjd_max))
+    comments.append("MJD_BEGIN<{} and MJD_END>{}".format(mjd_max, mjd_min))
     # AR case too_tile = False (i.e. not dedicated tile):
     if not too_tile:
         # AR cut on TOO_TYPE


### PR DESCRIPTION
This PR addresses https://github.com/desihub/fiberassign/issues/393.

It adds a mtltime argument to the `fba_launch_io.create_too()` function.

For potential backward-compatibility in the function calling sequence, we have made this argument optional, defaulting to None; that could be changed.
