### PR TITLE
Minor Enhancements and Bug Fixes to fba_replay.

### DIFF
--- a/etc/fba_replay_kpno.sh
+++ b/etc/fba_replay_kpno.sh
@@ -14,6 +14,9 @@ usage () {
     --subfolder     SUBFOLDER     optional; if set, only rerun that subfolder (e.g. 001, for 1??? tileids)
     --rerundir      RERUNDIR      the local folder where outputs will be stored
     --njob          NJOB          nb of parallel jobs running (default=8)
+    --rerun                       optional; toggles whether to do the rerun or not
+    --compare                     optional; toggles comparing rerun fiberassign output to original KPNO output
+    --concat                      optional; toggles concatenating all the diff files into one large diff file
 
     Should be run on one or multiple interactive (or debug) nodes.
     If the reproducibility is successful, then the \$RERUNDIR/fba_nersc_kpno-diff.asc
@@ -24,6 +27,10 @@ usage () {
     This script was typically used to perform NERSC vs. KPNO reproducibility
         when developing fiberassign code (one would then load the local, in development
         version of the fiberassign code before running).
+
+    If any of the toggles (--rerun, --compare and --concat) are toggled on, any toggles not explciitly
+        set on will be set to false. If none of the toggles are passed, they are all assumed to be true
+        and all three steps are run.
 
     Files from KPNO should be organized as follows:
         \$KPNO_COPYDIR/000/fiberassign-001000.fits.gz

--- a/etc/fba_replay_kpno.sh
+++ b/etc/fba_replay_kpno.sh
@@ -121,7 +121,7 @@ if [[ "$SUBFOLDER" == "" ]]
 then
     ORIGFNS=`ls $KPNO_COPYDIR/???/fiberassign-??????.fits.gz`
 else
-    ORIGFNS=`ls $KPNO_COPYDIR/100/fiberassign-??????.fits.gz`
+    ORIGFNS=`ls $KPNO_COPYDIR/$SUBFOLDER/fiberassign-??????.fits.gz`
 fi
 
 # AR text file with the commands to rerun the KPNO fiberassign files
@@ -175,5 +175,5 @@ do
     COUNT=`echo $COUNT | awk '{print $1+1}'`
     cat $DIFFFN | grep -v \# >> $DIFFASC
 done
-echo "    Done at: " `date`                                                                                                                                                                    
+echo "    Done at: " `date`
 

--- a/etc/fba_replay_kpno.sh
+++ b/etc/fba_replay_kpno.sh
@@ -55,6 +55,12 @@ HELP_USAGE
 
 [ -z "$1" ] && { usage; exit;}
 
+# Switches for each of the three steps, in case we want to run any combination
+# of less than all three of them
+RERUN=false
+COMPARE=false
+CONCAT=false
+
 # AR read the provided arguments
 POSITIONAL=()
 while [[ $# -gt 0 ]]
@@ -83,6 +89,15 @@ do
             shift
             shift
             ;;
+            --rerun)
+            RERUN=true
+            ;;
+            --compare)
+            COMPARE=true
+            ;;
+            --concat)
+            CONCAT=true
+            ;;
             *)
                   # unknown option
             ;;
@@ -91,12 +106,24 @@ do
     set -- "${POSITIONAL[@]}" # restore positional parameters
 done
 
+# If all are false still then none of them were passed, so set them all to true
+# to run all steps.
+if ! $RERUN && ! $COMPARE && ! $CONCAT
+then
+    RERUN=true
+    COMPARE=true
+    CONCAT=true
+fi
+
 # AR print arguments
 echo ""
 echo "KPNO_COPYDIR="$KPNO_COPYDIR
 echo "SUBFOLDER="$SUBFOLDER
 echo "RERUNDIR="$RERUNDIR
 echo "NJOB="$NJOB
+echo "RERUN="$RERUN
+echo "COMPARE="$COMPARE
+echo "CONCAT="$CONCAT
 echo ""
 
 # AR to manage multiple jobs over one or several nodes, with GNU parallel
@@ -124,56 +151,62 @@ else
     ORIGFNS=`ls $KPNO_COPYDIR/$SUBFOLDER/fiberassign-??????.fits.gz`
 fi
 
-# AR text file with the commands to rerun the KPNO fiberassign files
-rm $CMDSH
-echo "rerun fiberassign-TILEID.fits.gz"
-echo "    Start at: " `date`
-for ORIGFN in $ORIGFNS
-do
-    echo 'fba_rerun --infiberassign '$ORIGFN' --outdir '$RERUNDIR' --nosteps qa' >> $CMDSH
-done
+if $RERUN
+then
+    # AR text file with the commands to rerun the KPNO fiberassign files
+    rm $CMDSH
+    echo "rerun fiberassign-TILEID.fits.gz"
+    echo "    Start at: " `date`
+    for ORIGFN in $ORIGFNS
+    do
+        echo 'fba_rerun --infiberassign '$ORIGFN' --outdir '$RERUNDIR' --nosteps qa' >> $CMDSH
+    done
 
-# AR execute the rerun in parallel
-CMD="srun --ntasks $SLURM_NNODES --ntasks-per-node 1 --wait=0 $WRAP_PARALLEL_FN --input_fn $CMDSH --njob $NJOB > $CMDLOG 2>&1"
-echo "    "$CMD
-eval $CMD
+    # AR execute the rerun in parallel
+    CMD="srun --ntasks $SLURM_NNODES --ntasks-per-node 1 --wait=0 $WRAP_PARALLEL_FN --input_fn $CMDSH --njob $NJOB > $CMDLOG 2>&1"
+    echo "    "$CMD
+    eval $CMD
 echo "    Done at: " `date`
+fi
 
