### PR TITLE
get_fba_use_fabs(): add log infos

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,11 +6,13 @@ fiberassign change log
 5.8.0 (unreleased)
 ------------------
 
+* get_fba_use_fabs(): add log infos (PR `#478`_)
 * Freeze downloads of the IERS leap second table in ``fba_launch``, ``fba_run`` and ``fba_rerun`` (PR `#475`_).
 * Field rotation updates to avoid hexapod rotation limit errors (PR `#466`_).
 * Fix C++ bug with use of std::abs and improve floating point reproducibility (PR `#470`_).
 * Remove ``DesiTest`` from setup.py and warn about other deprecated features (PR `#464`_).
 
+.. _`#478`: https://github.com/desihub/fiberassign/pull/478
 .. _`#475`: https://github.com/desihub/fiberassign/pull/475
 .. _`#466`: https://github.com/desihub/fiberassign/pull/466
 .. _`#470`: https://github.com/desihub/fiberassign/pull/470

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -7,12 +7,14 @@ fiberassign change log
 ------------------
 
 * get_fba_use_fabs(): add log infos (PR `#478`_)
+* include cstdint for gcc/13 support (PR `#477`_)
 * Freeze downloads of the IERS leap second table in ``fba_launch``, ``fba_run`` and ``fba_rerun`` (PR `#475`_).
 * Field rotation updates to avoid hexapod rotation limit errors (PR `#466`_).
 * Fix C++ bug with use of std::abs and improve floating point reproducibility (PR `#470`_).
 * Remove ``DesiTest`` from setup.py and warn about other deprecated features (PR `#464`_).
 
 .. _`#478`: https://github.com/desihub/fiberassign/pull/478
+.. _`#477`: https://github.com/desihub/fiberassign/pull/477
 .. _`#475`: https://github.com/desihub/fiberassign/pull/475
 .. _`#466`: https://github.com/desihub/fiberassign/pull/466
 .. _`#470`: https://github.com/desihub/fiberassign/pull/470

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -7,6 +7,7 @@ fiberassign change log
 ------------------
 
 * get_fba_use_fabs(): add log infos (PR `#478`_)
+* Doc err fix (PR `#479`_)
 * include cstdint for gcc/13 support (PR `#477`_)
 * Freeze downloads of the IERS leap second table in ``fba_launch``, ``fba_run`` and ``fba_rerun`` (PR `#475`_).
 * Field rotation updates to avoid hexapod rotation limit errors (PR `#466`_).
@@ -14,6 +15,7 @@ fiberassign change log
 * Remove ``DesiTest`` from setup.py and warn about other deprecated features (PR `#464`_).
 
 .. _`#478`: https://github.com/desihub/fiberassign/pull/478
+.. _`#479`: https://github.com/desihub/fiberassign/pull/479
 .. _`#477`: https://github.com/desihub/fiberassign/pull/477
 .. _`#475`: https://github.com/desihub/fiberassign/pull/475
 .. _`#466`: https://github.com/desihub/fiberassign/pull/466

--- a/py/fiberassign/utils.py
+++ b/py/fiberassign/utils.py
@@ -203,6 +203,11 @@ def get_fba_use_fabs(rundate):
     cutoff_rundates = np.array([key for key in mydict])
     cutoff_mjds = np.array([get_mjd(_) for _ in cutoff_rundates])
     values = np.array([mydict[_] for _ in cutoff_rundates])
+    log.info(
+        "fba_use_fabs cutoff dates: {}".format(
+            ", ".join(["{} = {}".format(rundate, value) for rundate, value in zip(cutoff_rundates, values)])
+        )
+    )
     # AR safe, order by increasing mjd
     ii = cutoff_mjds.argsort()
     cutoff_rundates, cutoff_mjds, values = cutoff_rundates[ii], cutoff_mjds[ii], values[ii]
@@ -219,6 +224,7 @@ def get_fba_use_fabs(rundate):
         raise ValueError(msg)
 
     i = np.where(cutoff_mjds <= get_mjd(rundate))[0][-1]
+    log.info("pick fba_use_fabs = {} for rundate = {}".format(values[i], rundate))
 
     return values[i]
 


### PR DESCRIPTION
In the spirit of "let s keep track of key settings in the fiberassign log", this PR adds infos about the `get_fba_use_fabs()` which sets the environment variable introduced in https://github.com/desihub/fiberassign/pull/470 to control the c++ behavior.

I noticed I forgot to add that then...