### PR TITLE
add tagalong argument in the docstr

### DIFF
--- a/py/fiberassign/assign.py
+++ b/py/fiberassign/assign.py
@@ -138,7 +138,7 @@ def write_assignment_fits_tile(asgn, tagalong, fulltarget, overwrite, params):
     Args:
         outroot (str):  full path of the output root file name.
         asgn (Assignment):  the assignment class instance.
-        tagalong (TargetTagalong): a data structure that carries RA,Dec, and other information for targets from the targeting files, to be written to the fiberassign outputs.  A new one can be created using `fiberassign.targets.create_tagalong`
+        tagalong (TargetTagalong): a data structure that carries RA,Dec, and other information for targets from the targeting files, to be written to the fiberassign outputs.
         fulltarget (bool):  if True, dump the target information for all
             available targets, not just the ones that are assigned.
         overwrite (bool): overwrite output files or not
@@ -583,7 +583,7 @@ def write_assignment_fits(tiles, tagalong, asgn, out_dir=".", out_prefix="fba-",
     Args:
         tiles (Tiles):  The Tiles object containing the properties of each
             tile.
-        tagalong (TargetTagalong): a data structure that carries RA,Dec, and other information for targets from the targeting files, to be written to the fiberassign outputs.  A new one can be created using `fiberassign.targets.create_tagalong`
+        tagalong (TargetTagalong): a data structure that carries RA,Dec, and other information for targets from the targeting files, to be written to the fiberassign outputs.
         asgn (Assignment):  The assignment object.
         out_dir (str):  The output directory for writing per-tile files.
         out_prefix (str):  The output file name prefix.
@@ -654,7 +654,7 @@ def write_assignment_ascii(tiles, asgn, tagalong, out_dir=".", out_prefix="fba-"
         tiles (Tiles):  The Tiles object containing the properties of each
             tile.
         asgn (Assignment):  The assignment object.
-        tagalong (TargetTagalong): a data structure that carries RA,Dec, and other information for targets from the targeting files, to be written to the fiberassign outputs.  A new one can be created using `fiberassign.targets.create_tagalong`
+        tagalong (TargetTagalong): a data structure that carries RA,Dec, and other information for targets from the targeting files, to be written to the fiberassign outputs.
         out_dir (str):  The output directory for writing per-tile files.
         out_prefix (str):  The output file name prefix.
         split_dir (bool):  Optionally split files by tile ID prefix.

--- a/py/fiberassign/assign.py
+++ b/py/fiberassign/assign.py
@@ -138,6 +138,7 @@ def write_assignment_fits_tile(asgn, tagalong, fulltarget, overwrite, params):
     Args:
         outroot (str):  full path of the output root file name.
         asgn (Assignment):  the assignment class instance.
+        tagalong (TargetTagalong): a data structure that carries RA,Dec, and other information for targets from the targeting files, to be written to the fiberassign outputs.  A new one can be created using `fiberassign.targets.create_tagalong`
         fulltarget (bool):  if True, dump the target information for all
             available targets, not just the ones that are assigned.
         overwrite (bool): overwrite output files or not
@@ -582,6 +583,7 @@ def write_assignment_fits(tiles, tagalong, asgn, out_dir=".", out_prefix="fba-",
     Args:
         tiles (Tiles):  The Tiles object containing the properties of each
             tile.
+        tagalong (TargetTagalong): a data structure that carries RA,Dec, and other information for targets from the targeting files, to be written to the fiberassign outputs.  A new one can be created using `fiberassign.targets.create_tagalong`
         asgn (Assignment):  The assignment object.
         out_dir (str):  The output directory for writing per-tile files.
         out_prefix (str):  The output file name prefix.
@@ -652,6 +654,7 @@ def write_assignment_ascii(tiles, asgn, tagalong, out_dir=".", out_prefix="fba-"
         tiles (Tiles):  The Tiles object containing the properties of each
             tile.
         asgn (Assignment):  The assignment object.
+        tagalong (TargetTagalong): a data structure that carries RA,Dec, and other information for targets from the targeting files, to be written to the fiberassign outputs.  A new one can be created using `fiberassign.targets.create_tagalong`
         out_dir (str):  The output directory for writing per-tile files.
         out_prefix (str):  The output file name prefix.
         split_dir (bool):  Optionally split files by tile ID prefix.

--- a/py/fiberassign/targets.py
+++ b/py/fiberassign/targets.py
@@ -781,6 +781,7 @@ def append_target_table(tgs, tagalong, tgdata, survey, typeforce, typecol,
 
     Args:
         tgs (Targets): The targets object to modify.
+        tagalong (TargetTagalong): a data structure that carries RA,Dec, and other information for targets from the targeting files, to be written to the fiberassign outputs.  A new one can be created using `fiberassign.targets.create_tagalong`.
         tgdata (Table): The table or recarray containing the input data.
         survey (str):  The survey type.
         typeforce (int): If not None, all targets are considered to be this
@@ -920,6 +921,7 @@ def load_target_table(tgs, tagalong, tgdata, survey=None, typeforce=None, typeco
 
     Args:
         tgs (Targets): The targets object on which to append this data.
+        tagalong (TargetTagalong): a data structure that carries RA,Dec, and other information for targets from the targeting files, to be written to the fiberassign outputs.  A new one can be created using `fiberassign.targets.create_tagalong`.
         tgdata (Table): A table or recarray with the target properties.
         survey (str):  The survey type.  If None, query from columns.
         typeforce (int): If specified, it must equal one of the TARGET_TYPE_*
@@ -1132,6 +1134,7 @@ def load_target_file(tgs, tagalong, tfile, survey=None, typeforce=None, typecol=
 
     Args:
         tgs (Targets): The targets object on which to append this data.
+        tagalong (TargetTagalong): a data structure that carries RA,Dec, and other information for targets from the targeting files, to be written to the fiberassign outputs.  A new one can be created using `fiberassign.targets.create_tagalong`.
         tfile (str): The path to the target catalog.
         survey (str):  The survey type.  If None, query from columns and
             the FITS header.

--- a/py/fiberassign/targets.py
+++ b/py/fiberassign/targets.py
@@ -781,7 +781,7 @@ def append_target_table(tgs, tagalong, tgdata, survey, typeforce, typecol,
 
     Args:
         tgs (Targets): The targets object to modify.
-        tagalong (TargetTagalong): a data structure that carries RA,Dec, and other information for targets from the targeting files, to be written to the fiberassign outputs.  A new one can be created using `fiberassign.targets.create_tagalong`.
+        tagalong (TargetTagalong): a data structure that carries RA,Dec, and other information for targets from the targeting files, to be written to the fiberassign outputs.
         tgdata (Table): The table or recarray containing the input data.
         survey (str):  The survey type.
         typeforce (int): If not None, all targets are considered to be this
@@ -921,7 +921,7 @@ def load_target_table(tgs, tagalong, tgdata, survey=None, typeforce=None, typeco
 
     Args:
         tgs (Targets): The targets object on which to append this data.
-        tagalong (TargetTagalong): a data structure that carries RA,Dec, and other information for targets from the targeting files, to be written to the fiberassign outputs.  A new one can be created using `fiberassign.targets.create_tagalong`.
+        tagalong (TargetTagalong): a data structure that carries RA,Dec, and other information for targets from the targeting files, to be written to the fiberassign outputs.
         tgdata (Table): A table or recarray with the target properties.
         survey (str):  The survey type.  If None, query from columns.
         typeforce (int): If specified, it must equal one of the TARGET_TYPE_*


### PR DESCRIPTION
This PR adds the `tagalong` argument in the docstr of the functions using it in `targets.py` and `assign.py`.

This was raised in https://github.com/desihub/fiberassign/issues/429 (and the `taglong` was introduced in PR https://github.com/desihub/fiberassign/pull/353).

`tagalong` is also used in some `vis.py` functions, but I m not at all familiar with those, and they haven t any docstr yet, so I didn t do any modification there.
