### PR TITLE
Replay kpno fiberassign at nersc

### DIFF
--- a/etc/fba_replay_kpno.sh
+++ b/etc/fba_replay_kpno.sh
@@ -1,0 +1,179 @@
+#!/bin/bash
+
+NJOB=8
+SUBFOLDER=
+
+usage () {
+    cat <<HELP_USAGE
+
+    Rerun fiberassign for a batch of tiles designed at KPNO.
+
+    `basename $0` --kpno_copydir KPNO_COPYDIR --rerundir RERUNDIR --njob NJOB
+
+    --kpno_copydir  KPNO_COPYDIR  the local folder where KPNO files are copied into
+    --subfolder     SUBFOLDER     optional; if set, only rerun that subfolder (e.g. 001, for 1??? tileids)
+    --rerundir      RERUNDIR      the local folder where outputs will be stored
+    --njob          NJOB          nb of parallel jobs running (default=8)
+
+    Should be run on one or multiple interactive (or debug) nodes.
+    If the reproducibility is successful, then the \$RERUNDIR/fba_nersc_kpno-diff.asc
+        file should be empty, i.e. only with the header (and a file size of 139 octets).
+
+    The code will overwrite any existing file in \$RERUNDIR.
+
+    This script was typically used to perform NERSC vs. KPNO reproducibility
+        when developing fiberassign code (one would then load the local, in development
+        version of the fiberassign code before running).
+
+    Files from KPNO should be organized as follows:
+        \$KPNO_COPYDIR/000/fiberassign-001000.fits.gz
+
+    \$RERUNDIR must exist.
+    Rerun fiberassign files will be in:
+        \$RERUNDIR/000/fiberassign-001000.fits.gz
+
+    The NERSC vs. KPNO comparison summary file will be:
+        \$RERUNDIR/fba_nersc_kpno-diff.asc
+
+    The overall environment must be loaded.
+    For example to rerun with the main environment, one should run beforehand (from a fresh environment):
+
+=====
+source /global/cfs/cdirs/desi/software/desi_environment.sh main
+export DESIMODEL=/global/common/software/desi/perlmutter/desiconda/current/code/desimodel/main
+export SKYHEALPIXS_DIR=\$DESI_ROOT/target/skyhealpixs/v1
+====
+
+    If one wants to rerun with a fiberassign branch in \$BRANCH_DIR, one should in addition run:
+====
+export PATH=\$BRANCH_DIR/bin:\$PATH
+export PYTHONPATH=\$BRANCH_DIR/py:\$PYTHONPATH
+====
+
+HELP_USAGE
+}
+
+[ -z "$1" ] && { usage; exit;}
+
+# AR read the provided arguments
+POSITIONAL=()
+while [[ $# -gt 0 ]]
+do
+    key="$1"
+    for i in "$@"
+    do
+        case $i in
+            --kpno_copydir)
+            KPNO_COPYDIR=$2
+            shift
+            shift
+            ;;
+            --subfolder)
+            SUBFOLDER=$2
+            shift
+            shift
+            ;;
+            --rerundir)
+            RERUNDIR=$2
+            shift
+            shift
+            ;;
+            --njob)
+            NJOB=$2
+            shift
+            shift
+            ;;
+            *)
+                  # unknown option
+            ;;
+        esac
+    done
+    set -- "${POSITIONAL[@]}" # restore positional parameters
+done
+
+# AR print arguments
+echo ""
+echo "KPNO_COPYDIR="$KPNO_COPYDIR
+echo "SUBFOLDER="$SUBFOLDER
+echo "RERUNDIR="$RERUNDIR
+echo "NJOB="$NJOB
+echo ""
+
+# AR to manage multiple jobs over one or several nodes, with GNU parallel
+WRAP_PARALLEL_FN=`which fba_launch | xargs dirname | awk '{print $1"/../etc/wrap_parallel.sh"}'`
+echo "WRAP_PARALLEL_FN="$WRAP_PARALLEL_FN
+echo ""
+
+# AR tiles file
+TILESFN=$DESI_SURVEYOPS/ops/tiles-main.ecsv
+
+# AR files with the command lines for the GNU parallel call
+CMDSH=$RERUNDIR/fba_nersc_kpno-cmd.sh
+CMDLOG=$RERUNDIR/fba_nersc_kpno-cmd.log
+
+# AR files the NERSC vs. KPNO comparison
+DIFFSH=$RERUNDIR/fba_nersc_kpno-diff.sh
+DIFFLOG=$RERUNDIR/fba_nersc_kpno-diff.log
+DIFFASC=$RERUNDIR/fba_nersc_kpno-diff.asc
+
+# AR get the fiberassign files to rerun.
+if [[ "$SUBFOLDER" == "" ]]
+then
+    ORIGFNS=`ls $KPNO_COPYDIR/???/fiberassign-??????.fits.gz`
+else
+    ORIGFNS=`ls $KPNO_COPYDIR/100/fiberassign-??????.fits.gz`
+fi
+
+# AR text file with the commands to rerun the KPNO fiberassign files
+rm $CMDSH
+echo "rerun fiberassign-TILEID.fits.gz"
+echo "    Start at: " `date`
+for ORIGFN in $ORIGFNS
+do
+    echo 'fba_rerun --infiberassign '$ORIGFN' --outdir '$RERUNDIR' --nosteps qa' >> $CMDSH
+done
+
+# AR execute the rerun in parallel
+CMD="srun --ntasks $SLURM_NNODES --ntasks-per-node 1 --wait=0 $WRAP_PARALLEL_FN --input_fn $CMDSH --njob $NJOB > $CMDLOG 2>&1"
+echo "    "$CMD
+eval $CMD
+echo "    Done at: " `date`
+
+
+# AR text file with the_NERSC vs. KPNO comparison command for each fiberassign file
+rm $DIFFSH
+echo "run NERSC vs. KPNO comparison"
+echo "    Start at: " `date`
+for ORIGFN in $ORIGFNS
+do
+    SUBDIR=`basename $ORIGFN | awk '{print substr($1, 13, 3)}'`
+    RERUNFN=$RERUNDIR/$SUBDIR/`basename $ORIGFN`
+    DIFFFN=`echo $RERUNFN | sed -e 's/.fits.gz/.diff/'`
+    echo 'python -c '\''from fiberassign.fba_rerun_io import fba_rerun_check; fba_rerun_check("'$ORIGFN'", "'$RERUNFN'", "'$DIFFFN'")'\''' >> $DIFFSH
+done
+
+# AR execute the comparison in parallel
+CMD="srun --ntasks $SLURM_NNODES --ntasks-per-node 1 --wait=0 $WRAP_PARALLEL_FN --input_fn $DIFFSH --njob $NJOB > $DIFFLOG 2>&1"
+echo "    "$CMD
+eval $CMD
+echo "    Done at: " `date`
+
+
+# AR make a single diff file for the NERSC vs. KPNO comparison
+echo "create a single diff file"
+echo "    Start at: " `date`
+COUNT=0
+for ORIGFN in $ORIGFNS
+do
+    SUBDIR=`basename $ORIGFN | awk '{print substr($1, 13, 3)}'`
+    RERUNFN=$RERUNDIR/$SUBDIR/`basename $ORIGFN`
+    DIFFFN=`echo $RERUNFN | sed -e 's/.fits.gz/.diff/'`
+    if [[ $COUNT == 0 ]]
+    then
+        head -n 1 $DIFFFN > $DIFFASC
+    fi
+    COUNT=`echo $COUNT | awk '{print $1+1}'`
+    cat $DIFFFN | grep -v \# >> $DIFFASC
+done
+echo "    Done at: " `date`                                                                                                                                                                    
+

