### PR TITLE
Add .readthedocs.yml and update documentation configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,25 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+    os: ubuntu-22.04
+    tools:
+        python: "3.10"
+
+# Build documentation in the doc/ directory with Sphinx
+sphinx:
+    configuration: doc/conf.py
+    fail_on_warning: true
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+    install:
+      - requirements: doc/rtd_requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -23,3 +23,5 @@ formats: all
 python:
     install:
       - requirements: doc/rtd_requirements.txt
+      - method: setuptools
+        path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,8 +16,9 @@ sphinx:
     configuration: doc/conf.py
     fail_on_warning: true
 
-# Optionally build your docs in additional formats such as PDF and ePub
-formats: all
+# Optionally build your docs in additional formats such as PDF and ePub.
+# Note ePub format does not like include files.
+formats: []
 
 # Optionally set the version of Python and requirements required to build your docs
 python:

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,11 +6,13 @@ fiberassign change log
 5.7.2 (unreleased)
 ------------------
 
+* Update ReadTheDocs configuration (PR `#459`_).
 * Add Assignment.check_avail_collisions(tile, all_matches=False) to check potential assignments for collisions (PR `#454`_).
 * uses the focalplane radius from DESIMODEL instead of the hardcoded version in fiberassign (PR `#453`_).
 
 .. _`#453`: https://github.com/desihub/fiberassign/pull/453
 .. _`#454`: https://github.com/desihub/fiberassign/pull/454
+.. _`#459`: https://github.com/desihub/fiberassign/pull/459
 
 5.7.1 (2023-02-06)
 ------------------

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -136,10 +136,9 @@ napoleon_include_private_with_doc = True
 # some external dependencies are not met at build time and break the
 # building process.
 autodoc_mock_imports = []
-for missing in ('astropy', 'numpy', 'fitsio', 'healpy',
-        'desitarget.skyhealpixs', 'yaml', 'scipy',
-        'desimodel', 'desitarget', 'desiutil',
-        'fiberassign._internal'):
+for missing in ('astropy', 'numpy', 'fitsio', 'healpy', 'yaml', 'scipy',
+                'desimodel', 'desitarget', 'desiutil',
+                'fiberassign._internal'):
     try:
         foo = import_module(missing)
     except ImportError:

--- a/doc/rtd_requirements.txt
+++ b/doc/rtd_requirements.txt
@@ -1,3 +1,3 @@
-Sphinx
-sphinx-rtd-theme
+Sphinx>6,<7
+sphinx-rtd-theme>1
 git+https://github.com/desihub/desiutil.git@main#egg=desiutil

--- a/doc/rtd_requirements.txt
+++ b/doc/rtd_requirements.txt
@@ -1,7 +1,3 @@
 Sphinx
-pyyaml
-numpy
-scipy
-matplotlib
-astropy
-fitsio
+sphinx-rtd-theme
+git+https://github.com/desihub/desiutil.git@main#egg=desiutil

--- a/setup.py
+++ b/setup.py
@@ -20,33 +20,6 @@ from distutils.errors import CompileError
 #
 # DESI support code.
 #
-# If this code is being run within the readthedocs environment, then we
-# need special steps.
-#
-# Longer story:  desimodel and desitarget are fiberassign build requirements
-# but these are not pip installable from a requirements file, due to the way
-# that pip handles recursive requirements files and the fact that desiutil is
-# required for obtaining even basic package info (egg_info).  Since this is
-# such a specialized case, we just check if this is running on readthedocs
-# and manually pip install things right here.
-#
-try:
-    import desiutil
-except ImportError:
-    if os.getenv('READTHEDOCS') == 'True':
-        import subprocess as sp
-        dutil = \
-            'git+https://github.com/desihub/desiutil.git@main#egg=desiutil'
-        dmodel = \
-            'git+https://github.com/desihub/desimodel.git@main#egg=desimodel'
-        dtarget = \
-            'git+https://github.com/desihub/desitarget.git@main#egg=desitarget'
-        sp.check_call(['pip', 'install', dutil])
-        sp.check_call(['pip', 'install', dmodel])
-        sp.check_call(['pip', 'install', dtarget])
-    else:
-        raise
-
 from desiutil.setup import DesiTest, DesiVersion, get_version
 #
 # Begin setup


### PR DESCRIPTION
This PR closes #456.

Besides the new `.readthedocs.yml` file, installation of `desiutil` is moved from the `setup.py` file to the `doc/rtd_requirements.txt file`.