+if $COMPARE
+then
+    # AR text file with the_NERSC vs. KPNO comparison command for each fiberassign file
+    rm $DIFFSH
+    echo "run NERSC vs. KPNO comparison"
+    echo "    Start at: " `date`
+    for ORIGFN in $ORIGFNS
+    do
+        SUBDIR=`basename $ORIGFN | awk '{print substr($1, 13, 3)}'`
+        RERUNFN=$RERUNDIR/$SUBDIR/`basename $ORIGFN`
+        DIFFFN=`echo $RERUNFN | sed -e 's/.fits.gz/.diff/'`
+        echo 'python -c '\''from fiberassign.fba_rerun_io import fba_rerun_check; fba_rerun_check("'$ORIGFN'", "'$RERUNFN'", "'$DIFFFN'")'\''' >> $DIFFSH
+    done
 
-# AR text file with the_NERSC vs. KPNO comparison command for each fiberassign file
-rm $DIFFSH
-echo "run NERSC vs. KPNO comparison"
-echo "    Start at: " `date`
-for ORIGFN in $ORIGFNS
-do
-    SUBDIR=`basename $ORIGFN | awk '{print substr($1, 13, 3)}'`
-    RERUNFN=$RERUNDIR/$SUBDIR/`basename $ORIGFN`
-    DIFFFN=`echo $RERUNFN | sed -e 's/.fits.gz/.diff/'`
-    echo 'python -c '\''from fiberassign.fba_rerun_io import fba_rerun_check; fba_rerun_check("'$ORIGFN'", "'$RERUNFN'", "'$DIFFFN'")'\''' >> $DIFFSH
-done
+    # AR execute the comparison in parallel
+    CMD="srun --ntasks $SLURM_NNODES --ntasks-per-node 1 --wait=0 $WRAP_PARALLEL_FN --input_fn $DIFFSH --njob $NJOB > $DIFFLOG 2>&1"
+    echo "    "$CMD
+    eval $CMD
+    echo "    Done at: " `date`
+fi
 
-# AR execute the comparison in parallel
-CMD="srun --ntasks $SLURM_NNODES --ntasks-per-node 1 --wait=0 $WRAP_PARALLEL_FN --input_fn $DIFFSH --njob $NJOB > $DIFFLOG 2>&1"
-echo "    "$CMD
-eval $CMD
-echo "    Done at: " `date`
-
-
-# AR make a single diff file for the NERSC vs. KPNO comparison
-echo "create a single diff file"
-echo "    Start at: " `date`
-COUNT=0
-for ORIGFN in $ORIGFNS
-do
-    SUBDIR=`basename $ORIGFN | awk '{print substr($1, 13, 3)}'`
-    RERUNFN=$RERUNDIR/$SUBDIR/`basename $ORIGFN`
-    DIFFFN=`echo $RERUNFN | sed -e 's/.fits.gz/.diff/'`
-    if [[ $COUNT == 0 ]]
-    then
-        head -n 1 $DIFFFN > $DIFFASC
-    fi
-    COUNT=`echo $COUNT | awk '{print $1+1}'`
-    cat $DIFFFN | grep -v \# >> $DIFFASC
-done
-echo "    Done at: " `date`
-
+if $CONCAT
+then
+    # AR make a single diff file for the NERSC vs. KPNO comparison
+    echo "create a single diff file"
+    echo "    Start at: " `date`
+    COUNT=0
+    for ORIGFN in $ORIGFNS
+    do
+        SUBDIR=`basename $ORIGFN | awk '{print substr($1, 13, 3)}'`
+        RERUNFN=$RERUNDIR/$SUBDIR/`basename $ORIGFN`
+        DIFFFN=`echo $RERUNFN | sed -e 's/.fits.gz/.diff/'`
+        if [[ $COUNT == 0 ]]
+        then
+            head -n 1 $DIFFFN > $DIFFASC
+        fi
+        COUNT=`echo $COUNT | awk '{print $1+1}'`
+        cat $DIFFFN | grep -v \# >> $DIFFASC
+    done
+    echo "    Done at: " `date`
+fi


### PR DESCRIPTION
This PR makes (minor) changes to fba_replay_kpno.sh. The script is designed to load logs and fiberassign output files copied from KPNO, rerun the fiberassignment using the currently initialized environment (and associated desi* package versions, which may be different than the original) to either confirm or deny reproducibility. I have been using the script to rerun fiberassign to check the impact of the MTL read_two_ledgers bug. 

First, this PR fixes a bug that originally hardcoded the subdirectory, meaning any subdirectory passed to the script was ignored, and the script attempted to run only over the subdirectory "100". 

Second, I've added some quality of life toggles as command line arguments to the script:
`--rerun`: toggles running the actual fiber assign rerun
`--compare`: toggles running the comparison between the new fiberassignment and the KPNO fiber assignment.
`--concat`: toggles concatenating all of the individual diff files into one global file.

These toggles were motivated by the large volume of tiles necessary to rerun. In this regime it was necessary to run in two jobs, instead of running all the tiles (or attempting to) in one job. The script as originally coded, for example, only concatenates the diffs for the tile(s) run in this specific job/run, but with the command switch you can now concat the two runs together by passing only the `--concat` flag.

Alternatively, one could run only the `--rerun` flag if they only wanted to replay, but did not necessitate any information about the difference to the KPNO output (for example, if a user has their own pipeline for comparing fiber assign). 

The behavior of these toggles is as such:
- If no toggles are passed, the script assumes that all three steps are requested. This means that the script is backwards compatible (modulo the bug fix) with previous versions: if you run the script with the exact command before and after this PR the results are identical.
- If one or more toggles are passed, then only those specific steps are run. 