### PR TITLE
numpy 2, importlib, test matrix coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,13 +15,26 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                os: [ubuntu-22.04]  # , ubuntu-24.04]
-                python-version: ['3.10']  # '3.11', '3.12']
-                numpy-version: ['<1.23']
-                astropy-version: ['<6.1', '<7']
+              include:
+                - os: ubuntu-latest
+                  python-version: '3.13'
+                  numpy-version: '<2.3' # Numba does not yet support NumPy 2.3
+                  astropy-version: '<8.0'
+                - os: ubuntu-latest
+                  python-version: '3.12'
+                  numpy-version: '<2.2'
+                  astropy-version: '<7.0'
+                - os: ubuntu-latest
+                  python-version: '3.11'
+                  numpy-version: '<2.1'
+                  astropy-version: '<6.1'
+                - os: ubuntu-latest
+                  python-version: '3.10'
+                  numpy-version: '<2.0'
+                  astropy-version: '<6.1'
 
         env:
-            DESIUTIL_VERSION: 3.4.3
+            DESIUTIL_VERSION: 3.5.0
             DESIMODEL_VERSION: 0.19.2
             DESIMETER_VERSION: 0.7.1
             DESIMODEL_DATA: branches/test-0.19

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
                 python -m pip install --no-cache-dir --upgrade "numpy${{ matrix.numpy-version }}"
                 python -m pip install --no-cache-dir --upgrade "astropy${{ matrix.astropy-version }}"
                 python -m pip install --no-cache-dir fitsio
-                python -m pip install --no-cache-dir git+https://github.com/desihub/desiutil.git@${{ env.DESIUTIL_VERSION }}#egg=desiutil
+                python -m pip install desiutil==${DESIUTIL_VERSION}
                 python -m pip install --no-cache-dir git+https://github.com/desihub/desimodel.git@${{ env.DESIMODEL_VERSION }}#egg=desimodel
                 python -m pip install --no-cache-dir git+https://github.com/desihub/desitarget.git@${{ env.DESITARGET_VERSION }}#egg=desitarget
                 python -m pip install --no-cache-dir git+https://github.com/desihub/desimeter.git@${{ env.DESIMETER_VERSION }}#egg=desimeter

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
 
         env:
             DESIUTIL_VERSION: 3.5.0
-            DESIMODEL_VERSION: 0.19.2
+            DESIMODEL_VERSION: 0.19.3
             DESIMETER_VERSION: 0.7.1
             DESIMODEL_DATA: branches/test-0.19
             DESIMODEL: ${{ github.workspace }}/desimodel

