### PR TITLE
ToO: MJD definition and cut

### DIFF
--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -108,6 +108,13 @@ def main():
     # AR safe: argument dates correctly formatted?
     assert_arg_dates(args, log=log, step="settings", start=start)
 
+    # AR mjd_now: setting to pmtime_utc_str if not set
+    # AR    see https://github.com/desihub/fiberassign/issues/395
+    # AR    (and we just assessed args.pmtime_utc_str has the correct formatting)
+    # AR    (instead of utc_time_now_str, to allow reproducibility)
+    # AR    (purposely not tying to rundate)
+    mjd_now = Time(datetime.strptime(args.pmtime_utc_str, "%Y-%m-%dT%H:%M:%S%z")).mjd
+
     # AR print general configuration informations
     print_config_infos(log=log, step="settings", start=start)
 
@@ -647,7 +654,6 @@ if __name__ == "__main__":
     # AR utc_time_now, rundate, pmtime
     utc_time_now = datetime.now(tz=timezone.utc)
     utc_time_now_str = utc_time_now.isoformat(timespec="seconds")
-    mjd_now = Time(utc_time_now).mjd
     if args.rundate is None:
         args.rundate = utc_time_now_str
     if args.pmtime_utc_str is None:

--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -265,13 +265,14 @@ def main():
 
 
     # AR ToO targets
-    # AR TBD: handling to MJD window boundaries as script argument?
+    # AR 20210902: setting mjd_min = mjd_max = mjd_now
+    # AR        so that we select: (d["MJD_BEGIN"] < mjd_now) & (d["MJD_END"] > mjd_now)
     if "too" in steps:
         expected_files["too"] = create_too(
             mytmpouts["tiles"],
             mydirs["too"],
-            mjd_now - 1,
-            mjd_now + 30,
+            mjd_now,
+            mjd_now,
             args.survey,
             args.gaiadr.replace("gaia", ""),
             args.pmcorr,

--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -114,6 +114,11 @@ def main():
     # AR    (instead of utc_time_now_str, to allow reproducibility)
     # AR    (purposely not tying to rundate)
     mjd_now = Time(datetime.strptime(args.pmtime_utc_str, "%Y-%m-%dT%H:%M:%S%z")).mjd
+    log.info(
+        "{:.1f}s\tsettings\tsetting mjd_now={}, corresponding to args.pmtime_utc_str={}".format(
+            time() - start, mjd_now, args.pmtime_utc_str
+        )
+    )
 
     # AR print general configuration informations
     print_config_infos(log=log, step="settings", start=start)


### PR DESCRIPTION
This PR addresses https://github.com/desihub/fiberassign/issues/395.

Previously:
- the `mjd_now` was defined as `datetime.now()`, i.e. when the fiberassign code is run to design the tile, causing a non-reproducibility issue for re-run of a tile;
- up to 2020 pre-shutdown (SV3, Main), the tiles were designed ahead of observations; hence we were defining a MJD window with  `mjd_min=mjd_now-1`, `mjd_max=mjd_now+30`, and selecting ToO targets with: `keep &= (d["MJD_BEGIN"] < mjd_max) & (d["MJD_END"] > mjd_min)`; with now moving to fiberassign on-the-fly, this -1, +30 is unnecessary.

We now use:
- `mjd_now = args.pmtime_utc_str`, i.e. the time used for proper-motion correction, solving the non-reproducibility issue;
- `mjd_min = mjd_max = mjd_now` in the call to `create_too()` in fba_launch, acting similarly to select ToO targets with: `keep &= (d["MJD_BEGIN"] < mjd_now) & (d["MJD_END"] > mjd_now)`, which the desired behavior for fiberassign on-the-fly.