### PR TITLE
add stuck_on_sky_from_fafns() option

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,6 +6,7 @@ fiberassign change log
 5.8.0 (unreleased)
 ------------------
 
+* add stuck_on_sky_from_fafns() option (PR `#471`_)
 * get_fba_use_fabs(): add log infos (PR `#478`_)
 * Doc err fix (PR `#479`_)
 * include cstdint for gcc/13 support (PR `#477`_)
@@ -14,6 +15,7 @@ fiberassign change log
 * Fix C++ bug with use of std::abs and improve floating point reproducibility (PR `#470`_).
 * Remove ``DesiTest`` from setup.py and warn about other deprecated features (PR `#464`_).
 
+.. _`#471`: https://github.com/desihub/fiberassign/pull/471
 .. _`#478`: https://github.com/desihub/fiberassign/pull/478
 .. _`#479`: https://github.com/desihub/fiberassign/pull/479
 .. _`#477`: https://github.com/desihub/fiberassign/pull/477

--- a/py/fiberassign/scripts/assign.py
+++ b/py/fiberassign/scripts/assign.py
@@ -206,16 +206,15 @@ def parse_assign(optlist=None):
                         choices=["ls", "gaia"],
                         help="Source for the look-up table for sky positions for stuck fibers:"
                         " 'ls': uses $SKYBRICKS_DIR; 'gaia': uses $SKYHEALPIXS_DIR (default=ls)")
+
     parser.add_argument("--fafns_for_stucksky", required=False, default=None,
                         help="csv list of fiberassign-TILEID.fits.gz files;"
                         " if set, fiberassign will use this fiberassign file to know which"
                         " stuck fibers are usable for sky")
-    parser.add_argument(
-        "--fba_use_fabs",
-        help="value to determine the cpp behavior, see PR470 (default: based on the rundate)",
-        type=str,
-        default=None
-    )
+
+    parser.add_argument("--fba_use_fabs", required=False, default=None,
+                        help="value to determine the cpp behavior, see PR470 (default: based on the rundate)",
+                        type=str)
 
     args = None
     if optlist is None:

