### PR TITLE
allow several folders for inflating ledgers

### DIFF
--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -280,11 +280,15 @@ def main():
     # AR if not backup
     if ("scnd" in steps):
         if ("scnd" in list(mydirs.keys())):
+            targdirs = [mydirs["scnd"]]
+            for key in sorted(list(mydirs.keys())):
+                if (key[:4] == "scnd") & (key != "scnd") & (key != "scndmtl"):
+                    targdirs.append(mydirs[key])
             create_mtl(
                 mytmpouts["tiles"],
                 mydirs["scndmtl"],
                 args.mtltime,
-                mydirs["scnd"],
+                targdirs,
                 args.survey,
                 args.gaiadr.replace("gaia", ""),
                 args.pmcorr,

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -905,8 +905,9 @@ def get_desitarget_paths(
         - gfa: GFA folder
         - targ: targets folder (static catalogs, with all columns)
         - mtl: MTL folder
-        - scnd: secondary fits catalog (static)
+        - scnd: secondary fits catalog (static, with all columns)
         - scndmtl: MTL folder for secondary targets
+        - scnd2, scnd3, etc: any other existing secondary fits catalog (static, with all columns)
         - too: ToO ecsv catalog
 
     Notes:
@@ -974,7 +975,7 @@ def get_desitarget_paths(
             basename,
         )
         # AR check possible extra folders, like main2/, main3/, etc
-        # AR and store the file path in keys like SCND2, SCND3, etc
+        # AR and store the file path in keys like scnd2, scnd3, etc
         # AR note: the index in the key name is not related to the extra folder name,
         # AR        it is just the order of appearance
         extradirs = sorted(
@@ -1141,7 +1142,7 @@ def create_sky(
         skydirs.append(suppskydir)
     ds = [read_targets_in_tiles(skydir, tiles=tiles, quick=True) for skydir in skydirs]
     for skydir, d in zip(skydirs, ds):
-        log.info("{:.1f}s\t{}\treadin {} targets from {}".format(time() - start, step, len(d), skydir))
+        log.info("{:.1f}s\t{}\treading {} targets from {}".format(time() - start, step, len(d), skydir))
     d = np.concatenate(ds)
 
     # AR adding PLATE_RA, PLATE_DEC?
@@ -1309,7 +1310,7 @@ def create_mtl(
         tilesfn: path to a tiles fits file (string)
         mtldir: desisurveyops MTL folder (string)
         mtltime: MTL isodate (string formatted as yyyy-mm-ddThh:mm:ss+00:00)
-        targdirs: desitarget targets folder (or file name(s) if secondary) (string or list)
+        targdirs: desitarget targets folder (or file name(s) if secondary) for static fits catalog(s) (string or list)
         survey: survey (string; e.g. "sv1", "sv2", "sv3", "main")
         gaiadr: Gaia dr ("dr2" or "edr3")
         pmcorr: apply proper-motion correction? ("y" or "n")
@@ -1441,6 +1442,9 @@ def create_mtl(
             nside, nest = pixarea2nside(7.), True
             pixlist = tiles2pix(nside, tiles=tiles)
             # AR mtl: loop on targdirs
+            # AR mtl: note: this coding *should* work if ii or jj is empty for a targdir
+            # AR mtl:       (even if that case should not happen, as current secondary
+            # AR mtl:       targets cover the full DESI footprint)
             targs = []
             for targdir in targdirs:
                 radec = fitsio.read(targdir, columns=["RA", "DEC"])


### PR DESCRIPTION
This PR prepares for the soon-to-come addition of extra secondary targets files, as:
`$DESI_TARGET/catalogs/{dr}/{dtver}/targets/{extradir}/secondary/{program}/{extradir}targets-{program}-secondary.fits` (with extradir!={survey})
See related PR https://github.com/desihub/desitarget/pull/764.
Catalogs with extradir=main2 are expected to be created soon, but this PR should handle any other name *starting with main* (e.g. main3).

In fba_launch_io.py, those files are only used to add flux columns to the secondary catalogs read from the ledgers (which will contain *all* secondary targets, from main/, main2/, etc).

**New steps:**
The fba_launch_io.get_desitarget_paths() function records the extra existing secondary catalogs, proceeding as follow:
- first look for folders named `$DESI_TARGET/catalogs/{dr}/{dtver}/targets/{survey}*`, other than `$DESI_TARGET/catalogs/{dr}/{dtver}/targets/{survey}`;
- then, for each found extra folder {extradir} look for an extra catalog `$DESI_TARGET/catalogs/{dr}/{dtver}/targets/{extradir}/secondary/{program}/{extradir}targets-{program}-secondary.fits`;
- store each of those extra catalogs in a "scnd2", "scnd3", ... key (sorted by extradir names)

Then in fba_launch_io.create_mtl() for the secondary targets case, the "regular" secondary catalog, along with any recorded extra catalog, will be used to get the flux column information missing from the ledgers.

Lastly, fba_launch_io.update_fiberassign_header() records in the header any found SCND2, SCND3, ... extra catalog.


**Example of use:**
With test catalogs with main/ and  main2/ secondary catalogs:
```
export DESI_TARGET=/global/cscratch1/sd/adamyers/desi/target
export DESI_SURVEYOPS=/global/cscratch1/sd/adamyers/test-new-mtl-adds
fba_launch --tileid 999999 --tilera 0 --tiledec 0 --survey main --program DARK --dtver 1.1.1 --outdir ./
```

This change is backward-compatible, for instance (currently there only is a main/ secondary catalog):
```
export DESI_TARGET=$DESI_ROOT/target
export DESI_SURVEYOPS=$DESI_ROOT/survey/ops/surveyops/trunk
fba_launch --tileid 999999 --tilera 0 --tiledec 0 --survey main --program DARK --dtver 1.1.1 --outdir ./
```

**Technical python remark:**
I came up with: `targ = Table(fitsio.read(targdir, columns = columns + ["TARGETID"], rows=rows))`, because:
- I want the fast reading of fitsio with only few columns and some specific rows;
- I want to stack those with astropy.table.vstack.
I m happy to implement any more elegant suggestion.

