### PR TITLE
Populate EBV=0 rows in FIBERASSIGN with correct values

### DIFF
--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -625,6 +625,7 @@ def assert_env_vars(
         "DESIMODEL",
         "DESI_SURVEYOPS",
         "SKYBRICKS_DIR",
+        "DUST_DIR",
     ],
     log=Logger.get(),
     step="settings",
@@ -638,14 +639,16 @@ def assert_env_vars(
         "DESI_TARGET",
         "DESIMODEL",
         "DESI_SURVEYOPS",
-        "SKYBRICKS_DIR",]): list of environment variables required by fba_launch
+        "SKYBRICKS_DIR",
+        "DUST_DIR",]): list of environment variables required by fba_launch
         log (optional, defaults to Logger.get()): Logger object
         step (optional, defaults to ""): corresponding step, for fba_launch log recording
             (e.g. dotiles, dosky, dogfa, domtl, doscnd, dotoo)
         start(optional, defaults to time()): start time for log (in seconds; output of time.time()
 
     Notes:
-        will exit with error if some assertions are not verified
+        Will exit with error if some assertions are not verified.
+        20210928 : add DUST_DIR, as assign.merge_results_tile() requires it to populate EBV=0 values.
     """
     # AR safe: DESI environment variables
     for required_env_var in required_env_vars:
@@ -746,6 +749,7 @@ def print_config_infos(
         "DESIMODEL",
         "DESI_SURVEYOPS",
         "SKYBRICKS_DIR",
+        "DUST_DIR",
     ],
     log=Logger.get(),
     step="settings",
@@ -759,11 +763,15 @@ def print_config_infos(
         "DESI_TARGET",
         "DESIMODEL",
         "DESI_SURVEYOPS",
-        "SKYBRICKS_DIR",]): list of environment variables required by fba_launch
+        "SKYBRICKS_DIR",
+        "DUST_DIR",]): list of environment variables required by fba_launch
         log (optional, defaults to Logger.get()): Logger object
         step (optional, defaults to ""): corresponding step, for fba_launch log recording
             (e.g. dotiles, dosky, dogfa, domtl, doscnd, dotoo)
         start(optional, defaults to time()): start time for log (in seconds; output of time.time()
+
+    Notes:
+        20210928 : add DUST_DIR, as assign.merge_results_tile() requires it to populate EBV=0 values.
     """
     # AR machine
     log.info(


### PR DESCRIPTION
This PR addresses https://github.com/desihub/fiberassign/issues/413.
Currently, `EBV=0` in the FIBERASSIGN extension of `fiberassign-TILEID.fits.gz` files for: sky fibers, stand-alone secondary fibers ToO fibers, unassigned fibers.
This complicates the downstream analysis.
Typically, there will be ~800 fibers with `EBV=0` (~700 skys+unassigned, ~100 secondaries); though could be more for tiles with more passes, as more secondaries will be assigned.

We now populate in `assign.merge_results_tile()` the `EBV=0` rows with correct values.
This queries the EBV maps in `$DUST_DIR`.
I ve thus also added `$DUST_DIR` in the list of environmental variables to be defined.

On the NERSC logging node, this takes ~1s.
@schlafly: could you test that at KPNO? hoping that `$DUST_DIR` is already defined, and that the dust maps are there.

Lastly: this adds an astropy dependence in assign.py, I don t know if that matters...