### PR TITLE
Get SVN revision number in more compatible way

### DIFF
--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -102,11 +102,17 @@ def get_svn_version(svn_dir):
     Notes:
         `svn_dir` can contain environment variables to expand, e.g. "$DESIMODEL/data"
     """
-    cmd = ["svn", "info", "--show-item", "revision", os.path.expandvars(svn_dir)]
+    cmd = ["svn", "info", os.path.expandvars(svn_dir)]
     try:
         svn_ver = (
             subprocess.check_output(cmd, stderr=subprocess.DEVNULL).strip().decode()
         )
+        # search for "Revision: " line and parse out revision number.  Recent versions
+        # of svn have a --show-item argument that does this in a less fragile way,
+        # but the svn installed at KPNO is old and doesn't support this option.
+        searchstr = 'Revision: '
+        svn_ver = [line[len(searchstr):] for line in svn_ver.split('\n')
+                   if searchstr in line][0]
     except subprocess.CalledProcessError:
         svn_ver = "unknown"
 


### PR DESCRIPTION
fba_launch_io grabs SVN revision numbers from key repositories so we track what versions of things we are using.  It does this via
svn info --show-item revision
which unfortunately is not available on the desi machines at kpno.  This PR changes the logic to do more cumbersome parsing of svn info to find the revision number.