### PR TITLE
Fix duplicate negative TARGETID for stuck positioners

### DIFF
--- a/py/fiberassign/assign.py
+++ b/py/fiberassign/assign.py
@@ -307,7 +307,7 @@ def write_assignment_fits_tile(asgn, tagalong, fulltarget, overwrite, params):
 
         # For unassigned fibers, we give each location a unique negative
         # number based on the tile and loc.
-        unassign_offset = tile_id * nloc
+        unassign_offset = tile_id * 10000
         assigned_tgids = np.array([tdata[x] if x in tdata.keys()
                                   else -(unassign_offset + x)
                                   for x in locs], dtype=np.int64)


### PR DESCRIPTION
Change the fake negative TARGETID for stuck positioners to -(TILEID*10000 + loc) from -(TILEID*nloc + loc) to address
https://github.com/desihub/fiberassign/issues/385

The issue is that currently LOCATION is not dense, so nloc < max(location).  But max(location) is always less than 10000, so we just hard code this and forget about it.  It's also convenient in that it's easy for a human to read off the LOCATION and TILEID corresponding to each stuck sky TARGETID.