### PR TITLE
Add function to Assignment object, check_avail_collisions(), to check for collisions for potential targets

### DIFF
--- a/collide.py
+++ b/collide.py
@@ -1,0 +1,129 @@
+import numpy as np
+
+from astropy.table import Table
+
+from fiberassign.hardware import load_hardware
+from fiberassign.tiles import load_tiles
+from fiberassign.targets import Targets, TargetsAvailable, LocationsAvailable, create_tagalong, load_target_file, targets_in_tiles
+from fiberassign.assign import Assignment
+
+from fiberassign.utils import Logger
+
+import fitsio
+
+def main():
+
+    # from LSS.mkCat_singletile.fa4lsscat import getfatiles
+    # getfatiles()
+    # return
+    log = Logger.get()
+
+    margins = dict(pos=0.05,
+                   petal=0.4,
+                   gfa=0.4)
+
+    hw = load_hardware(rundate=None, add_margins=margins)
+
+    t = Table.read('/global/cfs/cdirs/desi/survey/catalogs/Y1/LSS/tiles-DARK.fits')
+    print('tiles:', t)
+
+    tile = 1230
+    ts = '%06i' % tile
+
+    fbah = fitsio.read_header('/global/cfs/cdirs/desi/target/fiberassign/tiles/trunk/'+ts[:3]+'/fiberassign-'+ts+'.fits.gz')
+
+    pr = 'DARK'
+    t['OBSCONDITIONS'] = 516
+    t['IN_DESI'] = 1
+    t['MTLTIME'] = fbah['MTLTIME']
+    t['FA_RUN'] = fbah['FA_RUN']
+    t['PROGRAM'] = pr
+
+    t.write('tiles.fits', overwrite=True)
+
+    tiles = load_tiles(
+        tiles_file='tiles.fits',
+        select=[tile])
+
+    tids = tiles.id
+    print('Tile ids:', tids)
+    I = np.flatnonzero(np.array(tids) == tile)
+    assert(len(I) == 1)
+    i = I[0]
+    tile_ra  = tiles.ra[i]
+    tile_dec = tiles.dec[i]
+
+    # Create empty target list
+    tgs = Targets()
+    # Create structure for carrying along auxiliary target data not needed by C++.
+    plate_radec=True
+    tagalong = create_tagalong(plate_radec=plate_radec)
+
+    # Load target files...
+    load_target_file(tgs, tagalong, '/global/cfs/cdirs/desi/survey/catalogs/main/LSS/random0/tilenofa-%i.fits' % tile)
+
+    # Find targets within tiles, and project their RA,Dec positions
+    # into focal-plane coordinates.
+    tile_targetids, tile_x, tile_y, tile_xy_cs5 = targets_in_tiles(hw, tgs, tiles, tagalong)
+    # Compute the targets available to each fiber for each tile.
+    tgsavail = TargetsAvailable(hw, tiles, tile_targetids, tile_x, tile_y)
+    # Compute the fibers on all tiles available for each target and sky
+    favail = LocationsAvailable(tgsavail)
+
+    # FAKE stucksky
+    stucksky = {}
+
+    # Create assignment object
+    asgn = Assignment(tgs, tgsavail, favail, stucksky)
+
+    coll = asgn.check_avail_collisions(tile)
+
+    #print('collisions:', coll)
+    # coll: dict (loc, targetid) -> bitmask
+
+    # All positioner locations -> x,y
+    loc_to_cs5 = hw.loc_pos_cs5_mm;
+    # target -> x,y
+    target_to_xy = dict()
+    for t,x,y in zip(tile_targetids[tile], tile_x[tile], tile_y[tile]):
+        target_to_xy[t] = (x,y)
+
+    goodx = []
+    goody = []
+    badx = []
+    bady = []
+    badval = []
+
+    for k,v in coll.items():
+        loc,targetid = k
+        bitmask = v
+
+        lxy = loc_to_cs5[loc]
+        txy = target_to_xy[targetid]
+
+        if bitmask == 0:
+            goodx.append([lxy[0], txy[0]])
+            goody.append([lxy[1], txy[1]])
+        else:
+            badx.append([lxy[0], txy[0]])
+            bady.append([lxy[1], txy[1]])
+            badval.append(bitmask)
+
+    import pylab as plt
+
+    plt.clf()
+    plt.plot(np.array(goodx).T, np.array(goody).T, '-', color='k', alpha=0.1)
+
+    badval = np.array(badval)
+    badx = np.array(badx)
+    bady = np.array(bady)
+    for val,cc in zip([1,2,4], ['r','m','k']):
+        I = np.flatnonzero(val & badval)
+        plt.plot(badx[I,:].T, bady[I,:].T, '-', color=cc)
+    plt.savefig('collide.png')
+
+    plt.axis([0, 200, -400, -200])
+    plt.savefig('collide2.png')
+
+if __name__ == '__main__':
+    main()

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,9 +6,11 @@ fiberassign change log
 5.7.2 (unreleased)
 ------------------
 
