### PR TITLE
Write speedups for multi-tiles runs

### DIFF
--- a/py/fiberassign/scripts/assign.py
+++ b/py/fiberassign/scripts/assign.py
@@ -197,6 +197,10 @@ def parse_assign(optlist=None):
                         choices=["ls", "gaia"],
                         help="Source for the look-up table for sky positions for stuck fibers:"
                         " 'ls': uses $SKYBRICKS_DIR; 'gaia': uses $SKYHEALPIXS_DIR (default=ls)")
+    parser.add_argument("--write_fits_numproc", required=False, default=0,
+                        type=int,
+                        help="if >0, then runs the write_assignment_fits() in parallel with numproc jobs (default=0)")
+
 
     args = None
     if optlist is None:
@@ -444,7 +448,8 @@ def run_assign_full(args, plate_radec=True):
                           out_prefix=args.prefix, split_dir=args.split,
                           all_targets=args.write_all_targets,
                           gfa_targets=gfa_targets, overwrite=args.overwrite,
-                          stucksky=stucksky, tile_xy_cs5=tile_xy_cs5)
+                          stucksky=stucksky, tile_xy_cs5=tile_xy_cs5,
+                          numproc=args.write_fits_numproc)
 
     gt.stop("run_assign_full write output")
 
@@ -539,7 +544,8 @@ def run_assign_bytile(args):
                           out_prefix=args.prefix, split_dir=args.split,
                           all_targets=args.write_all_targets,
                           gfa_targets=gfa_targets, overwrite=args.overwrite,
-                          stucksky=stucksky, tile_xy_cs5=tile_xy_cs5)
+                          stucksky=stucksky, tile_xy_cs5=tile_xy_cs5,
+                          numproc=args.write_fits_numproc)
 
     gt.stop("run_assign_bytile write output")
 

--- a/py/fiberassign/scripts/assign.py
+++ b/py/fiberassign/scripts/assign.py
@@ -200,6 +200,10 @@ def parse_assign(optlist=None):
     parser.add_argument("--write_fits_numproc", required=False, default=0,
                         type=int,
                         help="if >0, then runs the write_assignment_fits() in parallel with numproc jobs (default=0)")
+    parser.add_argument("--fast_match", required=False, default=False,
+                        type=bool,
+                        help="use a fast method to match TARGETID in the TargetTagalong Class;"
+                        "assumes there are no duplicates in TARGETID in the input files (default=False)")
 
 
     args = None
@@ -331,7 +335,7 @@ def run_assign_init(args, plate_radec=True):
     # Create empty target list
     tgs = Targets()
     # Create structure for carrying along auxiliary target data not needed by C++.
-    tagalong = create_tagalong(plate_radec=plate_radec)
+    tagalong = create_tagalong(plate_radec=plate_radec, fast_match=args.fast_match)
 
     # Append each input target file.  These target files must all be of the
     # same survey type, and will set the Targets object to be of that survey.


### PR DESCRIPTION
This PR adds a couple of -- simple but efficient -- "tricks" to speed-up the individual `fba-TILEID.fits` file writing:
- allow parallelisation in `write_assignment_fits()`: when N>1 tiles are run at once, those are sequentially written in the current main;
- add fast_match argument in TargetTagalong class: this uses the `desitarget.geomask.match()` function, instead of building a dictionary with a `TARGETID` for each key, which takes a long time when dealing with 10M+ targets.

Those two "tricks" are controlled by two new arguments in `parse_assign()` in `fiberassign/scripts/assign.py`:
- `--write_fits_numproc (default=0)`: number of jobs to be run in parallel when calling `write_assignment_fits()`;
- `--fast_match (default=False)`.

The use case is when one runs N>>1 tiles at once with tens of millions of targets (I developed that to explore the expected fiberassign when the GD1 tiles will be added to the Bright program).
The default values are disabling the "tricks", so that it is backwards-compatible, and this will change nothing in operations.

Test case with the GD1 tiles:
This case had ~800 tiles, and 7M targets plus 43M sky targets, so 50M targets.
The actual part of running the fiberassign is reasonably fast (1h), but the writing part was not.
Here are few timings to write the ~800 `fba-TILEID.fits` files (ie once the fiberassign is computed):
- current main: 6h30;
- with using `--fast_match True --write_fits_numproc 0`:  1h30.
- with using `--fast_match True --write_fits_numproc 64`: 13min
- with using `--fast_match True --write_fits_numproc 128`: 10min (no significant improvement w.r.t. 64 processes).

Note about the `fast_match` trick:
It assumes that the input `TARGETID` are unique.
If that is not the case, results will be wrong (ie the column values will be wrongly filled); but that s probably also the case for the current main... (I don t have clear, in-depth, understanding of the process).
As the goal is to look for speed, no checks are done (uniqueness of input the `TARGETID`, correctness of the matching).
Note to myself: a sanity check is planned to be implemented in `desitarget.geomask.match()`: https://github.com/desihub/desitarget/issues/811; once that is done, I will have to make sure that such check is disable in the call here, to preserve the speed-up.

For sanity, I've rerun 1% of the main tiles (125 backup, bright, dark tiles) with the current main and with turning on the `--fast_match` option, and I get no difference in the output data.

Note about the `write_fits_numproc` trick:
I had to use `multiprocessing.pool.ThreadPool` instead of the "usual" `multiprocessing.Pool`, because the latter was crashing with the Assignment() object `asgn`.
I found this workaround with a quick google search and it worked.

@dstndstn: in case you have time to have a look, I'd appreciate! but there is no rush.
