### PR TITLE
Patch 202210

### DIFF
--- a/bin/fba_patch
+++ b/bin/fba_patch
@@ -26,11 +26,10 @@ np.random.seed(1234)
 def get_parse():
     parser = ArgumentParser()
     parser.add_argument(
-        "--fasource",
-        help="source for fiberassign files (default=svn)",
-        choices=["svn"],
+        "--fa_srcdir",
+        help="source folder for input fiberassign files (default=$DESI_TARGET/fiberassign/tiles/trunk)",
         type=str,
-        default="svn",
+        default=None,
     )
     parser.add_argument(
         "--outdir",
@@ -83,6 +82,8 @@ def get_parse():
         help="log to stdout instead of redirecting to a file",
     )
     args = parser.parse_args()
+    if args.fa_srcdir is None:
+        args.fa_srcdir = os.path.join(os.getenv("DESI_TARGET"), "fiberassign", "tiles", "trunk")
     for kwargs in args._get_kwargs():
         log.info("{} = {}".format(kwargs[0], kwargs[1]))
     return args
@@ -124,8 +125,7 @@ def main():
         log.info("Patching with: {} = {}".format(key, params[key]))
 
     # AR fiberassign files
-    fafns = get_fafns_to_check(args.fasource, debug=args.debug)
-    fa_base = os.path.sep.join(fafns[0].split(os.path.sep)[:-2])
+    fafns = get_fafns_to_check(args.fa_srcdir, debug=args.debug)
     # AR shuffle so that the same healpix pixels are not hit at the same time..
     ii = np.random.choice(len(fafns), size=len(fafns), replace=False)
     fafns = fafns[ii]
@@ -190,9 +190,6 @@ def main():
     # AR then run
     myargs = []
     for fafn, tileid in zip(fafns, tileids):
-        if not fafn.startswith(fa_base):
-            print("All input filenames must start with fa_base = ", fa_base)
-            return -1
         outfn = os.path.join(
             args.outdir, "{:06d}".format(tileid)[:3], os.path.basename(fafn)
         )

--- a/bin/fba_patch
+++ b/bin/fba_patch
@@ -1,0 +1,219 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import fitsio
+from glob import glob
+import numpy as np
+from collections import Counter
+from astropy.table import vstack
+from fiberassign.utils import Logger
+from fiberassign.fba_patch_io import (
+    get_fafns_to_check,
+    get_tileid_from_fafn,
+    get_patching_params,
+    patch,
+)
+from desiutil.redirect import stdouterr_redirected
+import multiprocessing
+from argparse import ArgumentParser
+
+
+log = Logger.get()
+np.random.seed(1234)
+
+
+def get_parse():
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--fasource",
+        help="source for fiberassign files (default=svn)",
+        choices=["svn"],
+        type=str,
+        default="svn",
+    )
+    parser.add_argument(
+        "--outdir",
+        help="output directory",
+        type=str,
+        default=None,
+    )
+    parser.add_argument(
+        "--patching_params_fn",
+        help="path to a .yaml file with fixcols, addcols, populate_ebv (see fiberassign/data/patching_202210) (default='patching_202210.yaml')",
+        type=str,
+        default="patching_202210.yaml",
+    )
+    parser.add_argument(
+        "--patching_root",
+        help="if any, patching infos will be stored in files like fiberassign-TILEID-PATCHING_ROOT.ecsv (default='patching_202210')",
+        type=str,
+        default="patching_202210",
+    )
+    parser.add_argument(
+        "--numproc",
+        help="number of parallel processes (default=1) (suggestion: cori=64, perlmutter=128)",
+        type=int,
+        default=1,
+    )
+    parser.add_argument(
+        "--skip_subdirs",
+        help="comma-separated list of subdirs (e.g., '000,001') to skip (default=None)",
+        type=str,
+        default=None,
+    )
+    parser.add_argument(
+        "--only_subdirs",
+        help="comma-separated list of subdirs (e.g., '000,001') to restrict to (default=None)",
+        type=str,
+        default=None,
+    )
+    parser.add_argument(
+        "--only_tileids",
+        help="comma-separated list of tileids to process (e.g. '82405,82406') (default=None)",
+        type=str,
+        default=None,
+    )
+    parser.add_argument(
+        "--debug", action="store_true", help="only pick few tiles for debugging"
+    )
+    parser.add_argument(
+        "--log_stdout",
+        action="store_true",
+        help="log to stdout instead of redirecting to a file",
+    )
+    args = parser.parse_args()
+    for kwargs in args._get_kwargs():
+        log.info("{} = {}".format(kwargs[0], kwargs[1]))
+    return args
+
+
+def _patch_subdir(outdir, subdir, fafns, params_fn, numproc):
+
+    outecsv = os.path.join(outdir, "patch-{}.ecsv".format(subdir))
+
+    tileids = np.array([get_tileid_from_fafn(fafn) for fafn in fafns])
+    subdirs = np.array(["{:06d}".format(tileid)[:3] for tileid in tileids])
+    sel = subdirs == subdir
+
+    log.info("launch patch() via pool for {} fiberassign files".format(sel.sum()))
+
+    myargs = []
+    for fafn, tileid in zip(fafns[sel], tileids[sel]):
+        outfn = os.path.join(
+            outdir, "{:06d}".format(tileid)[:3], os.path.basename(fafn)
+        )
+        myargs.append([fafn, outfn, params_fn])
+
+    if numproc > 1:
+        pool = multiprocessing.Pool(processes=numproc)
+        with pool:
+            _ = pool.starmap(patch, myargs)
+    else:
+        _ = [patch(*myarg) for myarg in myargs]
+    log.info("pool done")
+
+
+def main():
+
+    args = get_parse()
+
+    # AR patching params
+    params = get_patching_params(fn=args.patching_params_fn)
+    for key in ["patching_root", "fixcols", "addcols", "populate_ebv"]:
+        log.info("Patching with: {} = {}".format(key, params[key]))
+
+    # AR fiberassign files
+    fafns = get_fafns_to_check(args.fasource, debug=args.debug)
+    fa_base = os.path.sep.join(fafns[0].split(os.path.sep)[:-2])
+    # AR shuffle so that the same healpix pixels are not hit at the same time..
+    ii = np.random.choice(len(fafns), size=len(fafns), replace=False)
+    fafns = fafns[ii]
+
+    # AR splitting per subdir (000, 001, etc)
+    tileids = np.array([get_tileid_from_fafn(fafn) for fafn in fafns])
+    subdirs = np.array(["{:06d}".format(tileid)[:3] for tileid in tileids])
+    if args.skip_subdirs is not None:
+        reject = np.zeros(len(fafns), dtype=bool)
+        for subdir in args.skip_subdirs.split(","):
+            reject_i = subdirs == subdir
+            reject |= reject_i
+            log.info(
+                "{}\tremove {} fiberassign files, as per args.skip_subdirs".format(
+                    subdir, reject_i.sum()
+                )
+            )
+        fafns, tileids, subdirs = fafns[~reject], tileids[~reject], subdirs[~reject]
+    if args.only_subdirs is not None:
+        sel = np.zeros(len(fafns), dtype=bool)
+        for subdir in args.only_subdirs.split(","):
+            sel_i = subdirs == subdir
+            sel |= sel_i
+            log.info(
+                "{}\trestrict to {} fiberassign files, as per args.only_subdirs".format(
+                    subdir, sel_i.sum()
+                )
+            )
+        fafns, tileids, subdirs = fafns[sel], tileids[sel], subdirs[sel]
+    for subdir in np.unique(subdirs):
+        log.info(
+            "{}\tkeep {} fiberassign files".format(subdir, (subdirs == subdir).sum())
+        )
+    if args.only_tileids is not None:
+        sel = np.in1d(tileids, [int(tileid) for tileid in args.only_tileids.split(",")])
+        log.info(
+            "{}\trestrict to {} fiberassign files, as per args.only_tileids".format(
+                subdir, sel.sum()
+            )
+        )
+        fafns, tileids, subdirs = fafns[sel], tileids[sel], subdirs[sel]
+
+    # AR first check that no output files already exist
+    fns = []
+    for fafn, tileid in zip(fafns, tileids):
+        fn = os.path.join(
+            args.outdir, "{:06d}".format(tileid)[:3], os.path.basename(fafn)
+        )
+        fns.append(fn)
+        fns.append(fn.replace(".fits.gz", "-{}.ecsv".format(params["patching_root"])))
+    if not args.log_stdout:
+        for subdir in np.unique(subdirs):
+            fns.append(os.path.join(args.outdir, "patch-{}.log".format(subdir)))
+    fns = [fn for fn in fns if os.path.isfile(fn)]
+    if len(fns) > 0:
+        msg = "the following file(s) already exist(s); delete beforehand\n{}".format(
+            "\n".join(["\t{}".format(fn) for fn in fns])
+        )
+        log.error(msg)
+        raise IOError(msg)
+
+    # AR then run
+    myargs = []
+    for fafn, tileid in zip(fafns, tileids):
+        if not fafn.startswith(fa_base):
+            print("All input filenames must start with fa_base = ", fa_base)
+            return -1
+        outfn = os.path.join(
+            args.outdir, "{:06d}".format(tileid)[:3], os.path.basename(fafn)
+        )
+        myargs.append([fafn, outfn])
+
+    for subdir in np.unique(subdirs):
+        outlog = os.path.join(args.outdir, "patch-{}.log".format(subdir))
+        myarg = [
+            args.outdir,
+            subdir,
+            fafns,
+            args.patching_params_fn,
+            args.numproc,
+        ]
+        if args.log_stdout:
+            _patch_subdir(*myarg)
+        else:
+            with stdouterr_redirected(to=outlog):
+                _patch_subdir(*myarg)
+
+
+if __name__ == "__main__":
+
+    main()

--- a/bin/fba_patch
+++ b/bin/fba_patch
@@ -125,48 +125,16 @@ def main():
         log.info("Patching with: {} = {}".format(key, params[key]))
 
     # AR fiberassign files
-    fafns = get_fafns_to_check(args.fa_srcdir, debug=args.debug)
+    fafns, tileids, subdirs = get_fafns_to_check(
+        args.fa_srcdir,
+        skip_subdirs=args.skip_subdirs,
+        only_subdirs=args.only_subdirs,
+        only_tileids=args.only_tileids,
+        debug=args.debug,
+    )
     # AR shuffle so that the same healpix pixels are not hit at the same time..
     ii = np.random.choice(len(fafns), size=len(fafns), replace=False)
