### PR TITLE
Skyhealpixs gaia

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       DESIMETER_VERSION: 0.6.5
       DESIMODEL_DATA: trunk
       DESIMODEL: ${{ github.workspace }}/desimodel
-      DESITARGET_VERSION: 1.0.0
+      DESITARGET_VERSION: 2.2.1
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.8.0

--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -760,7 +760,7 @@ if __name__ == "__main__":
 
     # AR lookup_sky_source
     if args.lookup_sky_source is None:
-        if (args.survey == "main") & (args.program == "backup"):
+        if (args.survey == "main") & (args.program == "BACKUP"):
             args.lookup_sky_source = "gaia"
             if os.getenv("SKYHEALPIXS_DIR") is None:
                 log.warning("SKYHEALPIXS_DIR not set: stuck positioners will not be used for skies.")

--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -684,6 +684,13 @@ if __name__ == "__main__":
         action='store_true',
         default=False,
     )
+    parser.add_argument(
+        "--lookup_sky_source",
+        help="'ls' or 'gaia' (default='gaia' if main/backup, 'ls' otherwise)",
+        type=str,
+        choices=["ls", "gaia"],
+        default=None,
+    )
 
     args = parser.parse_args()
     log = Logger.get()
@@ -750,6 +757,17 @@ if __name__ == "__main__":
                 )
             )
             sys.exit(1)
+
+    # AR lookup_sky_source
+    if args.lookup_sky_source is None:
+        if (args.survey == "main") & (args.program == "backup"):
+            args.lookup_sky_source = "gaia"
+            if os.getenv("SKYHEALPIXS_DIR") is None:
+                log.warning("SKYHEALPIXS_DIR not set: stuck positioners will not be used for skies.")
+        else:
+            args.lookup_sky_source = "ls"
+            if os.getenv("SKYBRICKS_DIR") is None:
+                log.warning("SKYBRICKS_DIR not set: stuck positioners will not be used for skies.")
 
     # AR create a temporary directory for generated files
     tmpoutdir = tempfile.mkdtemp()

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,6 +6,8 @@ fiberassign change log
 5.3.1 (unreleased)
 ------------------
 
+This version now requires desitarget >= 2.2.1
+
 5.3.0 (2021-09-20)
 ------------------
 

--- a/py/fiberassign/assign.py
+++ b/py/fiberassign/assign.py
@@ -299,12 +299,14 @@ def write_assignment_fits_tile(asgn, tagalong, fulltarget, overwrite, params):
 
         #- Keep SKYBRICKS_DIR used to lookup sky locations,
         #- shortening full path if possible
