### PR TITLE
fba_rerun: handle custom_too_development argument

### DIFF
--- a/bin/fba_rerun
+++ b/bin/fba_rerun
@@ -82,7 +82,7 @@ def main():
         # AR handling of the "action_store=True" arguments..
         # AR - if True, we keep the argument name
         # AR - if False, we remove
-        if key in ["--log_stdout", "--worldreadable", "--targ_std_only", "--too_tile"]:
+        if key in ["--log_stdout", "--worldreadable", "--targ_std_only", "--too_tile", "--custom_too_development"]:
             if val == "False":
                 continue
             else:

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,11 +6,13 @@ fiberassign change log
 5.7.2 (unreleased)
 ------------------
 
+* fba_rerun: handle custom_too_development argument (PR `#458`_).
 * Add Assignment.check_avail_collisions(tile, all_matches=False) to check potential assignments for collisions (PR `#454`_).
 * uses the focalplane radius from DESIMODEL instead of the hardcoded version in fiberassign (PR `#453`_).
 
 .. _`#453`: https://github.com/desihub/fiberassign/pull/453
 .. _`#454`: https://github.com/desihub/fiberassign/pull/454
+.. _`#458`: https://github.com/desihub/fiberassign/pull/458
 
 5.7.1 (2023-02-06)
 ------------------


### PR DESCRIPTION
This PR is a minor update/bugfix in `bin/fba_rerun`.
It handles the `--custom_too_development` argument, which has been introduced in https://github.com/desihub/fiberassign/pull/437, but which has not been handled in `bin/fba_rerun` (where the `action="store_true"` `fba_launch` arguments need a special handling).