-    fafns = fafns[ii]
-
-    # AR splitting per subdir (000, 001, etc)
-    tileids = np.array([get_tileid_from_fafn(fafn) for fafn in fafns])
-    subdirs = np.array(["{:06d}".format(tileid)[:3] for tileid in tileids])
-    if args.skip_subdirs is not None:
-        reject = np.zeros(len(fafns), dtype=bool)
-        for subdir in args.skip_subdirs.split(","):
-            reject_i = subdirs == subdir
-            reject |= reject_i
-            log.info(
-                "{}\tremove {} fiberassign files, as per args.skip_subdirs".format(
-                    subdir, reject_i.sum()
-                )
-            )
-        fafns, tileids, subdirs = fafns[~reject], tileids[~reject], subdirs[~reject]
-    if args.only_subdirs is not None:
-        sel = np.zeros(len(fafns), dtype=bool)
-        for subdir in args.only_subdirs.split(","):
-            sel_i = subdirs == subdir
-            sel |= sel_i
-            log.info(
-                "{}\trestrict to {} fiberassign files, as per args.only_subdirs".format(
-                    subdir, sel_i.sum()
-                )
-            )
-        fafns, tileids, subdirs = fafns[sel], tileids[sel], subdirs[sel]
-    for subdir in np.unique(subdirs):
-        log.info(
-            "{}\tkeep {} fiberassign files".format(subdir, (subdirs == subdir).sum())
-        )
-    if args.only_tileids is not None:
-        sel = np.in1d(tileids, [int(tileid) for tileid in args.only_tileids.split(",")])
-        log.info(
-            "{}\trestrict to {} fiberassign files, as per args.only_tileids".format(
-                subdir, sel.sum()
-            )
-        )
-        fafns, tileids, subdirs = fafns[sel], tileids[sel], subdirs[sel]
+    fafns, tileids, subdirs = fafns[ii], tileids[ii], subdirs[ii]
 
     # AR first check that no output files already exist
     fns = []

--- a/bin/fba_patch
+++ b/bin/fba_patch
@@ -1,12 +1,7 @@
 #!/usr/bin/env python
 
 import os
-import sys
-import fitsio
-from glob import glob
 import numpy as np
-from collections import Counter
-from astropy.table import vstack
 from fiberassign.utils import Logger
 from fiberassign.fba_patch_io import (
     get_fafns_to_check,

--- a/bin/fba_patch
+++ b/bin/fba_patch
@@ -91,8 +91,6 @@ def get_parse():
 
 def _patch_subdir(outdir, subdir, fafns, params_fn, numproc):
 
-    outecsv = os.path.join(outdir, "patch-{}.ecsv".format(subdir))
-
     tileids = np.array([get_tileid_from_fafn(fafn) for fafn in fafns])
     subdirs = np.array(["{:06d}".format(tileid)[:3] for tileid in tileids])
     sel = subdirs == subdir

--- a/bin/fba_patch_diagnosis
+++ b/bin/fba_patch_diagnosis
@@ -1,0 +1,244 @@
+#!/usr/bin/env python
+
+import os
+import numpy as np
+import fitsio
+from astropy.table import Table, vstack
+from desitarget.geomask import match, pixarea2nside
+from fiberassign.utils import Logger
+from fba_patch_io import (
+    get_tileid_from_fafn,
+    get_fafns_to_check,
+    diagnose_values_fafn,
+    diagnose_columns_fafn,
+)
+from desiutil.redirect import stdouterr_redirected
+import multiprocessing
+from argparse import ArgumentParser
+
+
+log = Logger.get()
+np.random.seed(1234)
+
+
+def get_parse():
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--fasource",
+        help="source for fiberassign files (default=svn)",
+        choices=["svn"],
+        type=str,
+        default="svn",
+    )
+    parser.add_argument(
+        "--outdir",
+        help="output file will be {args.outdir}/fiberassign-differences-{args.fasource}-desitarget-???.ecsv",
+        type=str,
+        default=None,
+    )
+    parser.add_argument(
+        "--diagnose",
+        help="diagnose the columns content or the values content? (default=None)",
+        type=str,
+        choices=["columns", "values"],
+        default=None,
+    )
+    parser.add_argument(
+        "--numproc",
+        help="number of parallel processes (default=1) (suggestion: cori=64, perlmutter=128)",
+        type=int,
+        default=1,
+    )
+    parser.add_argument(
+        "--skip_subdirs",
+        help="comma-separated list of subdirs (e.g., '000,001') to skip (default=None)",
+        type=str,
+        default=None,
+    )
+    parser.add_argument(
+        "--only_subdirs",
+        help="comma-separated list of subdirs (e.g., '000,001') to restrict to (default=None)",
+        type=str,
+        default=None,
+    )
+    parser.add_argument(
+        "--only_tileids",
+        help="comma-separated list of tileids to process (e.g. '82405,82406') (default=None)",
+        type=str,
+        default=None,
+    )
+    parser.add_argument("--values_debug", action="store_true", help="only pick few tiles for the --diagnose values case")
+    parser.add_argument(
+        "--log_stdout",
+        action="store_true",
+        help="log to stdout instead of redirecting to a file",
+    )
+    args = parser.parse_args()
+    for kwargs in args._get_kwargs():
+        log.info("{} = {}".format(kwargs[0], kwargs[1]))
+    return args
+
+
+def get_outroot(outdir, fasource, diagnose, subdir=None):
+    outroot = os.path.join(
+        outdir, "fiberassign-diagnosis-{}-{}".format(fasource, diagnose)
+    )
+    if subdir is not None:
+        outroot = "{}-{}".format(outroot, subdir)
+    return outroot
+
+
+def _diagnose_values_subdir(outroot, fafns, numproc):
+
+    # AR launch process
+    log.info(
+        "launch diagnose_values_fafn via pool for {} fiberassign files".format(
+            len(fafns)
+        )
+    )
+    pool = multiprocessing.Pool(processes=numproc)
+    with pool:
+        ds = pool.map(diagnose_values_fafn, fafns)
+    log.info("pool done")
+
+    # AR restrict to fafns with some differences
+    ds = [d for d in ds if len(d) > 0]
+    log.info("restrict to {} fiberassign files with differences".format(len(ds)))
+
+    if len(ds) == 0:
+        log.info(
+            "no fiberassign files with differences, no {}.ecsv written".format(outroot)
+        )
+    else:
+        # AR sort by increasing tileid
+        ii = np.argsort([d["TILEID"][0] for d in ds])
+        ds = [ds[i] for i in ii]
+        # AR stack
+        log.info("start stacking")
+        d = vstack(ds)
+        # AR write
+        d.write("{}.ecsv".format(outroot))
+        log.info("{}.ecsv written".format(outroot))
+
+
+def _diagnose_columns(outroot, fafns, numproc):
+
+    # AR launch process
+    log.info(
+        "launch diagnose_columns_fafn via pool for {} fiberassign files".format(
+            len(fafns)
+        )
+    )
+    pool = multiprocessing.Pool(processes=numproc)
+    with pool:
+        ds = pool.map(diagnose_columns_fafn, fafns)
+    log.info("pool done")
+
+    # AR sort by increasing tileid
+    ii = np.argsort([d["TILEID"][0] for d in ds])
+    ds = [ds[i] for i in ii]
+    # AR stack
+    log.info("start stacking")
+    d = vstack(ds)
+    # AR write
+    d.write("{}.ecsv".format(outroot))
+    log.info("{}.ecsv written".format(outroot))
+
+
+def main():
+
+    args = get_parse()
+
+    # AR fiberassign files
+    fafns = get_fafns_to_check(args.fasource, debug=args.values_debug)
+    # AR shuffle so that the same healpix pixels are not hit at the same time..
+    ii = np.random.choice(len(fafns), size=len(fafns), replace=False)
+    fafns = fafns[ii]
+
+    # AR splitting per subdir (000, 001, etc)
+    tileids = np.array([get_tileid_from_fafn(fafn) for fafn in fafns])
+    subdirs = np.array(["{:06d}".format(tileid)[:3] for tileid in tileids])
+    if args.skip_subdirs is not None:
+        reject = np.zeros(len(fafns), dtype=bool)
+        for subdir in args.skip_subdirs.split(","):
+            reject_i = subdirs == subdir
+            reject |= reject_i
+            log.info(
+                "{}\tremove {} fiberassign files, as per args.skip_subdirs".format(
+                    subdir, reject_i.sum()
+                )
+            )
+        fafns, tileids, subdirs = fafns[~reject], tileids[~reject], subdirs[~reject]
+    if args.only_subdirs is not None:
+        sel = np.zeros(len(fafns), dtype=bool)
+        for subdir in args.only_subdirs.split(","):
+            sel_i = subdirs == subdir
+            sel |= sel_i
+            log.info(
+                "{}\trestrict to {} fiberassign files, as per args.only_subdirs".format(
+                    subdir, sel_i.sum()
+                )
+            )
+        fafns, tileids, subdirs = fafns[sel], tileids[sel], subdirs[sel]
+    for subdir in np.unique(subdirs):
+        log.info(
+            "{}\tdiagnosing {} fiberassign files".format(
+                subdir, (subdirs == subdir).sum()
+            )
+        )
+    if args.only_tileids is not None:
+        sel = np.in1d(tileids, [int(tileid) for tileid in args.only_tileids.split(",")])
+        log.info(
+            "{}\trestrict to {} fiberassign files, as per args.only_tileids".format(
+                subdir, sel.sum()
+            )
+        )
+        fafns, tileids, subdirs = fafns[sel], tileids[sel], subdirs[sel]
+
+    # AR first check that no output files already exist
+    fns = []
+    if args.diagnose == "values":
+        for subdir in np.unique(subdirs):
+            outroot = get_outroot(
+                args.outdir, args.fasource, args.diagnose, subdir=subdir
+            )
+            for fn in ["{}.ecsv".format(outroot), "{}.log".format(outroot)]:
+                if os.path.isfile(fn):
+                    fns.append(fn)
+    if args.diagnose == "columns":
+        outroot = get_outroot(args.outdir, args.fasource, args.diagnose)
+        for fn in ["{}.ecsv".format(outroot), "{}.log".format(outroot)]:
+            if os.path.isfile(fn):
+                fns.append(fn)
+    if len(fns) > 0:
+        msg = "the following file(s) already exist(s); delete beforehand\n{}".format(
+            "\n".join(["\t{}".format(fn) for fn in fns])
+        )
+        log.error(msg)
+        raise IOError(msg)
+
+    # AR then run
+    if args.diagnose == "values":
+        for subdir in np.unique(subdirs):
+            sel = subdirs == subdir
+            outroot = get_outroot(
+                args.outdir, args.fasource, args.diagnose, subdir=subdir
+            )
+            if args.log_stdout:
+                _diagnose_values_subdir(outroot, fafns[sel], args.numproc)
+            else:
+                with stdouterr_redirected(to="{}.log".format(outroot)):
+                    _diagnose_values_subdir(outroot, fafns[sel], args.numproc)
+
+    if args.diagnose == "columns":
+        outroot = get_outroot(args.outdir, args.fasource, args.diagnose)
+        if args.log_stdout:
+            _diagnose_columns(outroot, fafns, args.numproc)
+        else:
+            with stdouterr_redirected(to="{}.log".format(outroot)):
+                _diagnose_columns(outroot, fafns, args.numproc)
+
+
+if __name__ == "__main__":
+
+    main()

