### PR TITLE
Gaia std

### DIFF
--- a/bin/qa-fiberassign
+++ b/bin/qa-fiberassign
@@ -81,15 +81,16 @@ for filename in args.tilefiles:
     stdmask = None
     skymask = None
     excludemask = None
+    gaia_stdmask = None
     col=None
     if survey is not None:
             
-        sciencemask, stdmask, skymask, suppskymask, safemask, excludemask = \
+        sciencemask, stdmask, skymask, suppskymask, safemask, excludemask, gaia_stdmask = \
                 default_survey_target_masks(survey)
   
     else:
         fsurvey, col, sciencemask, stdmask, skymask, suppskymask, safemask, \
-                excludemask = default_target_masks(fbtargets)
+                excludemask, gaia_stdmask = default_target_masks(fbtargets)
         survey = fsurvey
 
 

--- a/py/fiberassign/assign.py
+++ b/py/fiberassign/assign.py
@@ -829,26 +829,32 @@ def read_assignment_fits_tile(tile_file):
 
         fsciencemask = None
         fstdmask = None
+        fgaia_stdmask = None
         fskymask = None
         fsuppskymask = None
         fexcludemask = None
         fcol = None
         if survey is not None:
             fsciencemask, fstdmask, fskymask, fsuppskymask, fsafemask, \
-                fexcludemask = default_survey_target_masks(survey)
+                fexcludemask, fgaia_stdmask = default_survey_target_masks(survey)
             fcol = "FA_TARGET"
         else:
             fsurvey, fcol, fsciencemask, fstdmask, fskymask, \
                 fsuppskymask, fsafemask, \
-                fexcludemask = default_target_masks(fbtargets)
+                fexcludemask, fgaia_stdmask = default_target_masks(fbtargets)
             survey = fsurvey
 
         for col in full_names:
             if col == "FA_TYPE":
+                # AR protect case where *MWS_TARGET does not exist
+                mws_targets = 0 * fbtargets[fcol][:]
+                if fcol.replace("DESI", "MWS") in fbtargets.dtype.names:
+                    mws_targets = fbtargets[fcol.replace("DESI", "MWS")][:]
                 targets_data[col][:nrawtarget] = [
-                    desi_target_type(x, fsciencemask, fstdmask, fskymask,
-                                     fsuppskymask, fsafemask, fexcludemask)
-                    for x in fbtargets[fcol][:]]
+                    desi_target_type(x, y, fsciencemask, fstdmask, fskymask,
+                                     fsuppskymask, fsafemask, fexcludemask,
+                                     fgaia_stdmask)
+                    for x, y in zip(fbtargets[fcol][:], mws_targets)]
             elif col == "FA_TARGET":
                 targets_data[col][:nrawtarget] = fbtargets[fcol]
             elif col == "TARGET_RA":

--- a/py/fiberassign/qa.py
+++ b/py/fiberassign/qa.py
@@ -22,7 +22,7 @@ from collections import OrderedDict
 
 import fitsio
 
-from desitarget.targetmask import desi_mask
+from desitarget.targetmask import desi_mask, mws_mask
 
 from .utils import Logger, default_mp_proc
 
@@ -31,6 +31,7 @@ from .targets import (
     load_target_table,
     default_main_sciencemask,
     default_main_stdmask,
+    default_main_gaia_stdmask,
     default_main_skymask,
     default_main_suppskymask,
     default_main_safemask,
@@ -76,9 +77,12 @@ def qa_parse_table(header, tgdata):
     stdfaintmask = int(desi_mask["STD_FAINT"].mask)
     stdwdmask = int(desi_mask["STD_WD"].mask)
     stdbrtmask = int(desi_mask["STD_BRIGHT"].mask)
+    gaiastdfaintmask = int(mws_mask["GAIA_STD_FAINT"].mask)
+    gaiastdbrtmask = int(mws_mask["GAIA_STD_BRIGHT"].mask)
 
     sciencemask = 0
     stdmask = 0
+    gaiastdmask = 0
     skymask = 0
     suppskymask = 0
     safemask = 0
@@ -87,6 +91,7 @@ def qa_parse_table(header, tgdata):
     if survey == "main":
         sciencemask = int(default_main_sciencemask())
         stdmask = int(default_main_stdmask())
+        gaiastdmask = int(default_main_gaia_stdmask())
         skymask = int(default_main_skymask())
         suppskymask = int(default_main_suppskymask())
         safemask = int(default_main_safemask())
@@ -131,6 +136,16 @@ def qa_parse_table(header, tgdata):
                 tgprops[tgid]["type"] = "STD_WD"
             elif dt & stdbrtmask:
                 tgprops[tgid]["type"] = "STD_BRIGHT"
+            else:
+                tgprops[tgid]["type"] = "NA"
+        elif dt & gaiastdmask:
+            tgprops[tgid]["class"] = "gaia-standard"
+            if dt & sciencemask:
+                tgprops[tgid]["class"] = "science-standard"
+            if dt & gaiastdfaintmask:
+                tgprops[tgid]["type"] = "GAIA_STD_FAINT"
+            elif dt & gaiastdbrtmask:
+                tgprops[tgid]["type"] = "GAIA_STD_BRIGHT"
             else:
                 tgprops[tgid]["type"] = "NA"
         elif dt & sciencemask:

--- a/py/fiberassign/scripts/assign.py
+++ b/py/fiberassign/scripts/assign.py
@@ -159,6 +159,11 @@ def parse_assign(optlist=None):
                         help="Default DESI_TARGET mask to use for stdstar "
                              "targets")
 
