### PR TITLE
Field rotation updates to avoid hexapod rotation limit errors

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,9 +6,11 @@ fiberassign change log
 5.7.3 (unreleased)
 ------------------
 
+* Field rotation updates to avoid hexapod rotation limit errors (PR `#466`_).
 * Fix C++ bug with use of std::abs and improve floating point reproducibility (PR `#470`_).
 * Remove ``DesiTest`` from setup.py and warn about other deprecated features (PR `#464`_).
 
+.. _`#466`: https://github.com/desihub/fiberassign/pull/466
 .. _`#470`: https://github.com/desihub/fiberassign/pull/470
 .. _`#464`: https://github.com/desihub/fiberassign/pull/464
 

--- a/py/fiberassign/data/cutoff-dates.yaml
+++ b/py/fiberassign/data/cutoff-dates.yaml
@@ -1,3 +1,4 @@
 rundate:
     std_wd: "2021-12-01T19:00:00+00:00" # std_wd not counted in per-petal-std after that rundate
     etc_stuck: "2022-04-28T19:00:00+00:00" # etc fibers are treated as stuck fibers after this date
+    obsdate: "2025-03-01T19:00:00+00:00" # obsdate set as rundate + 1yr

--- a/py/fiberassign/data/cutoff-dates.yaml
+++ b/py/fiberassign/data/cutoff-dates.yaml
@@ -1,4 +1,4 @@
 rundate:
     std_wd: "2021-12-01T19:00:00+00:00" # std_wd not counted in per-petal-std after that rundate
     etc_stuck: "2022-04-28T19:00:00+00:00" # etc fibers are treated as stuck fibers after this date
-    obsdate: "2025-03-01T19:00:00+00:00" # obsdate set as rundate + 1yr
+    obsdate: "2025-05-02T19:00:00+00:00" # obsdate set as rundate + 1yr after this date

--- a/py/fiberassign/scripts/assign.py
+++ b/py/fiberassign/scripts/assign.py
@@ -112,7 +112,8 @@ def parse_assign(optlist=None):
     parser.add_argument("--fieldrot_corr", type=bool, required=False,
                         default=None,
                         help="apply correction to computed fieldrot "
-                        "(default: False if rundate<rundate_cutoff, True else")
+                        "(default: False if args.fieldrot is provided or "
+                        "if args.rundate<rundate_cutoff, True else")
 
     parser.add_argument("--dir", type=str, required=False, default=None,
                         help="Output directory.")
@@ -280,10 +281,13 @@ def parse_assign(optlist=None):
         args.obsdate = '{}-{}-{}'.format(year, mm, dd)
 
     # Apply the field rotation correction?
-    # - True if rundate!=None and rundate>=rundate_cutoff
+    # - True if fieldrot=None, rundate!=None and rundate>=rundate_cutoff
     # - False else
     if args.fieldrot_corr is None:
-        _, args.fieldrot_corr = get_obsdate(rundate=args.rundate)
+        if args.fieldrot is None:
+            _, args.fieldrot_corr = get_obsdate(rundate=args.rundate)
+        else:
+            args.fieldrot_corr = False
 
     # Set output directory
     if args.dir is None:

--- a/py/fiberassign/tiles.py
+++ b/py/fiberassign/tiles.py
@@ -22,6 +22,8 @@ from desimodel.focalplane.fieldrot import field_rotation_angle
 
 import astropy.time
 
+from fiberassign.utils import get_default_static_obsdate
+
 from ._internal import Tiles
 
 
