### PR TITLE
include cstdint for gcc/13 support

### DIFF
--- a/src/_pyfiberassign.cpp
+++ b/src/_pyfiberassign.cpp
@@ -1,5 +1,6 @@
 #include <string>
 #include <sstream>
+#include <cstdint>
 
 #include <pybind11/pybind11.h>
 #include <pybind11/operators.h>


### PR DESCRIPTION
This PR adds "`#include <cstdint>`" which is required to compile fiberassign with gcc/13.2.1 at NERSC.  Without it, we get errors like
```
src/pybind11/attr.h: At global scope:
src/pybind11/attr.h:185:10: error: ‘uint16_t’ in namespace ‘std’ does not name a type; did you mean ‘wint_t’?
  185 |     std::uint16_t nargs;
      |          ^~~~~~~~
      |          wint_t
```
Also see [specex #73](https://github.com/desihub/specex/pull/73).  Credit to @dmargala for debugging.

I plan to self-merge and update at NERSC since the current compilation of fiberassign/main is failing.