+    parser.add_argument("--gaia_stdmask", required=False,
+                        default=None,
+                        help="Default MWS_TARGET mask to use for Gaia stdstar "
+                             "targets (for BACKUP program)")
+
     parser.add_argument("--skymask", required=False,
                         default=None,
                         help="Default DESI_TARGET mask to use for sky targets")
@@ -199,6 +204,7 @@ def parse_assign(optlist=None):
     # the first target file to know which bitmask to use
     if isinstance(args.sciencemask, str) or \
        isinstance(args.stdmask, str) or \
+       isinstance(args.gaia_stdmask, str) or \
        isinstance(args.skymask, str) or \
        isinstance(args.safemask, str) or \
        isinstance(args.excludemask, str):
@@ -207,6 +213,7 @@ def parse_assign(optlist=None):
         data = fitsio.read(args.targets[0], 1, rows=[0,1])
         filecols, filemasks, filesurvey = main_cmx_or_sv(data)
         desi_mask = filemasks[0]
+        mws_mask = filemasks[2]
 
         # convert str bit names -> int bit mask
         if isinstance(args.sciencemask, str):
@@ -220,6 +227,12 @@ def parse_assign(optlist=None):
                 args.stdmask = int(args.stdmask)
             except ValueError:
                 args.stdmask = desi_mask.mask(args.stdmask.replace(",", "|"))
+
+        if isinstance(args.gaia_stdmask, str):
+            try:
+                args.gaia_stdmask = int(args.gaia_stdmask)
+            except ValueError:
+                args.gaia_stdmask = mws_mask.mask(args.gaia_stdmask.replace(",", "|"))
 
         if isinstance(args.skymask, str):
             try:
@@ -322,7 +335,8 @@ def run_assign_init(args, plate_radec=True):
                          stdmask=args.stdmask,
                          skymask=args.skymask,
                          safemask=args.safemask,
-                         excludemask=args.excludemask)
+                         excludemask=args.excludemask,
+                         gaia_stdmask=args.gaia_stdmask)
     # Now load the sky target files.  These are main-survey files that we will
     # force to be treated as the survey type of the other target files.
     survey = tgs.survey()
@@ -333,7 +347,8 @@ def run_assign_init(args, plate_radec=True):
                          stdmask=args.stdmask,
                          skymask=args.skymask,
                          safemask=args.safemask,
-                         excludemask=args.excludemask)
+                         excludemask=args.excludemask,
+                         gaia_stdmask=args.gaia_stdmask)
 
     return (hw, tiles, tgs, tagalong)
 

