### PR TITLE
fba_launch harmless bugfix: use of too_tile argument in get_desitarget_paths()

### DIFF
--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -192,7 +192,7 @@ def main():
         args.dtver,
         args.survey,
         args.program,
-        args.too_tile,
+        too_tile=args.too_tile,
         dr=args.dr,
         gaiadr=args.gaiadr,
         custom_too_file=args.custom_too_file,


### PR DESCRIPTION
This PR addresses the issue https://github.com/desihub/fiberassign/issues/445.
As said in the issue, this has no effect (i.e. things were running as expected with the bug).