--- a/py/fiberassign/scripts/assign.py
+++ b/py/fiberassign/scripts/assign.py
@@ -33,7 +33,7 @@ from ..targets import (str_to_target_type, TARGET_TYPE_SCIENCE,
 from ..assign import (Assignment, write_assignment_fits,
                       result_path, run)
 
-from ..stucksky import stuck_on_sky
+from ..stucksky import stuck_on_sky, stuck_on_sky_from_fafns
 
 def parse_assign(optlist=None):
     """Parse assignment options.
@@ -197,6 +197,10 @@ def parse_assign(optlist=None):
                         choices=["ls", "gaia"],
                         help="Source for the look-up table for sky positions for stuck fibers:"
                         " 'ls': uses $SKYBRICKS_DIR; 'gaia': uses $SKYHEALPIXS_DIR (default=ls)")
+    parser.add_argument("--fafns_for_stucksky", required=False, default=None,
+                        help="csv list of fiberassign-TILEID.fits.gz files;"
+                        " if set, fiberassign will use this fiberassign file to know which"
+                        " stuck fibers are usable for sky")
 
     args = None
     if optlist is None:
@@ -406,8 +410,11 @@ def run_assign_full(args, plate_radec=True):
     # Find stuck positioners and compute whether they will land on acceptable
     # sky locations for each tile.
     gt.start("Compute Stuck locations on good sky")
-    stucksky = stuck_on_sky(hw, tiles, args.lookup_sky_source,
-                            rundate=getattr(args, 'rundate', None))
+    if args.fafns_for_stucksky is not None:
+        stucksky = stuck_on_sky_from_fafns(args.fafns_for_stucksky)
+    else:
+        stucksky = stuck_on_sky(hw, tiles, args.lookup_sky_source,
+                                rundate=getattr(args, 'rundate', None))
     if stucksky is None:
         # (the pybind code doesn't like None when a dict is expected...)
         stucksky = {}


### PR DESCRIPTION
This PR adds the possibility to retrieve the "good sky" status for the stuck fibers from the `fiberassign-TILEID.fits.gz` file, in the hope to speed up `fba_run` for the `altmtl` runs.

It adds this option to `fba_run`:
```
  --fafns_for_stucksky FAFNS_FOR_STUCKSKY
                        csv list of fiberassign-TILEID.fits.gz files; if set, fiberassign will use this fiberassign file to know which stuck fibers are
                        usable for sky
```
The idea is to bypass the call `stuck_on_sky()`, as the information of which stuck fibers (including ETC) are usable for sky should already be accessible in the `fiberassign-TILEID.fits.gz`, where that computation has already been done.
It came up with questions from @echaussidon, thinking about ways to make the fiberassign reruns faster.

The call to `stuck_on_sky()` with this PR is here:
https://github.com/desihub/fiberassign/blob/4707fcc66854d0255b7be3c0a7b6cf878da073b9/py/fiberassign/scripts/assign.py#L410-L417
@ashleyjross: when you call `fba_run` in the altmtl, do you know if this `stuck_on_sky()` call takes a significant time?
I think I remember that @LNapolitano did some profiling at some point, no?

Interestingly, on a logging node, a call to `stuck_on_sky()` takes <2s, but on an interactive node, it takes more time, from 2-3s to 7-8s (and one call even took 28s!).

On a logging node, the computing speed gain is marginal:
```
# TILEID MAIN BRANCH
3370	1.2s	0.5s
3961	1.0s	0.1s
11681	1.1s	0.1s
23349	1.0s	0.1s
7837	1.2s	0.1s
40857	4.6s	0.2s
40529	3.7s	0.1s
27099	1.7s	0.2s
42424	3.6s	0.1s
23177	1.3s	0.1s
```

But on an interactive node, the computing speed gain becomes interesting:
```
# TILEID MAIN BRANCH
3370	2.2s	0.8s
3961	1.9s	0.2s
11681	2.0s	0.2s
23349	5.2s	0.3s
7837	5.9s	0.2s
40857	5.1s	0.3s
40529	11.6s	0.2s
27099	3.5s	0.4s
42424	10.9s	0.2s
23177	2.5s	0.3s
```

Here s the code snippet I use to test/validate and measure speed improvement:
```
from fiberassign.hardware import load_hardware
from fiberassign.tiles import load_tiles
from fiberassign.stucksky import stuck_on_sky, stuck_on_sky_from_fafns
from time import time

os.environ["SKYHEALPIXS_DIR"] = "/global/cfs/cdirs/desi/target/skyhealpixs/v1"
# pick 10 random tiles
d = Table.read("/global/cfs/cdirs/desi/spectro/redux/daily/tiles-daily.csv")
d = d[d["SURVEY"] == "main"]
np.random.seed(1234)
tileids = np.random.choice(d["TILEID"], size=10, replace=False)
dts, dt2s = np.zeros(len(tileids)), np.zeros(len(tileids))

for i, tileid in enumerate(tileids):
    #
    tileidpad = "{:06d}".format(tileid)
    fafn = "/global/cfs/cdirs/desi/target/fiberassign/tiles/trunk/{}/fiberassign-{}.fits.gz".format(tileidpad[:3], tileidpad)
    hdr = fitsio.read_header(fafn, 0)
    tilesfn = "/global/cfs/cdirs/desi/survey/fiberassign/main/{}/{}-tiles.fits".format(tileidpad[:3], tileidpad)
    tiles = load_tiles(tiles_file=tilesfn, obstime=hdr["FA_PLAN"], obstheta=hdr["FIELDROT"], obsha=hdr["FA_HA"])
    hw = load_hardware(rundate=hdr["RUNDATE"])
    #
    start = time()
    # we probably started with defaulting to ls,
    #   then implemented gaia for backup when backup was turned on
    lookup_sky_source = "ls"
    if "LKSKYSRC" in hdr:
        lookup_sky_source = hdr["LKSKYSRC"]
    stuck_sky = stuck_on_sky(hw, tiles, lookup_sky_source, rundate=hdr["RUNDATE"])
    dts[i] = time() - start
    #
    start = time()
    stuck_sky2 = stuck_on_sky_from_fafns(fafn)
    dt2s[i] = time() - start
    #
    assert np.all(list(stuck_sky[tileid].keys()) == list(stuck_sky2[tileid].keys()))
    assert stuck_sky == stuck_sky2
```