--- a/bin/fba_patch_diagnosis
+++ b/bin/fba_patch_diagnosis
@@ -6,7 +6,7 @@ import fitsio
 from astropy.table import Table, vstack
 from desitarget.geomask import match, pixarea2nside
 from fiberassign.utils import Logger
-from fba_patch_io import (
+from fiberassign.fba_patch_io import (
     get_tileid_from_fafn,
     get_fafns_to_check,
     diagnose_values_fafn,
@@ -24,15 +24,14 @@ np.random.seed(1234)
 def get_parse():
     parser = ArgumentParser()
     parser.add_argument(
-        "--fasource",
-        help="source for fiberassign files (default=svn)",
-        choices=["svn"],
+        "--fa_srcdir",
+        help="source folder for input fiberassign files (default=$DESI_TARGET/fiberassign/tiles/trunk)",
         type=str,
-        default="svn",
+        default=None,
     )
     parser.add_argument(
         "--outdir",
-        help="output file will be {args.outdir}/fiberassign-differences-{args.fasource}-desitarget-???.ecsv",
+        help="output file will be {args.outdir}/fiberassign-diagnosis-???.ecsv",
         type=str,
         default=None,
     )
@@ -74,14 +73,16 @@ def get_parse():
         help="log to stdout instead of redirecting to a file",
     )
     args = parser.parse_args()
+    if args.fa_srcdir is None:
+        args.fa_srcdir = os.path.join(os.getenv("DESI_TARGET"), "fiberassign", "tiles", "trunk")
     for kwargs in args._get_kwargs():
         log.info("{} = {}".format(kwargs[0], kwargs[1]))
     return args
 
 
-def get_outroot(outdir, fasource, diagnose, subdir=None):
+def get_outroot(outdir, diagnose, subdir=None):
     outroot = os.path.join(
-        outdir, "fiberassign-diagnosis-{}-{}".format(fasource, diagnose)
+        outdir, "fiberassign-diagnosis-{}".format(diagnose)
     )
     if subdir is not None:
         outroot = "{}-{}".format(outroot, subdir)
@@ -150,7 +151,7 @@ def main():
     args = get_parse()
 
     # AR fiberassign files
-    fafns = get_fafns_to_check(args.fasource, debug=args.values_debug)
+    fafns = get_fafns_to_check(args.fa_srcdir, debug=args.values_debug)
     # AR shuffle so that the same healpix pixels are not hit at the same time..
     ii = np.random.choice(len(fafns), size=len(fafns), replace=False)
     fafns = fafns[ii]
@@ -200,13 +201,13 @@ def main():
     if args.diagnose == "values":
         for subdir in np.unique(subdirs):
             outroot = get_outroot(
-                args.outdir, args.fasource, args.diagnose, subdir=subdir
+                args.outdir, args.diagnose, subdir=subdir
             )
             for fn in ["{}.ecsv".format(outroot), "{}.log".format(outroot)]:
                 if os.path.isfile(fn):
                     fns.append(fn)
     if args.diagnose == "columns":
-        outroot = get_outroot(args.outdir, args.fasource, args.diagnose)
+        outroot = get_outroot(args.outdir, args.diagnose)
         for fn in ["{}.ecsv".format(outroot), "{}.log".format(outroot)]:
             if os.path.isfile(fn):
                 fns.append(fn)
@@ -222,7 +223,7 @@ def main():
         for subdir in np.unique(subdirs):
             sel = subdirs == subdir
             outroot = get_outroot(
-                args.outdir, args.fasource, args.diagnose, subdir=subdir
+                args.outdir, args.diagnose, subdir=subdir
             )
             if args.log_stdout:
                 _diagnose_values_subdir(outroot, fafns[sel], args.numproc)
@@ -231,7 +232,7 @@ def main():
                     _diagnose_values_subdir(outroot, fafns[sel], args.numproc)
 
     if args.diagnose == "columns":
-        outroot = get_outroot(args.outdir, args.fasource, args.diagnose)
+        outroot = get_outroot(args.outdir, args.diagnose)
         if args.log_stdout:
             _diagnose_columns(outroot, fafns, args.numproc)
         else:

--- a/bin/fba_patch_diagnosis
+++ b/bin/fba_patch_diagnosis
@@ -2,12 +2,9 @@
 
 import os
 import numpy as np
-import fitsio
-from astropy.table import Table, vstack
-from desitarget.geomask import match, pixarea2nside
+from astropy.table import vstack
 from fiberassign.utils import Logger
 from fiberassign.fba_patch_io import (
-    get_tileid_from_fafn,
     get_fafns_to_check,
     diagnose_values_fafn,
     diagnose_columns_fafn,

--- a/bin/fba_patch_diagnosis
+++ b/bin/fba_patch_diagnosis
@@ -151,50 +151,16 @@ def main():
     args = get_parse()
 
     # AR fiberassign files
-    fafns = get_fafns_to_check(args.fa_srcdir, debug=args.values_debug)
+    fafns, tileids, subdirs = get_fafns_to_check(
+        args.fa_srcdir,
+        skip_subdirs=args.skip_subdirs,
+        only_subdirs=args.only_subdirs,
+        only_tileids=args.only_tileids,
+        debug=args.values_debug,
+    )
     # AR shuffle so that the same healpix pixels are not hit at the same time..
     ii = np.random.choice(len(fafns), size=len(fafns), replace=False)
-    fafns = fafns[ii]
-
-    # AR splitting per subdir (000, 001, etc)
-    tileids = np.array([get_tileid_from_fafn(fafn) for fafn in fafns])
-    subdirs = np.array(["{:06d}".format(tileid)[:3] for tileid in tileids])
-    if args.skip_subdirs is not None:
-        reject = np.zeros(len(fafns), dtype=bool)
-        for subdir in args.skip_subdirs.split(","):
-            reject_i = subdirs == subdir
-            reject |= reject_i
-            log.info(
-                "{}\tremove {} fiberassign files, as per args.skip_subdirs".format(
-                    subdir, reject_i.sum()
-                )
-            )
-        fafns, tileids, subdirs = fafns[~reject], tileids[~reject], subdirs[~reject]
-    if args.only_subdirs is not None:
-        sel = np.zeros(len(fafns), dtype=bool)
-        for subdir in args.only_subdirs.split(","):
-            sel_i = subdirs == subdir
-            sel |= sel_i
-            log.info(
-                "{}\trestrict to {} fiberassign files, as per args.only_subdirs".format(
-                    subdir, sel_i.sum()
-                )
-            )
-        fafns, tileids, subdirs = fafns[sel], tileids[sel], subdirs[sel]
-    for subdir in np.unique(subdirs):
-        log.info(
-            "{}\tdiagnosing {} fiberassign files".format(
-                subdir, (subdirs == subdir).sum()
-            )
-        )
-    if args.only_tileids is not None:
-        sel = np.in1d(tileids, [int(tileid) for tileid in args.only_tileids.split(",")])
-        log.info(
-            "{}\trestrict to {} fiberassign files, as per args.only_tileids".format(
-                subdir, sel.sum()
-            )
-        )
-        fafns, tileids, subdirs = fafns[sel], tileids[sel], subdirs[sel]
+    fafns, tileids, subdirs = fafns[ii], tileids[ii], subdirs[ii]
 
     # AR first check that no output files already exist
     fns = []
@@ -203,14 +169,15 @@ def main():
             outroot = get_outroot(
                 args.outdir, args.diagnose, subdir=subdir
             )
-            for fn in ["{}.ecsv".format(outroot), "{}.log".format(outroot)]:
-                if os.path.isfile(fn):
-                    fns.append(fn)
+            fns.append("{}.ecsv".format(outroot))
+            if not args.log_stdout:
+                fns.append("{}.log".format(outroot))
     if args.diagnose == "columns":
         outroot = get_outroot(args.outdir, args.diagnose)
-        for fn in ["{}.ecsv".format(outroot), "{}.log".format(outroot)]:
-            if os.path.isfile(fn):
-                fns.append(fn)
+        fns.append("{}.ecsv".format(outroot))
+        if not args.log_stdout:
+            fns.append("{}.log".format(outroot))
+    fns = [fn for fn in fns if os.path.isfile(fn)]
     if len(fns) > 0:
         msg = "the following file(s) already exist(s); delete beforehand\n{}".format(
             "\n".join(["\t{}".format(fn) for fn in fns])

--- a/py/fiberassign/data/patching_202210.yaml
+++ b/py/fiberassign/data/patching_202210.yaml
@@ -1,0 +1,21 @@
+patching_root: "patching_202210"
+fixcols: {
+    "FIBERASSIGN": [
+        "BRICKID", "BRICKNAME", "BRICK_OBJID",
+        "FLUX_G", "FLUX_R", "FLUX_Z",
+        "FLUX_IVAR_G", "FLUX_IVAR_R", "FLUX_IVAR_Z",
+        "GAIA_PHOT_BP_MEAN_MAG", "GAIA_PHOT_G_MEAN_MAG",
+        "GAIA_PHOT_RP_MEAN_MAG", "HPXPIXEL", "MASKBITS", "MORPHTYPE",
+        "PARALLAX", "REF_CAT", "REF_ID", "RELEASE",
+        "SV3_DESI_TARGET", "SV3_SCND_TARGET",
+        ],
+    "TARGETS": [
+        "BRICKID", "BRICKNAME", "BRICK_OBJID", "HPXPIXEL", "RELEASE", "SV3_DESI_TARGET", "SV3_SCND_TARGET",
+    ]
+}
+addcols: {
+    "FIBERASSIGN": [["FLUX_IVAR_W1", ">f4"], ["FLUX_IVAR_W2", ">f4"]],
+}
+populate_ebv: {
+    "FIBERASSIGN": True,
+}

--- a/py/fiberassign/fba_patch_io.py
+++ b/py/fiberassign/fba_patch_io.py
@@ -480,7 +480,6 @@ def get_dith_infos(ext, name, fafn, fa_name):
             fa_undith = h["EXTRA"].data
             sel = np.in1d(fa_name["TARGETID"], fa_undith["TARGETID"])
             isdith[sel] = True
-            print(name, sel.sum())
     log.info(
         "{:06d}\t{}\t{}\tdith: found {} rows".format(
             fahdr["TILEID"], ext.ljust(11), name.upper(), isdith.sum()
@@ -1377,7 +1376,8 @@ def patch(in_fafn, out_fafn, params_fn):
 
         # AR store in patched/added_tables the fixed/added table
         patched_tables[ext] = tab
-        added_tables[ext] = addtab
+        if len(added_cols) > 0:
+            added_tables[ext] = addtab
 
         # AR there should not be duplicates in ii_match
         n_match = len(ii_match)

--- a/py/fiberassign/fba_patch_io.py
+++ b/py/fiberassign/fba_patch_io.py
@@ -1,0 +1,1095 @@
+#!/usr/bin/env python
+
+import sys
+import os
+from glob import glob
+from datetime import datetime
+import numpy as np
+import fitsio
+import healpy as hp
+from astropy.io import fits
+from astropy.table import Table, vstack
+from desimodel.footprint import is_point_in_desi, tiles2pix
+from desitarget.geomask import match, pixarea2nside
+from desitarget.io import read_targets_in_tiles
+from desitarget.targetmask import obsconditions
+from desitarget.gaiamatch import gaia_psflike
+from fiberassign.assign import merged_fiberassign_swap
+from desitarget.targets import main_cmx_or_sv
+from fiberassign.utils import Logger
+from desiutil.redirect import stdouterr_redirected
+
+
+log = Logger.get()
+
+
+# AR fiberassign extensions
+# AR POTENTIAL_ASSIGNMENTS only have TARGETID,FIBER,LOCATION, so nothing to patch
+all_exts = ["FIBERASSIGN", "SKY_MONITOR", "GFA_TARGETS", "TARGETS"]
+
+# AR possible sources of desitarget catalogs
+# AR all_names refer to the header keywords in the 0-extension of the fiberassign-TILEID.fits.gz files
+all_names = ["targ", "sky", "gfa", "scnd", "too"]
+
+
+def get_tileid_from_fafn(fafn):
+    """
+    Returns the tileid for a single fiberassign file name.
+
+    Args:
+        fafn: fiberassign file name (fiberassign-ABCDE.fits.gz) (str)
+
+    Returns:
+        tileid: tileid (int)
+    """
+    return int(os.path.basename(fafn)[12:18])
+
+
+def get_fafns_to_check(fasource, debug=False):
+    """
+    List of fiberassign files to check for patching diagnosis.
+
+    Args:
+        fasource: "svn" only for now (str)
+        debug (optional, defaults to False): if set, picks one fiberassign file per FAFLAVOR (bool)
+
+    Returns:
+        fafns: list of fiberassign files to check (np.array())
+    """
+    log.info("fasource = {}".format(fasource))
+    if fasource == "svn":
+        fafns = np.sort(
+            glob(
+                os.path.join(
+                    os.getenv("DESI_TARGET"),
+                    "fiberassign",
+                    "tiles",
+                    "trunk",
+                    "???",
+                    "fiberassign-??????.fits*",
+                )
+            )
+        )
+    log.info("start with {} fiberassign-TILEID.fits* files".format(fafns.size))
+    tileids = np.array([get_tileid_from_fafn(fafn) for fafn in fafns])
+    # AR 50000 <= TILEID < 80000
+    reject = (tileids >= 50000) & (tileids < 80000)
+    log.info("reject {} tiles with 50000 <= TILEID < 80000".format(reject.sum()))
+    fafns, tileids = fafns[~reject], tileids[~reject]
+    # AR 82248 <= TILEID < 82258
+    reject = (tileids >= 82248) & (tileids < 82258)
+    log.info(
+        "reject {} tiles with 82248 <= TILEID < 82258 (cmxposmapping)".format(
+            reject.sum()
+        )
+    )
+    fafns, tileids = fafns[~reject], tileids[~reject]
+    # AR
+    log.info("keep {} tiles".format(fafns.size))
+    # AR debug: pick one tileid per faflavor
+    if debug:
+        d = Table.read(
+            os.path.join(
+                os.getenv("DESI_ROOT"), "spectro", "redux", "daily", "tiles-daily.csv"
+            )
+        )
+        d = d[~np.in1d(d["FAFLAVOR"], ["cmxposmapping", "unknown"])]
+        faflavors, ii = np.unique(d["FAFLAVOR"], return_index=True)
+        sel = np.in1d(tileids, d["TILEID"][ii])
+        if sel.sum() != ii.size:
+            log.warning(
+                "debug: only {} / {} FAFLAVORs picked".format(sel.sum(), ii.size),
+            )
+        fafns, tileids = fafns[sel], tileids[sel]
+        log.warning("debug: keep {} tiles".format(fafns.size))
+    return fafns
+
+
+# AR name: targ, sky, gfa, scnd, too
+def get_static_desitarget_fns(fafn, name):
+    """
+    Obtain the full paths of the input static (=not MTL except for ToOs) desitarget catalogs
+        which have been used to design the tile.
+
+    Args:
+        fafn: full path to the fiberassign file name (fiberassign-ABCDE.fits.gz) (str)
+        name: "targ", "scnd", "too", "sky", or "gfa" (str)
+
+    Returns:
+        fns: list of static desitarget catalogs (list of strs)
+
+    Notes:
+        The function fixes all the "historical" inconsistencies in the paths.
+        Note that the return "catalogs" paths can be folders.
+    """
+    tileid = get_tileid_from_fafn(fafn)
+
+    # AR valid name?
+    if name not in all_names:
+        msg = "{:06d}\tNAME={} not allowed".format(tileid, name)
+        log.error(msg)
+        raise ValueError(msg)
+
+    # AR get relevant paths
+    fahdr = fits.getheader(fafn, 0)
+    hdrkeys = [name.upper()]
+
+    # AR check for possible additional secondary folders
+    # AR and also for targ, as it happens for 80901 and 80865
+    # AR    (but that could be the only cases)
+    for i in range(2, 100):
+        if (name == "targ") & ("TARG{}".format(i) in fahdr):
+            hdrkeys.append("TARG{}".format(i))
+        if (name == "scnd") & ("SCND{}".format(i) in fahdr):
+            hdrkeys.append("SCND{}".format(i))
+    if (name == "sky") & ("SKYSUPP" in fahdr):
+        hdrkeys.append("SKYSUPP")
+    log.info(
+        "{:06d}\t{}\tcheck {} hdrkeys".format(
+            tileid, name.upper().ljust(11), ",".join(hdrkeys)
+        )
+    )
+
+    # AR fns can be empty (e.g. TOO for early tiles)
+    fns = [fahdr[hdrkey] for hdrkey in hdrkeys if hdrkey in fahdr]
+    # AR special case for 80615...
+    if (tileid == 80615) & (name == "targ"):
+        fns.append(
+            os.path.join(
+                os.getenv("DESI_TARGET"),
+                "catalogs",
+                "gaiadr2",
+                "0.47.0",
+                "targets",
+                "cmx",
+                "resolve",
+                "supp",
+            )
+        )
+
+    # AR fixing paths...
+    for i in range(len(fns)):
+        fn = fns[i]
+        fn = fn.replace(
+            "DESIROOT/target/catalogs/mtl/1.1.1/mtl/main/ToO/ToO.ecsv",
+            "{}/mtl/main/ToO/ToO.ecsv".format(os.getenv("DESI_SURVEYOPS")),
+        )
+        fn = fn.replace(
+            "DESIROOT/survey/ops/staging/mtl/main/ToO/ToO.ecsv",
+            "{}/mtl/main/ToO/ToO.ecsv".format(os.getenv("DESI_SURVEYOPS")),
+        )
+        # AR case where the path is generically defined, but not used (no mtl for sv1)
+        fn = fn.replace(
+            "DESIROOT/survey/ops/surveyops/trunk/mtl/sv1/ToO/ToO.ecsv",
+            "-",
+        )
+        # AR case where the path is generically defined, but not used (no mtl for sv1)
+        fn = fn.replace(
+            "DESIROOT/survey/ops/surveyops/trunk/mtl/sv2/ToO/ToO.ecsv",
+            "-",
+        )
+        fn = fn.replace(
+            "DESIROOT/target/catalogs/dr9/0.58.0/targets/main/secondary/dark/maintargets-dark-secondary.fits",
+            "DESIROOT/target/catalogs/dr9/0.58.0/targets/main/secondary/dark/targets-dark-secondary.fits",
+        )
+        # AR case where the path is generically defined, but not used (81096-81099; no secondaries for sv2)
+        fn = fn.replace(
+            "DESIROOT/target/catalogs/dr9/0.53.0/targets/sv2/secondary/dark/sv2targets-dark-secondary.fits",
+            "-",
+        )
+        if name == "scnd":
+            txt = os.path.sep.join(fn.split(os.path.sep)[-3:])
+            if txt in ["sv1/secondary/bright", "sv1/secondary/dark"]:
+                prog = fn.split(os.path.sep)[-1]
+                fn = os.path.join(fn, "sv1targets-{}-secondary.fits".format(prog))
+        fn = fn.replace("DESIROOT", os.getenv("DESI_ROOT"))
+        fn = fn.replace("/data/target", os.getenv("DESI_TARGET"))
+        fn = fn.replace(
+            "/data/afternoon_planning/surveyops/trunk", os.getenv("DESI_SURVEYOPS")
+        )
+        fn = fn.replace(
+            "/global/cscratch1/sd/adamyers/gaiadr2/1.3.0.dev5218/targets/main/resolve/backup",
+            "{}/catalogs/gaiadr2/2.2.0/targets/main/resolve/backup".format(
+                os.getenv("DESI_TARGET")
+            ),
+        )
+        if fn != fns[i]:
+            log.info(
+                "{:06d}\t{}\treplacing {} by {}".format(
+                    tileid, name.upper().ljust(11), fns[i], fn
+                ),
+            )
+        fns[i] = fn
+    for fn in fns:
+        log.info("{:06d}\t{}\t{}".format(tileid, name.upper().ljust(11), fn))
+        if fn != "-":
+            if (fn[-5:] == ".fits") | (fn[-5:] == ".ecsv"):
+                if not os.path.isfile(fn):
+                    msg = "{:06d}\t{}\tmissing {}".format(
+                        tileid, name.upper().ljust(11), fn
+                    )
+                    log.error(msg)
+                    raise IOError(msg)
+            else:
+                if not os.path.isdir(fn):
+                    msg = "{:06d}\t{}\tmissing {}".format(
+                        tileid, name.upper().ljust(11), fn
+                    )
+                    log.error(msg)
+                    raise IOError(msg)
+    return fns
+
+
+_scnd_radec_cache = {}
+
+
+def read_scnd_radec(fn, columns=["RA", "DEC"]):
+    """
+    Reads the RA,DEC columns of a secondary *.fits catalog.
+
+    Args:
+        fn: full path to the secondary catalog (str)
+
+    Returns:
+        The secondary catalog with RA,DEC columns (Table() array)
+
+    Notes:
+        To speed up, the catalog is cached.
+    """
+    global _scnd_radec_cache
+    try:
+        log.info("using cached {}".format(fn))
+        return _scnd_radec_cache[fn]
+    except KeyError:
+        pass
+    log.info("reading {}".format(fn))
+    assert fn[-5:] == ".fits"
+    _scnd_radec_cache[fn] = Table(fitsio.read(fn, columns=["RA", "DEC"]))
+    return _scnd_radec_cache[fn]
+
+
+def get_tiles(fafn):
+    """
+    Generate of "fake" tiles array for a given fiberassign file.
+
+    Args:
+        fafn: path to the fiberassign file (fiberassign-TILEID.fits.gz) (str)
+
+    Returns:
+        Table() array with TILEID,RA,DEC,IN_DESI,OBSCONDITIONS (Table() array)
+
+    Notes:
+        This is to be used in e.g. desitarget.io.read_targets_in_tiles()
+    """
+    fahdr = fits.getheader(fafn, 0)
+    tiles = Table()
+    tiles["TILEID"] = [fahdr["TILEID"]]
+    tiles["RA"] = [fahdr["TILERA"]]
+    tiles["DEC"] = [fahdr["TILEDEC"]]
+    tiles["IN_DESI"] = 1  # AR forcing 1, irrespective of location
+    tiles["OBSCONDITIONS"] = obsconditions.mask("DARK|GRAY|BRIGHT|BACKUP")
+    return tiles
+
+
+def get_desitarget_fafn_rows(fafn, ras, decs):
+    """
+    Returns the rows of (ras,decs) falling inside the fafn tile.
+
+    Args:
+        fafn: path to the fiberassign file (fiberassign-TILEID.fits.gz) (str)
+        ras: R.A. values (np.array())
+        decs: Dec. values (np.array())
+
+    Returns:
+        rows: indexes of ras,decs (list of ints)
+
+    """
+    tiles = get_tiles(fafn)
+    nside, nest = pixarea2nside(7.0), True
+    pixlist = tiles2pix(nside, tiles=tiles)
+    pixs = hp.ang2pix(nside, np.radians((90.0 - decs)), np.radians(ras), nest=nest)
+    ii = np.where(np.in1d(pixs, pixlist))[0]
+    jj = is_point_in_desi(tiles, ras[ii], decs[ii])
+    rows = ii[jj]
+    return rows
+
+
+def read_fafn_static_desitarget_name(fafn, name):
+    """
+    Reads a desitarget static catalog for a given fiberassign file.
+
+    Args:
+        fafn: path to the fiberassign file (fiberassign-TILEID.fits.gz) (str)
+        name: "targ", "scnd", "too", "sky", or "gfa" (str)
+
+    Returns:
+        d: targets catalog covered by the tile (Table() array)
+
+    Notes:
+        If several "inputs" (e.g. SCND and SCND2 in fafn header), the
+            catalogs are concatenated into one.
+    """
+    tileid = get_tileid_from_fafn(fafn)
+    fns = get_static_desitarget_fns(fafn, name)
+    fns = [fn for fn in fns if fn != "-"]
+    if len(fns) == 0:
+        d = None
+    else:
+        # AR fake tiles file
+        tiles = get_tiles(fafn)
+        # AR
+        ds = []
+        for fn in fns:
+            log.info(
+                "{:06d}\t{}\treading {}".format(tileid, name.upper().ljust(11), fn)
+            )
+            # AR fn is a catalog file
+            if fn[-5:] == ".fits":
+                assert name == "scnd"
+                radecs = read_scnd_radec(fn)
+                rows = get_desitarget_fafn_rows(fafn, radecs["RA"], radecs["DEC"])
+                d = Table(fitsio.read(fn, rows=rows))
+            elif fn[-5:] == ".ecsv":
+                d = Table.read(fn)
+                rows = get_desitarget_fafn_rows(fafn, d["RA"], d["DEC"])
+                d = d[rows]
+            # AR fn is a folder
+            else:
+
+                d = Table(read_targets_in_tiles(fn, tiles=tiles, quick=True))
+            ds.append(d)
+        d = vstack(ds)
+    return d
+
+
+def read_fafn_static_desitarget_names(fafn, names=all_names):
+    """
+    Reads all the desitarget static catalogs for a given fiberassign file.
+
+    Args:
+        fafn: path to the fiberassign file (fiberassign-TILEID.fits.gz) (str)
+        names (optional, defaults to ["targ", "scnd", "too", "sky", or "gfa"]:
+            list of fafn header keywords, restricted to "targ", "scnd", "too", "sky", or "gfa"
+            (list of strs)
+
+    Returns:
+        ds: dictionary of targets catalog covered by the tile, with one key
+            for each element of names, containing a Table() array (dict)
+    """
+
+    tileid = get_tileid_from_fafn(fafn)
+    # AR fiberassign header
+    fahdr = fits.getheader(fafn, 0)
+
+    # AR desitarget input files
+    ds = {}
+    for name in names:
+        if name in fahdr:
+            d = read_fafn_static_desitarget_name(fafn, name)
+            if d is not None:
+                ds[name] = d
+        else:
+            log.warning(
+                "{:06d}\t{}\tnot in header".format(tileid, name.upper().ljust(11)),
+            )
+    return ds
+
+
+def get_dith_infos(ext, name, fafn, fa_name):
+    """
+    Obtain per-row information if dithering is applied or not for a
+        fiberassign file.
+
+    Args:
+        ext: fiberassign extension (just used for logging) (str)
+        name: "targ", "scnd", "too", "sky", or "gfa" (str)
+        fafn: path to the fiberassign file (fiberassign-TILEID.fits.gz) (str)
+        fa_name: Table() array from the ext extension of fiberassign (Table() array)
+
+    Returns:
+        isdith: dithering is applied? (array of bools)
+    """
+
+    isdith = np.zeros(len(fa_name), dtype=bool)
+
+    # AR the dithering is for name = "targ" only
+    # AR identifying the dithered rows
+    fahdr = fits.getheader(fafn, 0)
+    if (name == "targ") & (fahdr["FAFLAVOR"] in ["dithprec", "dithlost", "dithfocus"]):
+        h = fits.open(fafn)
+        if "EXTRA" in [h[i].header["EXTNAME"] for i in range(1, len(h))]:
+            fa_undith = h["EXTRA"].data
+            sel = np.in1d(fa_name["TARGETID"], fa_undith["TARGETID"])
+            isdith[sel] = True
+            print(name, sel.sum())
+    log.info(
+        "{:06d}\t{}\t{}\tdith: found {} rows".format(
+            fahdr["TILEID"], ext.ljust(11), name.upper(), isdith.sum()
+        )
+    )
+
+    return isdith
+
+
+def get_pmcorr_infos(ext, name, fahdr, fa_name, d_name):
+    """
+    Obtain per-row information if proper-motion correction is applied or not for a
+        fiberassign file.
+
+    Args:
+        ext: fiberassign extension (just used for logging) (str)
+        name: "targ", "scnd", "too", "sky", or "gfa" (str)
+        fahdr: fiberassign 0-extension header (header array)
+        fa_name: Table() array from the ext extension of fiberassign (Table() array)
+        d_name: Table() from the static desitarget catalog, row-matched to fa_name
+            (Table() array)
+
+    Returns:
+        ispmcorr: proper-motion is applied? (array of bools)
+        iscmx33std: 80615-specific information, is it a standard star (array of bools)
+
+    Notes:
+        iscmx33std will be all False, except for TILEID=80615.
+    """
+    # AR for cmx,sv1 we did correct for proper-motion,
+    # AR    except for:
+    # AR    - fba_cmx early dith* tiles (targ and gfa at different times)
+    # AR    - cmxm33 (80615) for standards which are not science targets
+    # AR we identify here objects passing the criterion
+    # AR remarks:
+    # AR - hard-coding gaia/dr2 here (i.e. not using gaia/edr3)
+    # AR - we use the desitarget values, as fa values can be bugged
+    # AR - in fba_sv1, for "scnd", we pm-corrected for all rows with REF_EPOCH>0
+    # AR - we updated REF_EPOCH for all rows (except for cmxm33 stds)
+    pmcorr = False
+    ispmcorr = np.zeros(len(d_name), dtype=bool)
+    iscmx33std = np.zeros(len(d_name), dtype=bool)
+    if (fahdr["FA_SURV"] in ["cmx", "sv1"]) & (name != "sky"):
+        if fahdr["FAFLAVOR"] in ["dithprec", "dithlost", "dithfocus"]:
+            if (name == "gfa") & (fahdr["TILEID"] > 80171):
+                pmcorr = True
+            if (name == "targ") & (fahdr["TILEID"] > 80604):
+                pmcorr = True
+        else:
+            pmcorr = True
+
+    if pmcorr:
+        if name == "scnd":
+            ispmcorr = d_name["REF_EPOCH"] > 0
+        else:
+            gaia_aens, gaia_gs = (
+                d_name["GAIA_ASTROMETRIC_EXCESS_NOISE"],
+                d_name["GAIA_PHOT_G_MEAN_MAG"],
+            )
+            ispmcorr = gaia_psflike(gaia_aens, gaia_gs, dr="dr2")
+            # AR exluding cmxm33 standards which are not science targets
+            if (name == "targ") & (fahdr["FAFLAVOR"] == "cmxm33"):
+                from desitarget.cmx.cmx_targetmask import cmx_mask
+
+                std_mask = cmx_mask.mask("SV0_WD|STD_BRIGHT")
+                sci_mask = cmx_mask.mask(
+                    "SV0_WD|M33_H2PN|M33_GC|M33_QSO|M33_M33cen|M33_M33out|SV0_QSO|SV0_LRG|SV0_ELG"
+                )
+                iscmx33std = (d_name["CMX_TARGET"] & std_mask) > 0
+                iscmx33std &= (d_name["CMX_TARGET"] & sci_mask) == 0
+                ispmcorr &= ~iscmx33std
+
+        # AR verify that in that case, all REF_EPOCH values have been set to the same value
+        # AR (exclude the cmxm33 standards)
+        if "REF_EPOCH" in fa_name.dtype.names:
+            n = np.unique(fa_name["REF_EPOCH"][~iscmx33std]).size
+            if n != 1:
+                msg = "{:06d}\t{}\t{}\tfound {} unique values of REF_EPOCH; expected one".format(
+                    fahdr["TILEID"], ext.ljust(11), name.upper(), n
+                )
+                log.error(msg)
+                raise ValueError(msg)
+    log.info(
+        "{:06d}\t{}\t{}\tpmcorr: found {}/{} rows".format(
+            fahdr["TILEID"], ext.ljust(11), name.upper(), ispmcorr.sum(), ispmcorr.size
+        )
+    )
+    if "REF_EPOCH" in d_name.dtype.names:
+        log.info(
+            "{:06d}\t{}\t{}\tpmcorr: REF_EPOCH updated for {}/{} rows".format(
+                fahdr["TILEID"],
+                ext.ljust(11),
+                name.upper(),
+                (~iscmx33std).sum(),
+                ispmcorr.size,
+            )
+        )
+    return ispmcorr, iscmx33std
+
+
+def get_fbaonly_keys():
+    """
+    Returns the columns defined by fiberassign which are not present in the desitarget catalogs.
+
+    Args:
+        None
+
+    Returns:
+        keys: dictionary, with one key per fiberassign extension, containing the list of columns (dict)
+
+    """
+    keys = {
+        "FIBERASSIGN": [
+            "FIBER",
+            "LOCATION",
+            "FIBERSTATUS",
+            "LAMBDA_REF",
+            "PETAL_LOC",
+            "DEVICE_LOC",
+            "DEVICE_TYPE",
+            "FA_TARGET",
+            "FA_TYPE",
+            "FIBERASSIGN_X",
+            "FIBERASSIGN_Y",
+            "PLATE_RA",
+            "PLATE_DEC",
+        ]
+        + ["OBJTYPE"],
+        "SKY_MONITOR": [
+            "FIBER",
+            "LOCATION",
+            "FA_TARGET",
+            "FA_TYPE",
+            "FIBERASSIGN_X",
+            "FIBERASSIGN_Y",
+            "FIBERSTATUS",
+            "PETAL_LOC",
+            "DEVICE_LOC",
+            "PRIORITY",
+        ],
+        "GFA_TARGETS": ["ETC_FLAG", "FOCUS_FLAG", "GFA_LOC", "GUIDE_FLAG"],
+        "TARGETS": ["FA_TARGET", "FA_TYPE", "PLATE_RA", "PLATE_DEC"],
+    }
+    return keys
+
+
+# AR we rename some columns to match the original name
+# AR see fiberassign.assign merged_fiberassign_swap
+# AR APFLUX_... disappeared at some point in the fiberassign files...
+def fa_key_backswap(fa, ext):
+    """
+    Renaming some columns to match the original name in the static desitarget catalogs.
+
+    Args:
+        fa: Table() array for a fiberassign extension data (Table() array)
+        ext: fiberassign extension from which comes fa (str)
+
+    Returns:
+        fa: same as input, but with modified column names.
+    """
+    if ext in ["FIBERASSIGN", "SKY_MONITOR", "GFA_TARGETS"]:
+        fa["TARGET_RA"].name, fa["TARGET_DEC"].name = "RA", "DEC"
+        if ext == "GFA_TARGETS":
+            fa["TARGET_RA_IVAR"].name, fa["TARGET_DEC_IVAR"].name = (
+                "RA_IVAR",
+                "DEC_IVAR",
+            )
+    if ext in ["TARGETS"]:
+        for key in [
+            "APFLUX_G",
+            "APFLUX_R",
+            "APFLUX_Z",
+            "APFLUX_IVAR_G",
+            "APFLUX_IVAR_R",
+            "APFLUX_IVAR_Z",
+        ]:
+            if key in fa.dtype.names:
+                fa[key].name = key.replace("APFLUX", "FIBERFLUX")
+    return fa
+
+
+def get_names_to_check(ext):
+    """
+    For a given fiberassign extension, returns the list of names to check.
+
+    Args:
+        ext: fiberassign extension (str)
+
+    Returns:
+        ext_names: list of names to check (list of strs)
+
+    Notes:
+        Names are picked form "targ", "scnd", "too", "sky", "gfa".
+    """
+    if ext in ["FIBERASSIGN", "TARGETS"]:
+        ext_names = ["targ", "sky", "scnd", "too"]
+    elif ext in ["SKY_MONITOR"]:
+        ext_names = ["sky"]
+    elif ext in ["GFA_TARGETS"]:
+        ext_names = ["gfa"]
+    else:
+        raise ValueError("unexpected ext={}; exiting".format(ext))
+    return ext_names
+
+
+# AR black keys
+def get_black_keys(name, fafn):
+    """
+    Returns a list of keys to ignore for fiberassign patching diagnosis.
+
+    Args:
+        name: "targ", "scnd", "too", "sky", or "gfa" (str)
+        fafn: path to the fiberassign file (fiberassign-TILEID.fits.gz) (str)
+
+    Returns:
+        black_keys: list of columns to ignore (list of strs)
+
+    Notes:
+        This function is mostly handling the chaotic fiberassign
+            evolution in the first months of DESI.
+        The PRIORITY,PRIORITY_INIT,NUMOBS_INIT columns are always
+            black-listed, as they are fa-sensitive columns.
+    """
+    # AR check all keys
+    # AR but:
+    # AR - PRIORITY,PRIORITY_INIT,NUMOBS_INIT: fa-sensitive keys
+    # AR        (and often re-set by fiberassign, e.g. cmx/sv1, sv3/main mtl)
+    # AR - OBSCONDITIONS: re-set by fiberassign
+    # AR - FLUX_R against "gfa" (only for GFA_TARGETS), as fiberassign modifies it
+    # AR - EBV against "sky", "scnd" and "too", as those do not have EBV
+    # AR        (fiberassign fills the EBV value since fiberassign/5.4.0)
+    # AR - SUBPRIORITY, when it was overwritten by fiberassign:
+    # AR    - FA_VER < 5.0.0 (fixed in fba_launch in fiberassign/5.0.0)
+    # AR    - FA_SURV != "main" (the fix did not apply for fba_cmx/fba_sv1
+    # AR    - TILEIDS=82401-82409, designed with adamyers/gaiadr2/1.3.0.dev5218, different SUBPRIORITY...
+    # AR OBSCONDITIONS:
+    #       - reset in fba_cmx/fba_sv1 for targ,scnd
+    #       - (can be) different in mtl vs. static desitarget...
+    fahdr = fits.getheader(fafn, 0)
+    black_keys = []
+    black_keys += [
+        "PRIORITY",
+        "PRIORITY_INIT",
+        "NUMOBS_INIT",
+    ]
+    if name in ["sky", "scnd", "too"]:
+        black_keys += ["EBV"]
+    if name == "gfa":
+        black_keys += ["FLUX_R"]
+    if (
+        (fahdr["FA_VER"] < "5.0.0")
+        | (fahdr["FA_SURV"] != "main")
+        | (
+            fahdr["TILEID"]
+            in [82401, 82402, 82403, 82404, 82405, 82406, 82407, 82408, 82409]
+        )
+    ):
+        black_keys += ["SUBPRIORITY"]
+    if name in ["targ", "scnd"]:
+        if (
+            (fahdr["FA_SURV"] in ["cmx", "sv1"])
+            | ((name == "targ") & ("MTL" in fahdr))
+            | ((name == "scnd") & ("SCNDMTL" in fahdr))
+        ):
+            black_keys += ["OBSCONDITIONS"]
+    black_keys = np.unique(black_keys)
+    return black_keys
+
+
+# AR shall not use Table.read() ! (it messes up things... with "masking" some columns)
+def diagnose_values_fafn(fafn):
+    """
+    Execute diagnostic of discrepant values between the fiberassign file
+        and the input static desitarget catalogs.
+
+    Args:
+        fafn: path to the fiberassign file (fiberassign-TILEID.fits.gz) (str)
+
+    Returns:
+        d: a Table() array with the discrepant values (Table() array)
+
+    Notes:
+        The comparison ignores some expected/understood discrepancies.
+        The column content of the output is:
+            "FAFN": fiberassign file name
+            "TILEID": tileid
+            "FAFLAVOR": faflavor
+            "FA_VER": fiberassign version
+            "PMTIME": time when the tile was designed
+            "LASTNIGHT": last night of observation for that tile (-99 if not observed)
+            "EXTENSION": fiberassign extension
+            "TARGETID": targetid
+            "ORIGFN": path to the static desitarget catalog
+            "KEY": column name
+            "ORIGVAL": value in the desitarget catalog, converted to string ("none" if the column is not present)
+            "FAVAL": value in the fiberassign file
+    """
+
+    # AR tileid
+    tileid = get_tileid_from_fafn(fafn)
+    log.info("{:06d}\t{}\t{}".format(tileid, "FAFN".ljust(11), fafn))
+
+    # AR
+    fbaonly_keys = get_fbaonly_keys()
+
+    #
+    myd = {
+        key: []
+        for key in ["EXTENSION", "TARGETID", "ORIGFN", "KEY", "ORIGVAL", "FAVAL"]
+    }
+
+    # AR fiberassign header
+    fahdr = fits.getheader(fafn, 0)
+
+    # AR desitarget input files
+    ds = read_fafn_static_desitarget_names(fafn, names=all_names)
+
+    # AR check differences for each ext
+    for ext in all_exts:
+        fa = Table(fitsio.read(fafn, ext=ext))
+        # AR we restrict to TARGETID > 0
+        # AR that removes:
+        # AR - unassigned / stuck sky fibers
+        # AR - TARGETID=-1 in GFA_TARGETS
+        fa = fa[fa["TARGETID"] > 0]
+        log.info(
+            "{:06d}\t{}\t{} rows with TARGETID>0".format(tileid, ext.ljust(11), len(fa))
+        )
+
+        # AR we rename some columns to match the original name
+        # AR see fiberassign.assign merged_fiberassign_swap
+        # AR APFLUX_... disappeared at some point in the fiberassign files...
+        fa = fa_key_backswap(fa, ext)
+
+        # AR verify that TARGETIDs are unique
+        assert np.unique(fa["TARGETID"]).size == len(fa)
+
+        # AR names to check
+        ext_names = get_names_to_check(ext)
+
+        # AR now cutting on existing files
+        ext_names = [name for name in ext_names if name in ds]
+
+        # AR to record what rows are matched
+        ii_match = []
+
+        for name in ext_names:
+
+            # AR verify that TARGETIDs are unique
+            # AR exception for 80865, where three TARG catalogs are used
+            try:
+                assert np.unique(ds[name]["TARGETID"]).size == len(ds[name]["TARGETID"])
+            except AssertionError:
+                _, ii = np.unique(ds[name]["TARGETID"], return_index=True)
+                ds[name] = ds[name][ii]
+                log.warning(
+                    "{:06d}\t{}\t{}\tsome duplicates TARGETID; picking a unique list..".format(
+                        tileid, ext.ljust(11), name.upper()
+                    ),
+                )
+
+            # AR cut catalogs on matched objects
+            ii, iid = match(fa["TARGETID"], ds[name]["TARGETID"])
+            log.info(
+                "{:06d}\t{}\t{}\t{}/{} matched rows".format(
+                    tileid, ext.ljust(11), name.upper(), ii.size, len(fa)
+                )
+            )
+            ii_match += ii.tolist()
+
+            if ii.size > 0:
+
+                fa_name, d_name = fa[ii], ds[name][iid]
+                keys = np.array(fa_name.dtype.names)
+                extname_diffs = {key: -99 for key in keys}
+
+                # AR proper-motion correction infos
+                ispmcorr, iscmx33std = get_pmcorr_infos(
+                    ext, name, fahdr, fa_name, d_name
+                )
+
+                # AR dithering infos
+                isdith = get_dith_infos(ext, name, fafn, fa_name)
+
+                # AR check all keys, except black_keys
+                black_keys = get_black_keys(name, fafn)
+                check_keys = [
+                    key
+                    for key in keys
+                    if key not in black_keys and key not in fbaonly_keys[ext]
+                ]
+                log.info(
+                    "{:06d}\t{}\t{}\tblack_keys={}".format(
+                        tileid, ext.ljust(11), name.upper(), ",".join(black_keys)
+                    )
+                )
+                log.info(
+                    "{:06d}\t{}\t{}\tcheck_keys={}".format(
+                        tileid, ext.ljust(11), name.upper(), ",".join(check_keys)
+                    )
+                )
+
+                for key in check_keys:
+                    sel = np.zeros(len(fa_name), dtype=bool)
+                    # AR common key?
+                    if key in d_name.dtype.names:
+                        # AR PARALLAX,PMRA,PMDEC
+                        # AR - for some 'specialm31', 'sv1dc3r2' tiles, format change in desitarget (dtype= ">f8" or ">f4")
+                        # AR - else discrepancy in formatting between fiberassign and desitarget
+                        # AR        (makes difference <= 5e9; we pick 1e8 for simplicity)
+                        if key in ["PARALLAX", "PMRA", "PMDEC"]:
+                            if tileid in [
+                                80971,
+                                80972,
+                                80973,
+                                80974,
+                                80975,
+                                80976,
+                                82634,
+                                82635,
+                            ]:
+                                sel |= np.abs(fa_name[key] - d_name[key]) > 1e-6
+                            else:
+                                sel |= np.abs(fa_name[key] - d_name[key]) > 1e-8
+                        # AR RA,DEC:
+                        # AR - check only for rows with:
+                        # AR    - no proper-motion correction
+                        # AR    - no dithering
+                        elif key in ["RA", "DEC"]:
+                            ignore = ispmcorr.copy()
+                            ignore |= isdith
+                            sel |= (fa_name[key] != d_name[key]) & (~ignore)
+                        # AR REF_EPOCH:
+                        # AR - if some pmcorr, REF_EPOCH updated for all rows (except for iscmx33std)
+                        # AR - ignore cases where fiberassign changed 0 to 2015.5
+                        # AR - also ignore few sv3 tiles, as $DESI_SURVEYOPS/mtl/sv3/ToO/ToO.ecsv
+                        # AR        has been overwritten (orignal rows had REF_EPOCH=0,
+                        # AR        changed to REF_EPOCH=2015.5 in fiberassign; but then the ToO.ecsv
+                        # AR        got overwritten, with updated rows having REF_EPOCH=2000)
+                        # AR - same story for 80980-80981 and $DESI_SURVEYOPS/mtl/main/ToO/ToO.ecsv
+                        elif key == "REF_EPOCH":
+                            if ispmcorr.sum() > 0:
+                                ignore = (~iscmx33std).copy()
+                            else:
+                                # ignore = ispmcorr.copy()
+                                ignore = (d_name[key] == 0) & (fa_name[key] == 2015.5)
+                                if (name == "too") & (
+                                    tileid
+                                    in [466, 518, 519, 532, 533, 534, 80980, 80981]
+                                ):
+                                    ignore |= (d_name[key] == 2000) & (
+                                        fa_name[key] == 2015.5
+                                    )
+                            sel |= (fa_name[key] != d_name[key]) & (~ignore)
+                        # AR other keys
+                        else:
+                            sel |= fa_name[key] != d_name[key]
+                        # AR GAIA_PHOT_{BP,RP}_MEAN_{FLUX_OVER_ERROR,MAG}:
+                        # AR - those columns can have nan...
+                        if key in [
+                            "GAIA_PHOT_BP_MEAN_FLUX_OVER_ERROR",
+                            "GAIA_PHOT_RP_MEAN_FLUX_OVER_ERROR",
+                            "GAIA_PHOT_BP_MEAN_MAG",
+                            "GAIA_PHOT_RP_MEAN_MAG",
+                        ]:
+                            sel &= np.isfinite(d_name[key])
+                    # AR if not, then it should be zero (we already excluded fba-only keys)
+                    else:
+                        if isinstance(fa_name[key][0], str):
+                            sel |= fa_name[key] != ""
+                        else:
+                            sel |= fa_name[key] != 0
+                    n = sel.sum()
+                    extname_diffs[key] = n
+                    # log.info("{:06d}\t{}\t{}\tkey = {} -> {} discrepancies".format(tileid, ext.ljust(11), name, key, n))
+                    if n > 0:
+                        myd["EXTENSION"] += [ext for j in range(n)]
+                        myd["TARGETID"] += fa_name["TARGETID"][sel].tolist()
+                        tmpfn = ",".join(get_static_desitarget_fns(fafn, name))
+                        myd["ORIGFN"] += [tmpfn for j in range(n)]
+                        myd["KEY"] += [key for j in range(n)]
+                        if key in d_name.dtype.names:
+                            myd["ORIGVAL"] += d_name[key][sel].astype(str).tolist()
+                        else:
+                            myd["ORIGVAL"] += ["none" for j in range(n)]
+                        myd["FAVAL"] += fa_name[key][sel].astype(str).tolist()
+                vals = np.unique([extname_diffs[key] for key in keys])
+                vals = [val for val in vals if val not in [-99, 0]]
+                for val in vals:
+                    txt = "ndiff={}".format(str(val).ljust(4))
+                    keystxt = ",".join(
+                        np.sort([key for key in keys if extname_diffs[key] == val])
+                    )
+                    log.info(
+                        "{:06d}\t{}\t{}\t{}\t{}".format(
+                            tileid, ext.ljust(11), name.upper(), txt, keystxt
+                        )
+                    )
+
+        # AR there should not be duplicates in ii_match
+        n_match = len(ii_match)
+        if np.unique(ii_match).size != n_match:
+            msg = "{:06d}\t{}\tmatches have duplicated {} TARGETIDs".format(
+                tileid, name, n_match - np.unique(ii_match).size
+            )
+            log.error(msg)
+            raise ValueError(msg)
+
+        # AR verify that all rows have been matched
+        log.info(
+            "{:06d}\t{}\tall_names\t{}/{} matched rows".format(
+                tileid, ext.ljust(11), n_match, len(fa)
+            )
+        )
+        if n_match != len(fa):
+            msg = "{}:06d\t{}\tn_match={} != len(fa)={}".format(
+                tileid, ext.ljust(11), n_match, len(fa)
+            )
+            # AR mismatch happens for 82405,82406; we do not track it down, just ignore..
+            if tileid in [
+                82401,
+                82402,
+                82403,
+                82404,
+                82405,
+                82406,
+                82407,
+                82408,
+                82409,
+            ]:
+                log.warning(msg)
+                log.warning(
+                    "{:06d}\t{}\tignoring mismatch, as tile designed with /global/cscratch1/sd/adamyers/gaiadr2/1.3.0.dev5218".format(
+                        tileid, ext.ljust(11)
+                    ),
+                )
+            else:
+                log.error(msg)
+                raise ValueError(msg)
+
+    # AR store in a table
+    d = Table()
+    n = len(myd["TARGETID"])
+    log.info("{:06d}\t{}\tall_names\tndiff={}".format(tileid, "all_exts".ljust(11), n))
+    if n > 0:
+        d["FAFN"] = [fafn for j in range(n)]
+        for key in ["TILEID", "FAFLAVOR", "FA_VER", "PMTIME"]:
+            if key not in fahdr:
+                d[key] = "-"  # AR PMTIME
+            else:
+                d[key] = [fahdr[key] for j in range(n)]
+        tiles = Table.read(
+            os.path.join(
+                os.getenv("DESI_ROOT"), "spectro", "redux", "daily", "tiles-daily.csv"
+            )
+        )
+        ii = np.where(tiles["TILEID"] == tileid)[0]
+        keys = ["LASTNIGHT"]
+        if ii.size == 0:
+            for key in keys:
+                d[key] = -99
+        else:
+            for key in keys:
+                d[key] = [tiles[key][ii[0]] for j in range(n)]
+        for key in myd:
+            d[key] = myd[key]
+
+    return d
+
+
+def diagnose_columns_fafn(fafn, ref_tileid=3001):
+    """
+    Execute diagnostic of the column content of the fiberassign file, with
+        comparing with a fiducial Main tile.
+
+    Args:
+        fafn: path to the fiberassign file (fiberassign-TILEID.fits.gz) (str)
+        ref_tileid (optional, defaults to 3001): Main tileid used as a reference (int)
+
+    Returns:
+        d: a Table() array with the column diagnosis.
+
+    Notes:
+        The column content of the output is:
+            "TILEID": tileid
+            "FAFLAVOR": faflavor
+            "FA_VER": fiberassign version
+            "EXTENSION": fiberassign extension
+            "MISS": comma-separated list of missing columns
+            "EXTRA": comma-separated list of extra columns
+    """
+
+    # AR survey-specific keys
+    main_dt_keys = ["DESI_TARGET", "BGS_TARGET", "MWS_TARGET", "SCND_TARGET"]
+    main2surv_dtkeys = {
+        "cmx": {
+            key: "CMX_TARGET" if key == "DESI_TARGET" else None for key in main_dt_keys
+        },
+        "main": {key: key for key in main_dt_keys},
+    }
+    for surv in ["sv1", "sv2", "sv3"]:
+        main2surv_dtkeys[surv] = {
+            key: "{}_{}".format(surv.upper(), key) for key in main_dt_keys
+        }
+
+    # AR survey for fafn
+    h = fits.open(fafn)
+    _, _, surv = main_cmx_or_sv(h["FIBERASSIGN"].data)
+    if surv not in main2surv_dtkeys:
+        msg = "{}\tunexpected surv={}".format(fafn, surv)
+        log.error(msg)
+        raise ValueError(msg)
+
+    # AR reference set of columns
+    ref_tileidpad = "{:06d}".format(ref_tileid)
+    ref_fafn = os.path.join(
+        os.getenv("DESI_TARGET"),
+        "fiberassign",
+        "tiles",
+        "trunk",
+        ref_tileidpad[:3],
+        "fiberassign-{}.fits.gz".format(ref_tileidpad),
+    )
+    ref_fahdr = fits.getheader(ref_fafn, 0)
+    if ref_fahdr["FA_SURV"] != "main":
+        msg = "ref_tileid={} (FA_SURV={}) is not a Main tile".format(
+            ref_tileid, ref_fahdr["FA_SURV"]
+        )
+        log.error(msg)
+        raise ValueError(msg)
+
+    ref_h = fits.open(ref_fafn)
+    keys = {}
+    for ext in all_exts:
+        keys[ext] = []
+        for key in ref_h[ext].columns.names:
+            if key in main_dt_keys:
+                if main2surv_dtkeys[surv][key] is not None:
+                    keys[ext].append(main2surv_dtkeys[surv][key])
+                # AR DESI_TARGET,BGS_TARGET,MWS_TARGET are always present in FIBERASSIGN and TARGETS because of skies...
+                if (
+                    (ext in ["FIBERASSIGN", "TARGETS"])
+                    & (surv != "main")
+                    & (key in ["DESI_TARGET", "BGS_TARGET", "MWS_TARGET"])
+                ):
+                    keys[ext].append(key)
+            else:
+                keys[ext].append(key)
+
+    #
+    d = Table()
+    for key in ["TILEID", "FA_VER", "FAFLAVOR"]:
+        d[key] = [h[0].header[key] for ext in all_exts]
+    d["EXTENSION"] = all_exts
+    d["MISS"] = np.array(
+        [
+            ",".join([key for key in keys[ext] if key not in h[ext].columns.names])
+            for ext in all_exts
+        ]
+    )
+    d["EXTRA"] = np.array(
+        [
+            ",".join([key for key in h[ext].columns.names if key not in keys[ext]])
+            for ext in all_exts
+        ]
+    )
+    # AR replace "" by "-"
+    d["MISS"][d["MISS"] == ""] = "-"
+    d["EXTRA"][d["EXTRA"] == ""] = "-"
+
+    return d

--- a/py/fiberassign/fba_patch_io.py
+++ b/py/fiberassign/fba_patch_io.py
@@ -51,31 +51,31 @@ def get_tileid_from_fafn(fafn):
     return int(os.path.basename(fafn)[12:18])
 
 
-def get_fafns_to_check(fasource, debug=False):
+def get_fafns_to_check(fa_srcdir, debug=False):
     """
     List of fiberassign files to check for patching diagnosis.
 
     Args:
+        fa_srcdir: source folder for input fiberassign files (str)
         fasource: "svn" only for now (str)
         debug (optional, defaults to False): if set, picks one fiberassign file per FAFLAVOR (bool)
 
     Returns:
         fafns: list of fiberassign files to check (np.array())
+
+    Notes:
+        The function will look for {fa_srcdir}/???/fiberassign-??????.fits.gz files.
     """
-    log.info("fasource = {}".format(fasource))
-    if fasource == "svn":
-        fafns = np.sort(
-            glob(
-                os.path.join(
-                    os.getenv("DESI_TARGET"),
-                    "fiberassign",
-                    "tiles",
-                    "trunk",
-                    "???",
-                    "fiberassign-??????.fits*",
-                )
+    log.info("fa_srcdir = {}".format(fa_srcdir))
+    fafns = np.sort(
+        glob(
+            os.path.join(
+                fa_srcdir,
+                "???",
+                "fiberassign-??????.fits*",
             )
         )
+    )
     log.info("start with {} fiberassign-TILEID.fits* files".format(fafns.size))
     tileids = np.array([get_tileid_from_fafn(fafn) for fafn in fafns])
     # AR 50000 <= TILEID < 80000

--- a/py/fiberassign/fba_patch_io.py
+++ b/py/fiberassign/fba_patch_io.py
@@ -1413,7 +1413,7 @@ def patch(in_fafn, out_fafn, params_fn):
             os.makedirs(outdir)
 
         # DL write out output file, leaving other HDUs unchanged.
-        f, tempout = tempfile.mkstemp(dir=outdir, suffix=".fits")
+        f, tempout = tempfile.mkstemp(dir=outdir, suffix=".fits.gz")
         os.close(f)
         Fout = fitsio.FITS(tempout, "rw", clobber=True)
         # DL/AR fitsio will add its own headers about the FITS format

--- a/py/fiberassign/fba_patch_io.py
+++ b/py/fiberassign/fba_patch_io.py
@@ -131,7 +131,7 @@ def get_fafns_to_check(fa_srcdir, skip_subdirs=None, only_subdirs=None, only_til
         sel = np.in1d(tileids, [int(tileid) for tileid in only_tileids.split(",")])
         log.info(
             "{}\trestrict to {} fiberassign files, as per only_tileids".format(
-                subdir, sel.sum()
+                only_tileids, sel.sum()
             )
         )
         fafns, tileids, subdirs = fafns[sel], tileids[sel], subdirs[sel]


### PR DESCRIPTION
This PR prepares the Fall 2022 patching (dubbed "patch_202210") of the fiberassign files.
Patched files (in `$DESI_ROOT/users/raichoor/fiberassign-patch/20220928-patch`) still need to be vetted, but I am opening the PR as Work In Progress.

The first patching was done on Oct. 5, 2021.

This PR should addresses multiple raised issues (e.g., https://github.com/desihub/fiberassign/pull/375. https://github.com/desihub/fiberassign/issues/403, https://github.com/desihub/fiberassign/issues/423, https://github.com/desihub/fiberassign/issues/432, https://github.com/desihub/fiberassign/issues/433).

**_Patching approach:_**

The patching philosophy is:
- start from the svn fiberassign.fits.gz files (discarding some commissioning tiles, but not restricting to  observed tiles);
- use as "truth" the desitarget catalogs (not the fiberassign intermediate files);
- patch (remaining) discrepancies between the fiberassign files and the desitarget catalogs;
- write only the modified fiberassign files.

In addition, we agreed to do in the FIBERASSIGN-extension:
- fill the EBV values if those are equal to zero;
- add the FLUX_IVAR_{W1,W2} columns if missing.

The discrepancies can arise from:
- left-over from the row-mixing not patched in the first round of patching;
- patched values from the first round of patching that come from extra-desitarget catalogs (those values could be correct, but we just replace with "zeros" in those cases);
- values not propagated from the desitarget catalogs;
- other things (e.g. SV3_{DESI,SCND}_TARGET values not propagated for early ToOs).

We agreed to let some remaining discrepancies, and just document them.
For instance, few REF_EPOCH values (for PMRA=PMDEC=0 objects), some MWS_TARGET for "specialbackup" test tiles designed with preliminary desitarget catalogs, some early tiles with extra columns, etc.


**_Method:_**

There are three scripts:
- `py/fiberassign/fba_patch_io.py`: utility script with all relevant functions;
- `bin/fba_patch_diagnosis`: execute the diagnosis;
- `bin/fba_patch`: execute the patching, with writing patched files in a separate folder (and save all changes in a fiberassign-TILEID-patching_202210.ecsv file).

And one file:
- `py/fiberassign/data/patching_202210.yaml`: lists the desired patched columns, added columns, and populate_ebv behavior.


**_Test files:_**

My current test files are in: `$DESI_ROOT/users/raichoor/fiberassign-patch`:
- `20220928-diagnosis`: the diagnosis on the svn fiberassign files;
- `20220928-patch`: the patched files;
- `20220928-patch-diagnosis`: sanity check, diagnosis run on the patched files;
- `20220928-patch-patch`: sanity check, patching run on the patched files.

The sanity check have "expected" results with:
- `20220928-patch-diagnosis`:
 - remaining REF_EPOCH discrepancy for SUBDIR=000;
 - "created" EBV inconsistency for non-sky/scnd/too filled values for the FIBERASSIGN-extension for SUBDIR=080,082 (EBV inconsistency for sky/scnd/too are ignored, as we actually do modify those since https://github.com/desihub/fiberassign/pull/414);
- `20220928-patch-patch`: no remaining patching to do on the patched files.

Of course, those tests are kind of circular, so extra-checks are required!


