### PR TITLE
Fbarerun bugfix

### DIFF
--- a/bin/fba_rerun
+++ b/bin/fba_rerun
@@ -95,7 +95,7 @@ def main():
         # AR before 5.0.0, some arguments accepted with hyphen only, no underscore
         # AR    though hyphens have been automatically converted to underscores
         # AR    in the faargs...
-        if (fiberassign.__version__ < "5.0.0") & (
+        elif (fiberassign.__version__ < "5.0.0") & (
             key in ["--log_stdout", "--margin_gfa", "--margin_petal", "--margin_pos"]
         ):
             mydict[key.replace("_", "-")] = val

--- a/bin/fba_rerun
+++ b/bin/fba_rerun
@@ -89,7 +89,8 @@ def main():
                 mydict[key] = ""
 
         # AR doclean/steps/nosteps: we skip (if present), as we already set mydict["--steps"]
-        elif key in ["--doclean", "--steps", "--nosteps"]:
+        # AR svntiledir: we skip (if present), as we do not want to touch the SVN for reruns
+        elif key in ["--doclean", "--steps", "--nosteps",  "--svntiledir"]:
             continue
 
         # AR before 5.0.0, some arguments accepted with hyphen only, no underscore


### PR DESCRIPTION
This PR has two small modifications to bin/fba_rerun:
- fix a bug (discovered when --worldreadable is turned on in the original fiberassign file);
- disable any provided --svntiledir from the original fiberassign file, as we do not want to copy rerun files to svn.