@@ -71,7 +73,7 @@ def load_tiles(tiles_file=None, select=None, obstime=None, obstheta=None,
         obsdatestr = [x.isot for x in obsdate]
     else:
         # default to middle of the survey
-        obsdate = astropy.time.Time('2022-07-01')
+        obsdate = astropy.time.Time(get_default_static_obsdate())
         obsmjd = [obsdate.mjd,] * len(keeprows)
         obsdatestr = [obsdate.isot, ] * len(keeprows)
 

--- a/py/fiberassign/utils.py
+++ b/py/fiberassign/utils.py
@@ -145,28 +145,35 @@ def get_obsdate(rundate=None):
 
     Returns:
         obsdate: "YYYY-MM-DD" format (string)
+        is_after_cutoff: is rundate after rundate_cutoff? (bool)
     """
     obsdate = get_default_static_obsdate()
+    is_after_cutoff = False
     if rundate is None:
-        log.info("rundate={} -> setting obsdate={}".format(rundate, obsdate))
+        log.info(
+            "rundate={} -> (obsdate, is_after_cutoff)=({}, {})".format(
+                rundate, obsdate, is_after_cutoff
+            )
+        )
     else:
         assert_isoformat_utc(rundate)
         rundate_mjd = Time(datetime.strptime(rundate, "%Y-%m-%dT%H:%M:%S%z")).mjd
         rundate_cutoff = get_date_cutoff("rundate", "obsdate")
         rundate_mjd_cutoff = Time(datetime.strptime(rundate_cutoff, "%Y-%m-%dT%H:%M:%S%z")).mjd
         if rundate_mjd >= rundate_mjd_cutoff:
+            is_after_cutoff = True
             yyyy = int(rundate[:4])
             obsdate = "{}{}".format(yyyy + 1, rundate[4:10])
             log.info(
-                "rundate={} >= rundate_cutoff={} -> setting obsdate={}".format(
-                    rundate, rundate_cutoff, obsdate)
+                "rundate={} >= rundate_cutoff={} -> (obsdate, is_after_cutoff)=({}, {})".format(
+                    rundate, rundate_cutoff, obsdate, is_after_cutoff)
             )
         else:
             log.info(
-                "rundate={} < rundate_cutoff={} -> setting obsdate={}".format(
-                    rundate, rundate_cutoff, obsdate)
+                "rundate={} < rundate_cutoff={} -> (obsdate, is_after_cutoff)=({}, {})".format(
+                    rundate, rundate_cutoff, obsdate, is_after_cutoff)
             )
-    return obsdate
+    return obsdate, is_after_cutoff
 
   
 def get_svn_version(svn_dir):
@@ -373,3 +380,53 @@ def get_rev_fiberassign_changes(svndir, rev, subdirs=None):
     d["REVISION"] = np.array([rev for fn in fns], dtype=int)
     d["CHANGE"] = np.array(changes, dtype=str)
     return d
+
+
+def get_obstheta_corr(decs, has, clip_arcsec=600.):
+    """
+    Returns the computed correction to be applied to the field rotation
+        computed in fiberassign.tiles.load_tiles().
+    The correction should be applied as: obsthetas[deg] -= obstheta_corrs[deg].
+
+    Args:
+        decs: tile declinations (float or np array of floats)
+        has: hour angles (float or np array of floats)
+        clip_arcsec (optional, defaults to 600): abs(obstheta_corrs) is
+            forced to be <obstheta_corrs (float)
+
+    Returns:
+        obstheta_corrs: correction (in deg) to be applied (float or np array of floats)
+
+    Notes:
+        See DocDB-8931 for details.
+        During observations, PlateMaker computes the required field rotation,
+            then asks the hexapod to be rotated by
+            ROTOFFST = FIELDROT - PM_REQ_FIELDROT,
+            where FIELDROT is the field rotation coming from fiberassign.tiles.load_tiles().
+        When abs(ROTOFFST)>600 arcsec, the move is denied, and the exposure aborted.
+        Correction computed here is a fit to ROTOFFST=f(DEC), plus a fit on the residuals.
+    """
+    assert clip_arcsec >= 0
+    isoneval = isinstance(decs, float)
+    if isoneval:
+        decs, has = np.atleast_1d(decs), np.atleast_1d(has)
+    # AR fitted function, ROTOFFST[arcsec] = f(DEC)
+    # AR rescale decs into [0, 1]
+    xs = (90. - decs) / 180.
+    rotoffsts = 937.60578 - 697.06513 * xs ** -0.18835
+    # AR fitted function to the residuals, residuals[arcsec] = f(HA)
+    xs = (90. + has) / 180.
+    residuals = -113.90162 + 222.18009 * xs
+    sel = xs > 0.5
+    residuals[sel] = -245.49007 + 485.35700 * xs[sel]
+    # AR total correction
+    obstheta_corrs = rotoffsts + residuals
+    # AR clip
+    obstheta_corrs = np.clip(obstheta_corrs, -clip_arcsec, clip_arcsec)
+    # AR switch to degrees
+    obstheta_corrs /= 3600
+    if isoneval:
+        decs, has = decs[0], has[0]
+        return obstheta_corrs[0]
+    else:
+        return obstheta_corrs

--- a/py/fiberassign/utils.py
+++ b/py/fiberassign/utils.py
@@ -122,6 +122,52 @@ def get_date_cutoff(datetype, cutoff_case):
     date_cutoff = config[datetype][cutoff_case]
     return date_cutoff
 
+
+def get_default_static_obsdate():
+    """
+    Returns the 'historical' default obsdate value.
+
+    Args:
+        None
+
+    Returns:
+        "2022-07-01"
+    """
+    return "2022-07-01"
+
+
+def get_obsdate(rundate=None):
+    """
+    Returns the default obsdate: "2022-07-01" if rundate=None or rundate<obsdate_cutoff.
+
+    Args:
+        rundate (optional, defaults to None): rundate, in the "YYYY-MM-DDThh:mm:ss+00:00" format (string)
+
+    Returns:
+        obsdate: "YYYY-MM-DD" format (string)
+    """
+    obsdate = get_default_static_obsdate()
+    if rundate is None:
+        log.info("rundate={} -> setting obsdate={}".format(rundate, obsdate))
+    else:
+        assert_isoformat_utc(rundate)
+        rundate_mjd = Time(datetime.strptime(rundate, "%Y-%m-%dT%H:%M:%S%z")).mjd
+        rundate_cutoff = get_date_cutoff("rundate", "obsdate")
+        rundate_mjd_cutoff = Time(datetime.strptime(rundate_cutoff, "%Y-%m-%dT%H:%M:%S%z")).mjd
+        if rundate_mjd >= rundate_mjd_cutoff:
+            yyyy = int(rundate[:4])
+            obsdate = "{}{}".format(yyyy + 1, rundate[4:10])
+            log.info(
+                "rundate={} >= rundate_cutoff={} -> setting obsdate={}".format(
+                    rundate, rundate_cutoff, obsdate)
+            )
+        else:
+            log.info(
+                "rundate={} < rundate_cutoff={} -> setting obsdate={}".format(
+                    rundate, rundate_cutoff, obsdate)
+            )
+    return obsdate
+
   
 def get_svn_version(svn_dir):
     """

--- a/py/fiberassign/utils.py
+++ b/py/fiberassign/utils.py
@@ -156,7 +156,10 @@ def get_obsdate(rundate=None):
             )
         )
     else:
-        assert_isoformat_utc(rundate)
+        if not assert_isoformat_utc(rundate):
+            msg = "rundate={} is not yyyy-mm-ddThh:mm:ss+00:00".format(rundate)
+            log.info(msg)
+            raise ValueError(msg)
         rundate_mjd = Time(datetime.strptime(rundate, "%Y-%m-%dT%H:%M:%S%z")).mjd
         rundate_cutoff = get_date_cutoff("rundate", "obsdate")
         rundate_mjd_cutoff = Time(datetime.strptime(rundate_cutoff, "%Y-%m-%dT%H:%M:%S%z")).mjd


### PR DESCRIPTION
This PR is in-development, but I share now, so that we can discuss choices I made.
Once perlmutter is back up, I ll run more sanity checks.

The goal of this PR is to avoid the hexpod rotation limit errors that happen in operations.
Details are presented on DocDB-8931.
In short, for a given tile:
- fiberassign computes `FIELDROT = (RA, DEC, OBSDATE)`, the field rotation (using desimodel routines); so far, `OBSDATE=2022-07-01`, the "mid-survey" date which was defined years ago;
- then PlateMaker computes `PM_REQ_FIELDROT`, the proper field rotation, based on the exact date of observation and HA;
- the sent requested rotation for the hexapod is `ROTOFFST = PM_REQ_FIELDROT - FIELDROT`;
- if `abs(ROTOFFST) > 600 arcsec`, this triggers an hexapod rotation limit error, and we move to another tile.

The approach to solve that is twofold:
(1) change the `OBSDATE` (from `2022-07-01` to `when_we_observe + 1 yr`);
(2) apply a correction on the computed `FIELDROT`.
Based on DocDB-8931, those two actions should narrows the `ROTOFFST` distribution, keeping it within [-400 arcsec, +400 arcsec]; at least for the main survey observations.

Note that there is a subtlety that, during the observation, this rotation is updated every minute; though, hopefully, such additional rotation should be in total smaller than 30-60 arcsec for a 30min exposure, so the system should stay away from the 600 arcsec limit.

I ll discuss the implementation choices in a separate message.