--- a/py/fiberassign/targets.py
+++ b/py/fiberassign/targets.py
@@ -570,6 +570,7 @@ def desi_target_type(desi_target, mws_target, sciencemask, stdmask,
 
     Args:
         desi_target (iterable):  Scalar or array-like integer values.
+        mws_target (iterable): Scalar or array-like integer values.
         sciencemask (int):  Integer value to bitwise-and when checking for
             science targets.
         stdmask (int):  Integer value to bitwise-and when checking for
@@ -582,6 +583,8 @@ def desi_target_type(desi_target, mws_target, sciencemask, stdmask,
             safe targets.
         excludemask (int):  Integer value to bitwise-and when checking for
             targets to exclude.
+        gaia_stdmask (int):  Integer value to bitwise-and when checking for
+            Gaia standards targets.
 
     Returns:
         (array):  The fiberassign target types.
@@ -632,7 +635,7 @@ def default_survey_target_masks(survey):
 
     Returns:
         (tuple): The science mask, standard mask, sky mask, suppsky mask,
-            safe mask, and exclude mask for the data.
+            safe mask, exclude mask, and gaia standard mask for the data.
 
     """
     sciencemask = None
@@ -695,7 +698,8 @@ def default_target_masks(data):
 
     Returns:
         (tuple):  The survey, column name, science mask, standard mask,
-            sky mask, suppsky mask, safe mask, and exclude mask for the data.
+            sky mask, suppsky mask, safe mask, exclude mask, and
+            gaia standard mask for the data.
 
     """
     col = None
@@ -745,6 +749,8 @@ def append_target_table(tgs, tagalong, tgdata, survey, typeforce, typecol,
             safe targets.
         excludemask (int):  Integer value to bitwise-and when checking for
             targets to exclude.
+        gaia_stdmask (int):  Integer value to bitwise-and when checking for
+            Gaia standards targets.
 
     Returns:
         None
@@ -869,6 +875,7 @@ def load_target_table(tgs, tagalong, tgdata, survey=None, typeforce=None, typeco
         suppskymask (int): Bitmask for classifying targets as suppsky.
         safemask (int): Bitmask for classifying targets as a safe location.
         excludemask (int): Bitmask for excluding targets.
+        gaia_stdmask (int): Bitmask for classifying targets as a Gaia standard.
 
     Returns:
         None
@@ -1079,6 +1086,7 @@ def load_target_file(tgs, tagalong, tfile, survey=None, typeforce=None, typecol=
         excludemask (int): Bitmask for excluding targets.
         rowbuffer (int): Optional number of rows to read at once when loading
             very large files.
+        gaia_stdmask (int): Bitmask for classifying targets as a Gaia standard.
 
     Returns:
         (str): The survey type.

--- a/py/fiberassign/targets.py
+++ b/py/fiberassign/targets.py
@@ -615,6 +615,7 @@ def desi_target_type(desi_target, mws_target, sciencemask, stdmask,
             ttype = 0
     else:
         desi_target = np.asarray(desi_target)
+        mws_target = np.asarray(mws_target)
         ttype = np.zeros(len(desi_target), dtype=np.uint8)
         ttype[desi_target & sciencemask != 0] |= TARGET_TYPE_SCIENCE
         ttype[desi_target & stdmask != 0] |= TARGET_TYPE_STANDARD

--- a/py/fiberassign/targets.py
+++ b/py/fiberassign/targets.py
@@ -802,8 +802,15 @@ def append_target_table(tgs, tagalong, tgdata, survey, typeforce, typecol,
             d_bits[:] = tgdata["FA_TARGET"][:]
         else:
             d_bits[:] = tgdata[typecol][:]
+            # AR trying to protect against cases where the *MWS_TARGET column
+            # AR    is not present; that does not happen for the main
+            # AR    survey, but imagining cases where fiberassign is
+            # AR    run on some special targets set (e.g. only secondaries)
+            mws_targets = 0 * tgdata[typecol]
+            if typecol.replace("DESI", "MWS") in tgdata.dtype.names:
+                mws_targets = tgdata[typecol.replace("DESI", "MWS")]
             d_type[:] = desi_target_type(
-                tgdata[typecol], tgdata[typecol.replace("DESI", "MWS")], sciencemask, stdmask, skymask, suppskymask,
+                tgdata[typecol], mws_targets, sciencemask, stdmask, skymask, suppskymask,
                 safemask, excludemask, gaia_stdmask)
 
     if "OBSCONDITIONS" in tgdata.dtype.fields:

--- a/py/fiberassign/test/test_targets.py
+++ b/py/fiberassign/test/test_targets.py
@@ -8,7 +8,7 @@ import unittest
 
 import numpy as np
 
-from desitarget.targetmask import desi_mask
+from desitarget.targetmask import desi_mask, mws_mask
 
 from fiberassign.hardware import load_hardware
 
@@ -22,6 +22,7 @@ from fiberassign.targets import (TARGET_TYPE_SCIENCE, TARGET_TYPE_SKY,
                                  default_main_suppskymask,
                                  default_main_safemask,
                                  default_main_excludemask,
+                                 default_main_gaia_stdmask,
                                  Targets, TargetsAvailable,
                                  LocationsAvailable, targets_in_tiles, create_tagalong)
 
@@ -89,50 +90,65 @@ class TestTargets(unittest.TestCase):
         desi_target = [
             desi_mask["ELG"].mask,
             desi_mask["STD_FAINT"].mask,
+            0,
             desi_mask["SKY"].mask,
             desi_mask["SUPP_SKY"].mask,
             desi_mask["IN_BRIGHT_OBJECT"].mask,
             ]
+        mws_target = [
+            0,
+            0,
+            mws_mask["GAIA_STD_FAINT"].mask,
+            0,
+            0,
+            0,
+        ]
         fbatype = np.array([
             TARGET_TYPE_SCIENCE,
+            TARGET_TYPE_STANDARD,
             TARGET_TYPE_STANDARD,
             TARGET_TYPE_SKY,
             TARGET_TYPE_SUPPSKY,
             0
             ])
         result = desi_target_type(
-            desi_target, default_main_sciencemask(), default_main_stdmask(),
+            desi_target, mws_target, default_main_sciencemask(), default_main_stdmask(),
             default_main_skymask(), default_main_suppskymask(),
-            default_main_safemask(), default_main_excludemask())
+            default_main_safemask(), default_main_excludemask(),
+            default_main_gaia_stdmask())
         self.assertTrue(np.all(result == fbatype))
 
         # Scalar inputs
         for i in range(len(desi_target)):
             result = desi_target_type(
-                desi_target[i],
+                desi_target[i], mws_target[i],
                 default_main_sciencemask(), default_main_stdmask(),
                 default_main_skymask(), default_main_suppskymask(),
-                default_main_safemask(), default_main_excludemask())
+                default_main_safemask(), default_main_excludemask(),
+                default_main_gaia_stdmask())
             self.assertEqual(result, fbatype[i])
 
         # Does excludemask work?
         mask = desi_mask["ELG"].mask
+        mask2 = 0 # MWS_TARGET
         result = desi_target_type(
-            mask, default_main_sciencemask(), default_main_stdmask(),
+            mask, mask2, default_main_sciencemask(), default_main_stdmask(),
             default_main_skymask(), default_main_suppskymask(),
-            default_main_safemask(), default_main_excludemask())
+            default_main_safemask(), default_main_excludemask(),
+            default_main_gaia_stdmask())
         self.assertEqual(result, TARGET_TYPE_SCIENCE)
 
         result = desi_target_type(
-            mask, default_main_sciencemask(), default_main_stdmask(),
+            mask, mask2, default_main_sciencemask(), default_main_stdmask(),
             default_main_skymask(), default_main_suppskymask(),
-            default_main_safemask(), mask)
+            default_main_safemask(), mask,
+            default_main_gaia_stdmask())
         self.assertEqual(result, 0)
 
         result = desi_target_type(
-            [mask, mask], default_main_sciencemask(), default_main_stdmask(),
+            [mask, mask], [mask2, mask2], default_main_sciencemask(), default_main_stdmask(),
             default_main_skymask(), default_main_suppskymask(),
-            default_main_safemask(), mask)
+            default_main_safemask(), mask, default_main_gaia_stdmask())
         self.assertTrue(not np.any(result))
 
 


### PR DESCRIPTION
This PR assigns the `TARGET_TYPE_STANDARD` to GAIA_STD_BRIGHT and GAIA_STD_FAINT targets.

I have basically duplicated the "stdmask" lines to "gaia_stdmask" lines in `scripts.assign.py` and `targets.py`.
This noticely:
- adds a new `--gaia_stdmask` argument to `scripts.assign.parse_assign()` (defaulting to None, as for `--stdmask`);
- introduces a dependency on MWS_TARGET in `targets.py` (I've tried to protect against the case where no MWS_TARGET column is present, imagining some special fiberassign run).

I did not include `GAIA_STD_WD`, as we are going to remove the WD from the standard counting requirement.

With this PR, the code will assign `TARGET_TYPE_STANDARD` to any STD_BRIGHT, STD_FAINT, STD_WD (will be removed in another PR), GAIA_STD_BRIGHT, and GAIA_STD_FAINT.
But as it happens that:
- the main bright/dark have zero GAIA_STD_* targets,
- the main backup has zero STD_* targets,

so this approach selects STD_* for bright/dark and GAIA_STD_* for backup, without requiring to add a dependency on the program through those codes.

For the same reason it should be backwards-compatible for the main bright/dark observed tiles.
For other surveys (cmx, sv1, sv2, sv3), I ve not really checked, but those surveys already are not backwards-compatible with the current master version anyway.

I ve tested / developed using the temporary main backup catalogs here: `/global/cscratch1/sd/adamyers/gaiadr2/1.3.0.dev5218/targets/main/resolve/backup`.