--- a/etc/wrap_parallel.sh
+++ b/etc/wrap_parallel.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+usage () {
+    cat <<HELP_USAGE
+
+    Run multiple tasks in parallel across several nodes with using GNU parallel.
+
+    `basename $0` --input_fn INPUT_FN --njob NJOB
+
+    --input_fn INPUT_FN  a text file with one bash command per line
+    --njob     NJOB      nb of parallel jobs running
+
+    This is from https://docs.nersc.gov/jobs/workflow/gnuparallel/#many-tasks-inside-a-multiple-node-allocation.
+    The only minor adaptation is to include the two INPUT_FN and NJOB arguments.
+
+    GNU parallel should be installed (e.g., if not already install, run "module load parallel").
+
+    An example calling sequence is:
+        srun --ntasks \$SLURM_NNODES --ntasks-per-node 1 --wait=0  `basename $0` --input_fn \$INPUT_FN --njob \$NJOB
+
+    Should obviously not be run on a logging node.
+
+HELP_USAGE
+}
+
+[ -z "$1" ] && { usage; exit;}
+
+# AR read the provided arguments
+POSITIONAL=()
+while [[ $# -gt 0 ]]
+do
+    key="$1"
+    for i in "$@"
+    do
+        case $i in
+            --input_fn)
+            INPUT_FN=$2
+            shift
+            shift
+            ;;
+            --njob)
+            NJOB=$2
+            shift
+            shift
+            ;;
+            *)
+                  # unknown option
+            ;;
+        esac
+    done
+    set -- "${POSITIONAL[@]}" # restore positional parameters
+done
+
+# AR print arguments
+echo ""
+echo "INPUT_FN="$INPUT_FN
+echo "NJOB="$NJOB
+echo ""
+
+
+if [[ -z "${SLURM_NODEID}" ]]; then
+    echo "need \$SLURM_NODEID set"
+    exit
+fi
+
+if [[ -z "${SLURM_NNODES}" ]]; then
+    echo "need \$SLURM_NNODES set"
+    exit
+fi
+
+cat $INPUT_FN |                                            \
+    awk -v NNODE="$SLURM_NNODES" -v NODEID="$SLURM_NODEID" \
+    'NR % NNODE == NODEID' |                               \
+    parallel -j $NJOB {}


### PR DESCRIPTION
This PR adds two files, used to replay the KPNO fiberassign at NERSC (typically for fiberassign code development).
The calling sequence (e.g. on one or more interactive nodes):
```
    fba_replay_kpno.sh --kpno_copydir KPNO_COPYDIR --rerundir RERUNDIR --njob NJOB
```
The way to use `etc/fba_replay_kpno.sh` is described in the `HELP_USAGE` function in the script.

This uses the GNU `parallel` command, and jobs are distributed across the nodes with the `etc/wrap_parallel.sh` script (which is small adaptation from https://docs.nersc.gov/jobs/workflow/gnuparallel/#many-tasks-inside-a-multiple-node-allocation.

We may want to move `etc/wrap_parallel.sh` for instance in `desiutil/etc`.

Remark: to find the path to this `etc/wrap_parallel.sh`, I currently use this hacky way:
```
WRAP_PARALLEL_FN=`which fba_launch | xargs dirname | awk '{print $1"/../etc/wrap_parallel.sh"}'`
```
There probably is a nicer way to do that, just let me know!
