### PR TITLE
get_svn_version(): now grab 'Last Changed Rev'

### DIFF
--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -107,10 +107,10 @@ def get_svn_version(svn_dir):
         svn_ver = (
             subprocess.check_output(cmd, stderr=subprocess.DEVNULL).strip().decode()
         )
-        # search for "Revision: " line and parse out revision number.  Recent versions
+        # search for "Last Changed Rev: " line and parse out revision number.  Recent versions
         # of svn have a --show-item argument that does this in a less fragile way,
         # but the svn installed at KPNO is old and doesn't support this option.
-        searchstr = 'Revision: '
+        searchstr = 'Last Changed Rev: '
         svn_ver = [line[len(searchstr):] for line in svn_ver.split('\n')
                    if searchstr in line][0]
     except subprocess.CalledProcessError:


### PR DESCRIPTION
To record the SVN revision number from $DESIMODEL/data and $DESI_SURVEYOPS/mtl, we currently record the "Revision:" quantity from the call to "svn info svn_dir".
However, what we want is the *latest* revision number, i.e. "Last Changed Rev:".

This PR addresses that.

Here an example from NERSC:
```
[schlafly@cori06 data]$ svn info
Path: .
Working Copy Root Path: /global/common/software/desi/cori/desiconda/20200801-1.4.0-spec/code/desimodel/master/data
URL: https://desi.lbl.gov/svn/code/desimodel/trunk/data
Relative URL: ^/desimodel/trunk/data
Repository Root: https://desi.lbl.gov/svn/code
Repository UUID: 10003831-d790-44f6-a3bc-8e9ec13a4ac3
Revision: 137569
Node Kind: directory
Schedule: normal
Last Changed Author: jguy
Last Changed Rev: 136884
Last Changed Date: 2021-07-12 13:10:10 -0700 (Mon, 12 Jul 2021)

```