### PR TITLE
Handle exceptions in copy_to_svn

### DIFF
--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -791,7 +791,10 @@ if __name__ == "__main__":
         dirmode = 0o2775 if args.worldreadable else 0o2770
         fn = os.path.join(args.outdir, subdir)
         os.makedirs(fn, exist_ok=True, mode=dirmode)
-        os.chmod(fn, mode=dirmode)  # apparently umask can affect os.makedirs?
+        try:
+            os.chmod(fn, mode=dirmode)  # apparently umask can affect os.makedirs?
+        except:
+            log.info("Did not update permissions; we weren't the owner.")
 
     # AR utc_time_now, rundate, pmtime
     utc_time_now = datetime.now(tz=timezone.utc)

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,7 +6,9 @@ fiberassign change log
 5.8.1 (unreleased)
 ------------------
 
-* No changes yet.
+* Handle exceptions in copy_to_svn (PR `#481`_)
+
+.. _`#481`: https://github.com/desihub/fiberassign/pull/481
 
 5.8.0 (2025-04-29)
 ------------------

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -3781,7 +3781,10 @@ def copy_to_svn(svntiledir, tileid, myouts,
     files = []
     files += [myouts['fiberassign'], myouts['log'], myouts['png']]
     os.makedirs(svntiledir, exist_ok=True, mode=dirmode)
-    os.chmod(svntiledir, mode=dirmode)
+    try:
+        os.chmod(svntiledir, mode=dirmode)
+    except:
+        log.info("Did not update permissions; we weren't the owner.")
     for filename in files:
         # depending on specific steps that got executed, a file may not exist.
         if not os.path.exists(filename):


### PR DESCRIPTION
This PR wraps the permissions-changing lines in a try/except block to make them more robust.