+* Add Assignment.check_avail_collisions(tile, all_matches=False) to check potential assignments for collisions (PR `#454`_).
 * uses the focalplane radius from DESIMODEL instead of the hardcoded version in fiberassign (PR `#453`_).
 
 .. _`#453`: https://github.com/desihub/fiberassign/pull/453
+.. _`#454`: https://github.com/desihub/fiberassign/pull/454
 
 5.7.1 (2023-02-06)
 ------------------

--- a/py/fiberassign/test/collide.py
+++ b/py/fiberassign/test/collide.py
@@ -1,3 +1,7 @@
+'''
+This is a little demo script for the Assignment.check_avail_collisions() function.
+'''
+
 import numpy as np
 
 from astropy.table import Table
@@ -79,7 +83,12 @@ def main():
     coll = asgn.check_avail_collisions(tile)
 
     #print('collisions:', coll)
+    print('N collisions:', len(coll))
     # coll: dict (loc, targetid) -> bitmask
+
+    # For plotting: collect bitmasks for all collisions (even non-collisions)
+    coll = asgn.check_avail_collisions(tile, True)
+    print('Incl non-collisions:', len(coll))
 
     # All positioner locations -> x,y
     loc_to_cs5 = hw.loc_pos_cs5_mm;

--- a/src/_pyfiberassign.cpp
+++ b/src/_pyfiberassign.cpp
@@ -1609,15 +1609,15 @@ PYBIND11_MODULE(_internal, m) {
             Return a bitmask describing the collisions for each potential assignment
             for a given tile.
 
-            This returns a map from TARGETID to a bitmask:
+            This returns a dict from (LOCID, TARGETID) to a bitmask:
                 1: BROKEN or STUCK positioner
                 2: collision with STUCK positioner
                 4: collision with GFA or petal edge
 
             Args:
                 tile (int): The tile ID.
-                all_matches (bool): If True, returns the bitmask (including zeros) for all entries;
-                    otherwise, only return non-zero entries.
+                all_matches (bool, default False): If True, returns the bitmask (including zeros)
+                    for all entries; otherwise, only return non-zero entries.
 
             Returns:
                 (dict): Dictionary from (LOCID, TARGETID) to collision bitmask.

--- a/src/_pyfiberassign.cpp
+++ b/src/_pyfiberassign.cpp
@@ -1605,7 +1605,7 @@ PYBIND11_MODULE(_internal, m) {
 
         )")
         .def("check_avail_collisions", &fba::Assignment::check_avail_collisions,
-             py::arg("tile"), R"(
+             py::arg("tile"), py::arg("all_matches")=false, R"(
             Return a bitmask describing the collisions for each potential assignment
             for a given tile.
 

--- a/src/_pyfiberassign.cpp
+++ b/src/_pyfiberassign.cpp
@@ -1616,9 +1616,11 @@ PYBIND11_MODULE(_internal, m) {
 
             Args:
                 tile (int): The tile ID.
+                all_matches (bool): If True, returns the bitmask (including zeros) for all entries;
+                    otherwise, only return non-zero entries.
 
             Returns:
-                (dict): Dictionary from TARGETID to collision bitmask
+                (dict): Dictionary from (LOCID, TARGETID) to collision bitmask.
 
         )")
         .def("assign_unused", &fba::Assignment::assign_unused,

--- a/src/_pyfiberassign.cpp
+++ b/src/_pyfiberassign.cpp
@@ -1604,6 +1604,23 @@ PYBIND11_MODULE(_internal, m) {
                 (dict): Dictionary of assigned target for each location.
 
         )")
+        .def("check_avail_collisions", &fba::Assignment::check_avail_collisions,
+             py::arg("tile"), R"(
+            Return a bitmask describing the collisions for each potential assignment
+            for a given tile.
+
+            This returns a map from TARGETID to a bitmask:
+                1: BROKEN or STUCK positioner
+                2: collision with STUCK positioner
+                4: collision with GFA or petal edge
+
+            Args:
+                tile (int): The tile ID.
+
+            Returns:
+                (dict): Dictionary from TARGETID to collision bitmask
+
+        )")
         .def("assign_unused", &fba::Assignment::assign_unused,
              py::arg("tgtype")=TARGET_TYPE_SCIENCE,
              py::arg("max_per_petal")=-1,

--- a/src/assign.cpp
+++ b/src/assign.cpp
@@ -1284,7 +1284,7 @@ bool fba::Assignment::ok_to_assign (fba::Hardware const * hw, int32_t tile,
     return (check_collisions(hw, tile, loc, target, target_xy, true) == 0);
 }
 
-std::map< std::pair< int32_t, int64_t >, int > fba::Assignment::check_avail_collisions(int32_t tile) const {
+std::map< std::pair< int32_t, int64_t >, int > fba::Assignment::check_avail_collisions(int32_t tile, bool all_matches) const {
     std::map< std::pair< int32_t, int64_t>, int > rtn;
     std::map<int32_t, std::vector<int64_t> > avail = tgsavail_->tile_data(tile);
     auto const& target_xy = tile_target_xy.at(tile);
@@ -1293,7 +1293,9 @@ std::map< std::pair< int32_t, int64_t >, int > fba::Assignment::check_avail_coll
         int32_t loc = it.first;
         std::vector<int64_t> targets = it.second;
         for (int64_t target : targets) {
-            rtn[std::make_pair(loc, target)] = check_collisions(hw_.get(), tile, loc, target, target_xy, false);
+            int x = check_collisions(hw_.get(), tile, loc, target, target_xy, false);
+            if (x || all_matches)
+                rtn[std::make_pair(loc, target)] = x;
         }
     }
     return rtn;

--- a/src/assign.h
+++ b/src/assign.h
@@ -15,8 +15,17 @@
 #include <tiles.h>
 #include <targets.h>
 
-
 namespace fiberassign {
+
+// bitmask values returned by check_collisions:
+// this positioner is STUCK or BROKEN
+const int COLLISION_SELF_STUCK = 1;
+// this target would cause a collision with a STUCK or BROKEN positioner
+const int COLLISION_WITH_STUCK = 2;
+// this target would cause a collision with a petal or GFA edge
+const int COLLISION_WITH_EDGES = 4;
+// this target would cause a collision with a neighboring not-stuck positioner
+const int COLLISION_WITH_NEIGHBOR = 8;
 
 // This class holds the current assignment information and methods for
 // refinement.
@@ -116,6 +125,15 @@ class Assignment : public std::enable_shared_from_this <Assignment> {
             int32_t tile,
             int32_t petal,
             int32_t slitblock
+        ) const;
+
+        int check_collisions(
+            Hardware const * hw,
+            int32_t tile,
+            int32_t loc,
+            int64_t target,
+            std::map <int64_t, std::pair <double, double> > const & target_xy,
+            bool check_assigned_neighbors = true
         ) const;
 
         bool ok_to_assign(

--- a/src/assign.h
+++ b/src/assign.h
@@ -71,6 +71,8 @@ class Assignment : public std::enable_shared_from_this <Assignment> {
 
         std::map <int32_t, int64_t> const & tile_location_target(int32_t tile) const;
 
+        std::map< std::pair< int32_t, int64_t >, int > check_avail_collisions(int32_t tile) const;
+
         std::map <int32_t, std::map <int32_t, int64_t> > loc_target;
 
         std::map <int64_t, std::map <int32_t, int32_t> > target_loc;

--- a/src/assign.h
+++ b/src/assign.h
@@ -71,7 +71,8 @@ class Assignment : public std::enable_shared_from_this <Assignment> {
 
         std::map <int32_t, int64_t> const & tile_location_target(int32_t tile) const;
 
-        std::map< std::pair< int32_t, int64_t >, int > check_avail_collisions(int32_t tile) const;
+        std::map< std::pair< int32_t, int64_t >, int > check_avail_collisions(int32_t tile,
+                                                                              bool all_matches=false) const;
 
         std::map <int32_t, std::map <int32_t, int64_t> > loc_target;
 


### PR DESCRIPTION
Add `Assignment.check_avail_collisions(tile, all_matches=False)`, which returns a dict of `(locid, targetid)` to `bitmask`, describing all collisions with STUCK or BROKEN positioners, and petal and GFA edges, for potential assignments on this tile.

Under the hood, this calls a refactored `check_collisions()` function, which is the same function now called during fiber assignment, `ok_to_assign`, so the same collision checks can be performed for potential targets as during fiber assignment.
