### PR TITLE
Custom too: allow ToO from $DESI_ROOT/survey/fiberassign/special/tertiary

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,6 +6,7 @@ fiberassign change log
 5.8.0 (unreleased)
 ------------------
 
+* Custom too: allow ToO from fiberassign tertiary folder (PR `#476`_)
 * add stuck_on_sky_from_fafns() option (PR `#471`_)
 * get_fba_use_fabs(): add log infos (PR `#478`_)
 * Doc err fix (PR `#479`_)
@@ -15,6 +16,7 @@ fiberassign change log
 * Fix C++ bug with use of std::abs and improve floating point reproducibility (PR `#470`_).
 * Remove ``DesiTest`` from setup.py and warn about other deprecated features (PR `#464`_).
 
+.. _`#476`: https://github.com/desihub/fiberassign/pull/476
 .. _`#471`: https://github.com/desihub/fiberassign/pull/471
 .. _`#478`: https://github.com/desihub/fiberassign/pull/478
 .. _`#479`: https://github.com/desihub/fiberassign/pull/479

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -1008,6 +1008,10 @@ def get_desitarget_paths(
                 )
             )
         # AR check custom ToO file(s) exist + are in $DESI_SURVEYOPS, if not custom_too_development
+        allowed_dirs = [
+            os.getenv("DESI_SURVEYOPS"),
+            os.path.join(os.getenv("DESI_ROOT"), "survey", "fiberassign", "special", "tertiary")
+        ]
         if custom_too_development:
             log.info("{:.1f}s\t{}\tcustom_too_development=True, no check that custom_too_file(s) are in $DESI_SURVEYOPS".format(
                 time() - start, step,
@@ -1017,9 +1021,11 @@ def get_desitarget_paths(
             msg = None
             if not os.path.isfile(fn):
                 msg = "{:.1f}s\t{}\t{} does not exist".format(time() - start, step, fn)
-            if (not custom_too_development) & (not fn.startswith(os.getenv("DESI_SURVEYOPS"))):
+            if (not custom_too_development) & (
+                np.sum([fn.startswith(allowed_dir) for allowed_dir in allowed_dirs]) == 0
+            ):
                 msg = "{:.1f}s\t{}\t{} does not starts with {}; set custom_too_development=True if this is for development".format(
-                    time() - start, step, fn, os.getenv("DESI_SURVEYOPS"),
+                    time() - start, step, fn, ", ".join(allowed_dirs),
                 )
             if msg is not None:
                 log.error(msg)

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -846,8 +846,8 @@ def get_desitarget_paths(
                 (boolean)
         dr (optional, defaults to "dr9"): legacypipe dr (string)
         gaiadr (optional, defaults to "gaiadr2"): gaia dr (string)
-        custom_too_file (optional, default=None): full path to a custom ToO file, for development work, which overrides the official one (string)
-        custom_too_development (optional, defaults to False): is this for development? (allows custom_too_file to be outside of $DESI_SURVEYOPS) (bool)
+        custom_too_file (optional, default=None): comma-separated full paths to a custom ToO files, for development work, which overrides the official one (string)
+        custom_too_development (optional, defaults to False): is this for development? (allows custom_too_file to be outside of $DESI_SURVEYOPS or $DESI_ROOT/survey/fiberassign/special/tertiary) (bool)
         log (optional, defaults to Logger.get()): Logger object
         step (optional, defaults to ""): corresponding step, for fba_launch log recording
             (e.g. dotiles, dosky, dogfa, domtl, doscnd, dotoo)


### PR DESCRIPTION
This PR solves a little annoyance for the tertiary tile design.

Some time ago, out of cautious, we ve decided that `fiberassign` would refuse to design tiles with `ToO` target files not living in `$DESI_SURVEYOPS`, unless a `--custom_too_development` argument was provided.

For the tertiary programs, which "hack" the `ToO` channel, the `ToO` files live in `$DESI_ROOT/survey/fiberassign/special/tertiary`, so it was requiring until now to generate those with the `--custom_too_development` argument.
A work-around could be to svn-commit those `ToO` files to `$DESI_SURVEYOPS`, wait for the scron job to pick them up, then use the svn-checked out files in the tertiary design; but that would complicate (and could delay by one hour) the tertiary design; it s simpler to have everything happening at once, in a single folder, in `$DESI_ROOT/survey/fiberassign/special/tertiary`.

This PR now makes `fiberassign` accept ToO files living in `$DESI_ROOT/survey/fiberassign/special/tertiary`, so that this `--custom_too_development` argument should not be required anymore to design tertiary tiles.

Tested with this simple dummy call:
```
fba_launch --dtver 1.1.1 --survey main --program DARK --tileid 999990 --tilera 0. --tiledec 0. --outdir /global/cfs/cdirs/desi/users/raichoor/tmpdir --custom_too_file /global/cfs/cdirs/desi/survey/fiberassign/special/tertiary/0044/ToO-0044-083519.ecsv
```

Note that this PR does not have to make it in the next `fiberassign` tag we will soon cut for operations.