--- a/py/fiberassign/assign.py
+++ b/py/fiberassign/assign.py
@@ -74,7 +74,7 @@ results_assign_columns = OrderedDict([
     ("LAMBDA_REF", "f4"),
     ("PETAL_LOC", "i2"),
     ("DEVICE_LOC", "i4"),
-    ("DEVICE_TYPE", "a3"),
+    ("DEVICE_TYPE", "S3"),
     ("TARGET_RA", "f8"),
     ("TARGET_DEC", "f8"),
     ("FA_TARGET", "i8"),
@@ -466,7 +466,7 @@ def write_assignment_fits_tile(asgn, tagalong, fulltarget, overwrite, params):
         fdata["PETAL_LOC"] = np.array(
             [petal[x] for x in locs]).astype(np.int16)
         fdata["DEVICE_TYPE"] = np.array(
-            [device_type[x] for x in locs]).astype(np.dtype("a3"))
+            [device_type[x] for x in locs]).astype(np.dtype("S3"))
 
         # This hard-coded value copied from the original code...
         lambda_ref = np.ones(nloc, dtype=np.float32) * 5400.0
@@ -1027,7 +1027,7 @@ merged_fiberassign_req_columns = OrderedDict([
     ("LAMBDA_REF", "f4"),
     ("FA_TARGET", "i8"),
     ("FA_TYPE", "u1"),
-    ("OBJTYPE", "a3"),
+    ("OBJTYPE", "S3"),
     ("FIBERASSIGN_X", "f4"),
     ("FIBERASSIGN_Y", "f4"),
     #("NUMTARGET", "i2"),
@@ -1058,7 +1058,7 @@ merged_skymon_columns = OrderedDict([
     ("TARGET_DEC", "f8"),
     ("FIBERASSIGN_X", "f4"),
     ("FIBERASSIGN_Y", "f4"),
-    ("BRICKNAME", "a8"),
+    ("BRICKNAME", "S8"),
     ("FIBERSTATUS", "i4"),
     ("PETAL_LOC", "i2"),
     ("DEVICE_LOC", "i4"),

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -237,7 +237,7 @@ def get_program_latest_timestamp(
     if len(tms) > 0:
         timestamp = np.sort(tms)[-1]
         # AR does not end with +NN:MM timezone?
-        if re.search('\+\d{2}:\d{2}$', timestamp) is None:
+        if re.search(r'\+\d{2}:\d{2}$', timestamp) is None:
             timestamp = "{}+00:00".format(timestamp)
 
     log.info("{:.1f}s\t{}\tlatest timestamp : {}".format(time() - start, step, timestamp))

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -149,13 +149,13 @@ def get_program_latest_timestamp(
     if os.path.isfile(fn):
         d = Table.read(fn)
         if program.upper() in ["DARK", "DARK1B"]:
-            keep = np.in1d(d["PROGRAM"], ["DARK", "DARK1B"])
+            keep = np.isin(d["PROGRAM"], ["DARK", "DARK1B"])
         elif program.upper in ["BRIGHT", "BRIGHT1B"]:
-            keep = np.in1d(d["PROGRAM"], ["BRIGHT", "BRIGHT1B"])
+            keep = np.isin(d["PROGRAM"], ["BRIGHT", "BRIGHT1B"])
         else:
             keep = d["PROGRAM"] == program.upper()
         # AR add a cut on TILEID
-        # AR TODO: read tiles-{survey}.ecsv and use np.in1d()
+        # AR TODO: read tiles-{survey}.ecsv and use np.isin()
         if survey == "sv3":
             keep &= (d["TILEID"] < 1000)
         if survey == "main":
@@ -1570,7 +1570,7 @@ def create_mtl(
                 # AR sanity check: dups should have MTL_CONTAINS corresponding to
                 # AR    both ledgers
                 _ = np.arange(len(targ), dtype=int)
-                dups_ii = _[~np.in1d(_, ii)]
+                dups_ii = _[~np.isin(_, ii)]
                 dups_tids = np.unique(targ["TARGETID"][dups_ii])
                 oc0 = os.path.normpath(targdirs[0]).split(os.path.sep)[-1].upper()
                 oc1 = os.path.normpath(targdirs[1]).split(os.path.sep)[-1].upper()
@@ -1584,8 +1584,8 @@ def create_mtl(
                             dups_tids.size,
                             expect_dups_tids.size,
                             np.max([
-                                (~np.in1d(dups_ii, expect_dups_tids)).sum(),
-                                (~np.in1d(expect_dups_ii, dups_ii)).sum()
+                                (~np.isin(dups_ii, expect_dups_tids)).sum(),
+                                (~np.isin(expect_dups_ii, dups_ii)).sum()
                             ])
                     )
                     log.error(msg)
@@ -1623,7 +1623,7 @@ def create_mtl(
             for targdir in targdirs:
                 radec = fitsio.read(targdir, columns=["RA", "DEC"])
                 pixs = hp.ang2pix(nside, np.radians((90. - radec["DEC"])), np.radians(radec["RA"]), nest=nest)
-                ii = np.where(np.in1d(pixs, pixlist))[0]
+                ii = np.where(np.isin(pixs, pixlist))[0]
                 jj = is_point_in_desi(tiles, radec["RA"][ii], radec["DEC"][ii])
                 rows = ii[jj]
                 targ = Table(fitsio.read(targdir, columns = columns + ["TARGETID"], rows=rows))
@@ -3510,7 +3510,7 @@ def plot_sky_fa(
         ax = axs[2]
         x = dras["parent"][mskpsel]
         y = ddecs["parent"][mskpsel]
-        C = np.in1d(parent["TARGETID"][mskpsel], assign["TARGETID"][msksel])
+        C = np.isin(parent["TARGETID"][mskpsel], assign["TARGETID"][msksel])
         hb = ax.hexbin(
             x,
             y,

--- a/py/fiberassign/fba_patch_io.py
+++ b/py/fiberassign/fba_patch_io.py
@@ -129,7 +129,7 @@ def get_fafns_to_check(fa_srcdir, skip_subdirs=None, only_subdirs=None, only_til
 
     # AR only tileids?
     if only_tileids is not None:
-        sel = np.in1d(tileids, [int(tileid) for tileid in only_tileids.split(",")])
+        sel = np.isin(tileids, [int(tileid) for tileid in only_tileids.split(",")])
         log.info(
             "{}\trestrict to {} fiberassign files, as per only_tileids".format(
                 only_tileids, sel.sum()
@@ -144,9 +144,9 @@ def get_fafns_to_check(fa_srcdir, skip_subdirs=None, only_subdirs=None, only_til
                 os.getenv("DESI_ROOT"), "spectro", "redux", "daily", "tiles-daily.csv"
             )
         )
-        d = d[~np.in1d(d["FAFLAVOR"], ["cmxposmapping", "unknown"])]
+        d = d[~np.isin(d["FAFLAVOR"], ["cmxposmapping", "unknown"])]
         faflavors, ii = np.unique(d["FAFLAVOR"], return_index=True)
-        sel = np.in1d(tileids, d["TILEID"][ii])
+        sel = np.isin(tileids, d["TILEID"][ii])
         if sel.sum() != ii.size:
             log.warning(
                 "debug: only {} / {} FAFLAVORs picked".format(sel.sum(), ii.size),
@@ -368,7 +368,7 @@ def get_desitarget_fafn_rows(fafn, ras, decs):
     nside, nest = pixarea2nside(7.0), True
     pixlist = tiles2pix(nside, tiles=tiles)
     pixs = hp.ang2pix(nside, np.radians((90.0 - decs)), np.radians(ras), nest=nest)
-    ii = np.where(np.in1d(pixs, pixlist))[0]
+    ii = np.where(np.isin(pixs, pixlist))[0]
     jj = is_point_in_desi(tiles, ras[ii], decs[ii])
     rows = ii[jj]
     return rows
@@ -479,7 +479,7 @@ def get_dith_infos(ext, name, fafn, fa_name):
         h = fits.open(fafn)
         if "EXTRA" in [h[i].header["EXTNAME"] for i in range(1, len(h))]:
             fa_undith = h["EXTRA"].data
-            sel = np.in1d(fa_name["TARGETID"], fa_undith["TARGETID"])
+            sel = np.isin(fa_name["TARGETID"], fa_undith["TARGETID"])
             isdith[sel] = True
     log.info(
         "{:06d}\t{}\t{}\tdith: found {} rows".format(
@@ -1294,7 +1294,7 @@ def patch(in_fafn, out_fafn, params_fn):
             if len(I) == 0:
                 continue
             T = T[I]
-            ii_match += np.where(np.in1d(unq_targetids, T["TARGETID"]))[0].tolist()
+            ii_match += np.where(np.isin(unq_targetids, T["TARGETID"]))[0].tolist()
 
             # AR "targetids" are the ones from the FA file
             # AR "tids" are the ones from the desitarget files (always > 0)

--- a/py/fiberassign/fba_patch_io.py
+++ b/py/fiberassign/fba_patch_io.py
@@ -5,7 +5,7 @@ import os
 from glob import glob
 import tempfile
 import yaml
-from pkg_resources import resource_filename
+from importlib import resources
 from datetime import datetime, timezone
 import numpy as np
 import fitsio
@@ -1176,11 +1176,11 @@ def get_patching_params(fn="patching_202210.yaml"):
 
     Notes:
         fn: the code will first look for:
-            - first look for: resource_filename("fiberassign", os.path.join("data", fn))
+            - first look for: resources.files("fiberassign").joinpath("data", fn)
             - then look for: fn
         See fiberassign/data/patching_202210.yaml for the formatting.
     """
-    myfn = resource_filename("fiberassign", os.path.join("data", fn))
+    myfn = str(resources.files("fiberassign").joinpath("data", fn))
     if not os.path.isfile(myfn):
         log.warning("no {}".format(myfn))
         myfn = fn
@@ -1210,8 +1210,8 @@ def patch(in_fafn, out_fafn, params_fn):
         Targets are matched on TARGETID, and values updated as necessary.
         If any rows are changed, then an updated file is written out, preserving all other HDUs.
         params_fn:
-            - the code will first look for:
-                - first look for: resource_filename("fiberassign", os.path.join("data", fn))
+            - the code will use get_patching_params to first look for:
+                - first look for: resources.files("fiberassign").joinpath("data", fn)
                 - then look for: fn
             - see fiberassign/data/patching_202210.yaml for the formatting.
     """

--- a/py/fiberassign/fba_rerun_io.py
+++ b/py/fiberassign/fba_rerun_io.py
@@ -968,7 +968,7 @@ def fba_rerun_check(
             ]
         )
         # AR missed in rerun
-        ii = np.where(~np.in1d(orig_ids, rerun_ids))[0]
+        ii = np.where(~np.isin(orig_ids, rerun_ids))[0]
         for i in ii:
             f.write(
                 "{:06}\t{}\tmiss\t{}\n".format(
@@ -978,7 +978,7 @@ def fba_rerun_check(
                 )
             )
         # AR added in rerun
-        ii = np.where(~np.in1d(rerun_ids, orig_ids))[0]
+        ii = np.where(~np.isin(rerun_ids, orig_ids))[0]
         for i in ii:
             f.write(
                 "{:06}\t{}\tadd\t{}\n".format(

--- a/py/fiberassign/fba_tertiary_io.py
+++ b/py/fiberassign/fba_tertiary_io.py
@@ -267,7 +267,7 @@ def assert_tertiary_targ(prognum, targfn):
 
     # AR warning if some columns are present but will be overwritten
     keys = np.array(targ.dtype.names)
-    sel = np.in1d(
+    sel = np.isin(
         keys,
         [
             "SCND_ORDER",
@@ -432,9 +432,9 @@ def get_numobs_priority(too, prio, prognum, previous_tileids=None, fadir=None):
                 _, prev_prognum, prev_release, _, _, _ = decode_targetid(
                     prev_d["TARGETID"]
                 )
-                sel = np.in1d(prev_release, release) & np.in1d(prev_prognum, prognum)
+                sel = np.isin(prev_release, release) & np.isin(prev_prognum, prognum)
                 prev_d = prev_d[sel]
-                sel = np.in1d(too["TARGETID"], prev_d["TARGETID"])
+                sel = np.isin(too["TARGETID"], prev_d["TARGETID"])
                 # AR update columns
                 numobss[sel] += 1
                 numobs_mores[sel] -= 1

--- a/py/fiberassign/hardware.py
+++ b/py/fiberassign/hardware.py
@@ -309,7 +309,7 @@ def load_hardware_args(focalplane=None, rundate=None, add_margins={}):
     nloc = len(keep_rows)
     log.debug("  focalplane table keeping {} rows for POS and ETC devices".format(nloc))
 
-    device_type = np.full(nloc, "OOPSBUG", dtype="a8")
+    device_type = np.full(nloc, "OOPSBUG", dtype="S8")
     device_type[:] = fp["DEVICE_TYPE"][keep_rows]
 
     locations = np.copy(fp["LOCATION"][keep_rows])

--- a/py/fiberassign/scripts/assign.py
+++ b/py/fiberassign/scripts/assign.py
@@ -285,7 +285,7 @@ def parse_assign(optlist=None):
         args.obsdate, _ = get_obsdate(rundate=args.rundate)
 
     # convert YEARMMDD to YEAR-MM-DD to be ISO 8601 compatible
-    if re.match('\d{8}', args.obsdate):
+    if re.match(r'\d{8}', args.obsdate):
         year = args.obsdate[0:4]
         mm = args.obsdate[4:6]
         dd = args.obsdate[6:8]

--- a/py/fiberassign/test/simulate.py
+++ b/py/fiberassign/test/simulate.py
@@ -211,7 +211,7 @@ def sim_targets(path, tgtype, tgoffset, density=5000.0, science_frac=None):
         ("DESI_TARGET", "i8"),
         ("BRICKID", "i4"),
         ("BRICK_OBJID", "i4"),
-        ("BRICKNAME", "a8"),
+        ("BRICKNAME", "S8"),
         ("PRIORITY", "i4"),
         ("SUBPRIORITY", "f8"),
         ("OBSCONDITIONS", "i4"),

--- a/py/fiberassign/test/test_assign.py
+++ b/py/fiberassign/test/test_assign.py
@@ -630,14 +630,3 @@ class TestAssign(unittest.TestCase):
         #                     # self.assertEqual(newtg, tg)
 
         return
-
-
-def test_suite():
-    """Allows testing of only this module with the command::
-
-        python setup.py test -m <modulename>
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)
-
-# Note that you can run a single test function with
-# python3 -m unittest fiberassign.test.test_assign.TestAssign.test_full

--- a/py/fiberassign/test/test_hardware.py
+++ b/py/fiberassign/test/test_hardware.py
@@ -290,10 +290,3 @@ class TestHardware(unittest.TestCase):
             self.assertTrue(False)
 
         return
-
-def test_suite():
-    """Allows testing of only this module with the command::
-
-        python setup.py test -m <modulename>
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/fiberassign/test/test_qa.py
+++ b/py/fiberassign/test/test_qa.py
@@ -295,11 +295,3 @@ class TestQA(unittest.TestCase):
             self.assertEqual(err, 0, f"FAILED ({err}): {cmd}")
         else:
             print(f"ERROR: didn't find {script}")
-
-
-def test_suite():
-    """Allows testing of only this module with the command::
-
-        python setup.py test -m <modulename>
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/fiberassign/test/test_targets.py
+++ b/py/fiberassign/test/test_targets.py
@@ -150,11 +150,3 @@ class TestTargets(unittest.TestCase):
             default_main_skymask(), default_main_suppskymask(),
             default_main_safemask(), mask, default_main_gaia_stdmask())
         self.assertTrue(not np.any(result))
-
-
-def test_suite():
-    """Allows testing of only this module with the command::
-
-        python setup.py test -m fiberassign.test.test_targets
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/fiberassign/test/test_tiles.py
+++ b/py/fiberassign/test/test_tiles.py
@@ -63,11 +63,3 @@ class TestTiles(unittest.TestCase):
         self.assertEqual(tls.obstime[1], Time('2020-11-23').isot)
 
         return
-
-
-def test_suite():
-    """Allows testing of only this module with the command::
-
-        python setup.py test -m <modulename>
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/fiberassign/test/test_vis.py
+++ b/py/fiberassign/test/test_vis.py
@@ -253,11 +253,3 @@ class TestVis(unittest.TestCase):
         suffix = "{}".format(time)
         self._load_and_plotfp(hw, test_dir, suffix, simple=False)
         return
-
-
-def test_suite():
-    """Allows testing of only this module with the command::
-
-        python setup.py test -m <modulename>
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/fiberassign/utils.py
+++ b/py/fiberassign/utils.py
@@ -18,7 +18,7 @@ import numpy as np
 from astropy.table import Table
 from astropy.time import Time
 import yaml
-from pkg_resources import resource_filename
+from importlib import resources
 from desiutil.log import get_logger
 from ._internal import (Logger, Timer, GlobalTimers, Circle, Segments, Shape,
                         Environment)
@@ -115,7 +115,7 @@ def get_date_cutoff(datetype, cutoff_case):
         date_cutoff: cutoff date for datetype and cutoff_case, in the "YYYY-MM-DDThh:mm:ss+00:00" formatting (string)
 
     """
-    fn = resource_filename("fiberassign", "data/cutoff-dates.yaml")
+    fn = str(resources.files("fiberassign").joinpath("data", "cutoff-dates.yaml"))
     with open(fn, "r") as f:
         config = yaml.safe_load(f)
     f.close()

--- a/py/fiberassign/utils.py
+++ b/py/fiberassign/utils.py
@@ -419,7 +419,7 @@ def get_rev_fiberassign_changes(svndir, rev, subdirs=None):
     # AR cut on subdirs
     tmp_tileids = np.array([int(os.path.basename(fn)[12:18]) for fn in fns])
     tmp_subdirs = np.array(["{:06d}".format(tileid)[:3] for tileid in tmp_tileids])
-    sel = np.in1d(tmp_subdirs, subdirs.split(","))
+    sel = np.isin(tmp_subdirs, subdirs.split(","))
     fns, changes = fns[sel], changes[sel]
     log.info("rev={}\tdate={}\tnfile={}\t(dt={:.1f}s)".format(rev, date, len(fns), dt))
     # AR store


### PR DESCRIPTION
This PR expands the test matrix version coverage, addresses various deprecation warnings raised with numpy 2.x, and replaces `pkg_resources` with `importlib.resources`.

Closes #484.