### PR TITLE
fba_sv1 bugfix: avoid row-mixing

### DIFF
--- a/bin/fba_sv1
+++ b/bin/fba_sv1
@@ -1643,7 +1643,6 @@ def main():
             ag["tiles"] = [tileid]
             ag["columns"] = None
             ag["targets"] = [
-                troot + "-gfa.fits",
                 troot + "-targ.fits",
             ]
             if os.path.isfile(troot + "-std.fits"):


### PR DESCRIPTION
This PR addresses the issue https://github.com/desihub/fiberassign/issues/443.
Technically, that s a not backwards-compatible change (for the better).
Once merged, when creating a new tag including this PR, I don t know if that would deserve to create a new major tag (i.e. 6.0.0), as it s likely we will never use `fba_sv1` to design a tile...