### PR TITLE
fba_cmx: remove GFAs when calling run_merge()

### DIFF
--- a/bin/fba_cmx
+++ b/bin/fba_cmx
@@ -831,7 +831,6 @@ def main():
                 "--sky",
                 root + "-sky.fits",
                 "--targets",
-                root + "-gfa.fits",
             ]
             if args.faflavor in ["scidark", "scibright"]:
                 opts += [


### PR DESCRIPTION
This PR addresses https://github.com/desihub/fiberassign/issues/399.

with this change, @forero failure command now works:
`fba_cmx --dr=dr9 --dtver=0.49.0 --seed=77 --faflavor=dithlost --outdir=./ --tilera=343.0 --tiledec=30.0 --tileid=89000`

It would be great if @dstndstn could have a look, and confirm it is the correct fix.