-        skybricks = os.getenv('SKYBRICKS_DIR', None)
-        if (skybricks is not None) and ('DESI_ROOT' in os.environ):
-            if skybricks.startswith(os.environ['DESI_ROOT']):
-                skybricks = skybricks.replace(
-                        os.environ['DESI_ROOT'], '$DESI_ROOT', 1)
-        setdep(header, 'SKYBRICKS_DIR', skybricks)
+        # AR add SKYHEALPIX_DIR similarly, now looping over the variable names
+        for skyname in ["SKYBRICKS_DIR", "SKYHEALPIXS_DIR"]:
+            skydir = os.getenv(skyname, None)
+            if (skydir is not None) and ("DESI_ROOT" in os.environ):
+                if skydir.startswith(os.environ["DESI_ROOT"]):
+                    skydir = skydir.replace(
+                            os.environ["DESI_ROOT"], "$DESI_ROOT", 1)
+            setdep(header, skyname, skydir)
 
         fd.write(None, header=header, extname="PRIMARY")
 

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -1990,6 +1990,7 @@ def update_fiberassign_header(
         faflavor has to be {hdr_survey}{hdr_faprgrm}; will exit with an error if not;
             keeping this to be sure it is not forgotten to be done for dedicated programs.
         20210917 : keywords scnd2, scnd3, etc could be automatically added (see get_desitarget_paths())
+        20211119 : added lookup_sky_source keyword
     """
     # AR sanity check on faflavor
     if faflavor != "{}{}".format(hdr_survey, hdr_faprgrm):
@@ -2059,6 +2060,8 @@ def update_fiberassign_header(
     fd["PRIMARY"].write_key(
         "svnmtl", get_svn_version(os.path.join(os.getenv("DESI_SURVEYOPS"), "mtl"))
     )
+    # AR lookup_sky_source
+    fd["PRIMARY"].write_key("LKSKYSRC", args.lookup_sky_source)
     fd.close()
 
 

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -1806,6 +1806,7 @@ def launch_onetile_fa(
             requires a change in the launch_fa() call format.
         fba_launch-like adding information in the header is done in another function, update_fiberassign_header
         TBD: be careful if working in the SVN-directory; maybe add additional safety lines?
+        20211119 : added lookup_sky_source
     """
     log.info("")
     log.info("")

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -1787,6 +1787,7 @@ def launch_onetile_fa(
                 - sky_per_petal
                 - standards_per_petal
                 - sky_per_slitblock
+                - lookup_sky_source
         tilesfn: path to the input tiles fits file (string)
         targfns: paths to the input targets fits files, e.g. targ, scnd, too (either a string if only one file, or a list of strings)
         fbafn: path to the output fba-TILEID.fits file (string)
@@ -1796,7 +1797,7 @@ def launch_onetile_fa(
         log (optional, defaults to Logger.get()): Logger object
         step (optional, defaults to ""): corresponding step, for fba_launch log recording
             (e.g. dotiles, dosky, dogfa, domtl, doscnd, dotoo)
-        start(optional, defaults to time()): start time for log (in seconds; output of time.time()
+        start (optional, defaults to time()): start time for log (in seconds; output of time.time()
 
     Notes:
         no sanity checks done on inputs; assumed to be done elsewhere
@@ -1830,14 +1831,6 @@ def launch_onetile_fa(
         os.remove(fbafn)
     if os.path.isfile(fiberassignfn):
         os.remove(fiberassignfn)
-
-    # AR look-up table for stuck skies
-    # AR note: SV3 did use "ls" for backup, however SV3 used fiberassign.__version__ < 5.0.0
-    # AR        so need to handle SV3 here
-    if args.program == "BACKUP":
-        lookup_sky_source = "gaia"
-    else:
-        lookup_sky_source = "ls"
 
     # AR preparing fba_run inputs
     opts = [
@@ -1883,7 +1876,7 @@ def launch_onetile_fa(
             "--gfafile",
             gfafn,
         ]
-    opts += ["--lookup_sky_source", lookup_sky_source,]
+    opts += ["--lookup_sky_source", args.lookup_sky_source,]
     log.info(
         "{:.1f}s\t{}\ttileid={:06d}: running raw fiber assignment (run_assign_full) with opts={}".format(
             time() - start, step, tileid, " ; ".join(opts)

--- a/py/fiberassign/scripts/assign.py
+++ b/py/fiberassign/scripts/assign.py
@@ -187,7 +187,7 @@ def parse_assign(optlist=None):
                         help="Disable oversubscription of science targets with leftover fibers.")
 
     parser.add_argument("--lookup_sky_source", required=False, default="ls",
-                        choices={"ls", "gaia"},
+                        choices=["ls", "gaia"],
                         help="Source for the look-up table for sky positions for stuck fibers:"
                         " 'ls': uses $SKYBRICKS_DIR; 'gaia': uses $SKYHEALPIXS_DIR (default=ls)")
 

--- a/py/fiberassign/scripts/assign.py
+++ b/py/fiberassign/scripts/assign.py
@@ -186,6 +186,11 @@ def parse_assign(optlist=None):
                         action="store_true",
                         help="Disable oversubscription of science targets with leftover fibers.")
 
+    parser.add_argument("--lookup_sky_source", required=False, default="ls",
+                        choices={"ls", "gaia"},
+                        help="Source for the look-up table for sky positions for stuck fibers:"
+                        " 'ls': uses $SKYBRICKS_DIR; 'gaia': uses $SKYHEALPIXS_DIR (default=ls)")
+
     args = None
     if optlist is None:
         args = parser.parse_args()
@@ -380,7 +385,7 @@ def run_assign_full(args, plate_radec=True):
     # Find stuck positioners and compute whether they will land on acceptable
     # sky locations for each tile.
     gt.start("Compute Stuck locations on good sky")
-    stucksky = stuck_on_sky(hw, tiles)
+    stucksky = stuck_on_sky(hw, tiles, args.lookup_sky_source)
     if stucksky is None:
         # (the pybind code doesn't like None when a dict is expected...)
         stucksky = {}
@@ -468,7 +473,7 @@ def run_assign_bytile(args):
     # Find stuck positioners and compute whether they will land on acceptable
     # sky locations for each tile.
     gt.start("Compute Stuck locations on good sky")
-    stucksky = stuck_on_sky(hw, tiles)
+    stucksky = stuck_on_sky(hw, tiles, args.lookup_sky_source)
     if stucksky is None:
         # (the pybind code doesn't like None when a dict is expected...)
         stucksky = {}

--- a/py/fiberassign/test/test_assign.py
+++ b/py/fiberassign/test/test_assign.py
@@ -349,9 +349,10 @@ class TestAssign(unittest.TestCase):
         favail = LocationsAvailable(tgsavail)
 
         # Pass empty map of STUCK positioners that land on good sky
+        # AR 20211123 : picks lookup_sky_source = "ls" for the test
         stucksky = None
         if do_stucksky:
-            stucksky = stuck_on_sky(hw, tiles)
+            stucksky = stuck_on_sky(hw, tiles, "ls")
         if stucksky is None:
             # (the pybind code doesn't like None when a dict is expected...)
             stucksky = {}


### PR DESCRIPTION
This PR enables the reading of Gaia-based good sky positions for stuck positioners for the Main BACKUP program.
It is dependent on the twin desitarget PR https://github.com/desihub/desitarget/pull/771.

The chosen approach assumes new maps will be stored in `$SKYHEALPIXS_DIR`.
I expect this environment variable to be defined as `$DESI_ROOT/target/skyhealpixs/v1`.

I have defined a new args.sky_lookup_source argument in both `fiberassign.bin.fba_launch` and `fiberassign.scripts.assign.parse_assign()`.
Allowed values are "ls" and "gaia" and default values are:
- in `fba_launch` : "gaia" if survey=="main" and program=="BACKUP", else "ls".
- in `parse_assign()`: "ls".
That should allow backwards-compatibility.

Then `fiberassign.stucksky.py` will use this argument:
- if sky_lookup_source == "ls", it will read maps in $SKYBRICKS_DIR
- if sky_lookup_source == "gaia", it will read maps in $SKYHEALPIXS_DIR

@sbailey : for the spectroscopic pipeline to know what has been used:
I ve added in the 0-th extension header of fiberassign-TILEID.fits.gz:
- `SKYHEALPIXS_DIR` in the dependences, recording where the Gaia maps are
- a `LKSKYSRC` keyword, which is the args.sky_lookup_source argument:
   - if `LKSKYSRC=="ls"`, then one should use  `$SKYBRICKS_DIR`,
   - if `LKSKYSRC=="gaia"`, then one should use  `$SKYHEALPIXS_DIR`.

Preliminary tests with temporary:
- maps in `/global/cfs/cdirs/desi/users/koposov/sky_mask/gaia_data`
- catalogs in `/global/cscratch1/sd/adamyers/gaiadr2/1.3.0.dev5218/targets/main/resolve/backup/`
work.
But those are limited, as they require hacks in the code.
Once the desitarget backup catalogs + ledgers will be in place, I could proceed to more exhaustive tests.
