### PR TITLE
20260220 Patching of "NaN" TARGET_RA, TARGET_DEC, FIBERASSIGN_X, FIBERASSIGN_Y

### DIFF
--- a/etc/patch_nans.py
+++ b/etc/patch_nans.py
@@ -1,0 +1,95 @@
+from astropy.io import fits # use astropy.io.fits here because it allows us to implace update a fits file.
+import numpy as np
+from pathlib import Path
+from fiberassign.hardware import load_hardware, xy2radec, xy2cs5
+from types import SimpleNamespace
+
+import argparse
+from datetime import datetime, timezone
+
+parser = argparse.ArgumentParser()
+parser.add_argument("input", type=str, help="base directory of copied fiberassign files to process")
+args = parser.parse_args()
+# We will mimic the loop that sets the RA/DEC values at save time
+# using the run parameters saved in the original fiberassign files.
+
+orig_loc = Path(args.input)
+
+for fba_file in sorted(orig_loc.glob("*/fiberassign*fits.gz")):
+    with fits.open(fba_file, "update") as h:
+        tbl = h["FIBERASSIGN"].data
+        # Table of objects that need to be patched.
+        patch_tbl = tbl[np.isnan(tbl["TARGET_RA"]) | np.isnan(tbl["TARGET_DEC"])]
+
+        print(f"{fba_file}, {len(patch_tbl)} to update")
+        if len(patch_tbl) == 0: continue
+
+        header = h[0].header
+        runtime = header["FA_RUN"]
+
+        tile_ra = header["TILERA"]
+        tile_dec = header["TILEDEC"]
+        tile_obstime = header["FA_PLAN"]
+        tile_obsha = header["FA_HA"]
+        tile_obstheta = header["FIELDROT"]
+
+        hw = load_hardware(None, rundate=runtime)
+
+        # To be 100% clear, I don't exactly understand why we pull those out into
+        # new object. Again, I'm just mimicing the loop that sets these
+        # values in fiberassign when the output is saved.
+        hwduck = SimpleNamespace()
+        for attribute in [
+                'state', 'loc_pos_curved_mm', 'loc_theta_pos',
+                'loc_theta_offset', 'loc_phi_pos', 'loc_phi_offset',
+                'loc_theta_arm', 'loc_phi_arm', 'loc_theta_min',
+                'loc_phi_min', 'loc_theta_max', 'loc_phi_max']:
+            setattr(hwduck, attribute, getattr(hw, attribute))
+
+        # Extract the x, y coordinate of the stuck positioners from the
+        # hardware state using their theta and phi positions.
+        all_x = np.zeros(len(patch_tbl))
+        all_y = np.zeros(len(patch_tbl))
+
+        for i, loc in enumerate(patch_tbl["LOCATION"]):
+            xy = hw.thetaphi_to_xy(
+                                hwduck.loc_pos_curved_mm[loc],
+                                hwduck.loc_theta_pos[loc] + hwduck.loc_theta_offset[loc],
+                                hwduck.loc_phi_pos  [loc] + hwduck.loc_phi_offset  [loc],
+                                hwduck.loc_theta_arm[loc],
+                                hwduck.loc_phi_arm[loc],
+                                hwduck.loc_theta_offset[loc],
+                                hwduck.loc_phi_offset[loc],
+                                hwduck.loc_theta_min[loc],
+                                hwduck.loc_phi_min[loc],
+                                hwduck.loc_theta_max[loc],
+                                hwduck.loc_phi_max[loc],
+                                ignore_range=True
+                            )
+            all_x[i] = xy[0]
+            all_y[i] = xy[1]
+
+        # Convert those xy positions to the ra and dec positions.
+        ra,dec = xy2radec(hw, tile_ra, tile_dec, tile_obstime, tile_obstheta, tile_obsha,
+                    all_x, all_y, False, 0)
+
+        patch_tbl["TARGET_RA"] = ra
+        patch_tbl["TARGET_DEC"] = dec
+
+        # Patch these to match, because they also got set to nan originally
+        fiber_x, fiber_y = xy2cs5(all_x, all_y)
+
+        patch_tbl["FIBERASSIGN_X"] = fiber_x
+        patch_tbl["FIBERASSIGN_Y"] = fiber_y
+
+        # Copy the rows from the patch table into the full table.
+        # Remember we onl changed the values of TARGET_RAm DEC and FIBERASSIGN X, Y
+        # in the patch table, so all other values should remain unchanged.
+        for i, loc in enumerate(patch_tbl["LOCATION"]):
+            tbl[tbl["LOCATION"] == loc] = patch_tbl[i]
+
+        time_string = datetime.isoformat(datetime.now(timezone.utc), timespec="seconds")
+        header.add_comment(f"NaN RA/DEC Patched on {time_string}")
+
+    # According to the docs when we exit the context manager the changes should
+    # flush to the file....


### PR DESCRIPTION
In order to fix desihub/desispec/issues/2359, we have opted to patch the original fiberassign outputs for any tiles where the early version of fiberassign propagated a "NaN" value to the TARGET_RA and TARGET_DEC columns in the `FIBERASSIGN` header. The full set of 471 tiles affected is

```
1,     2,     3,     4,     5,     6,     7,     8,     9,
           10,    11,    12,    13,    14,    15,    16,    17,    18,
           19,    20,    21,    23,    24,    28,    29,    30,    31,
           32,    33,    34,    35,    39,    40,    41,    42,    43,
           44,    45,    46,    47,    48,    49,    50,    51,    52,
           53,    55,    56,    57,    58,    59,    60,    61,    62,
           63,    66,    67,    68,    69,    70,    71,    72,    73,
           77,    78,    79,    82,    83,    84,    85,    86,    87,
           88,    89,    90,    91,    92,    93,    94,    95,    96,
           97,    98,    99,   100,   104,   105,   106,   107,   109,
          110,   111,   112,   113,   114,   115,   116,   117,   118,
          119,   120,   121,   122,   123,   124,   125,   126,   131,
          132,   133,   136,   137,   138,   139,   140,   141,   142,
          143,   144,   145,   146,   147,   148,   149,   150,   151,
          152,   153,   154,   158,   163,   164,   165,   166,   167,
          168,   169,   170,   171,   174,   175,   176,   177,   178,
          179,   180,   181,   185,   186,   187,   190,   191,   192,
          193,   194,   195,   196,   197,   198,   199,   201,   202,
          203,   204,   205,   206,   207,   208,   209,   210,   211,
          212,   213,   214,   215,   217,   218,   219,   220,   221,
          222,   223,   224,   225,   226,   228,   229,   230,   231,
          232,   233,   234,   244,   245,   246,   247,   248,   249,
          250,   251,   252,   253,   254,   255,   256,   257,   258,
          259,   260,   261,   262,   263,   271,   272,   273,   274,
          275,   276,   277,   278,   279,   280,   281,   282,   283,
          284,   285,   286,   287,   288,   289,   298,   299,   300,
          301,   302,   303,   304,   305,   306,   307,   308,   309,
          310,   311,   312,   313,   314,   315,   316,   317,   318,
          319,   320,   321,   325,   326,   327,   328,   329,   330,
          331,   332,   333,   334,   335,   336,   337,   338,   339,
          340,   341,   342,   343,   344,   345,   347,   352,   353,
          354,   355,   356,   357,   358,   359,   360,   361,   362,
          363,   364,   365,   366,   367,   368,   369,   370,   371,
          372,   374,   375,   379,   380,   381,   382,   383,   384,
          385,   386,   387,   388,   389,   390,   391,   392,   393,
          394,   395,   396,   397,   398,   401,   402,   406,   407,
          408,   409,   410,   411,   412,   413,   414,   415,   416,
          417,   418,   419,   420,   421,   422,   423,   424,   425,
          428,   429,   433,   436,   437,   439,   440,   454,   457,
          472,   475,   478,   481,   482,   483,   484,   495,   496,
          506,   511,   512,   513,   525,   526,   527,   541,   542,
          543,   555,   556,   571,   572,   573,   585,   586,   587,
          588,   596, 80938, 80944, 80950, 80951, 80952, 80954, 80955,
        80956, 80959, 80960, 80962, 80963, 80966, 80968, 80970, 81000,
        81001, 81002, 81003, 81004, 81005, 81006, 81007, 81008, 81009,
        81010, 81011, 81012, 81013, 81014, 81015, 81022, 81056, 81057,
        81058, 81059, 81060, 81061, 81062, 81063, 81064, 81065, 81066,
        81067, 81068, 81069, 81072, 81073, 81074, 81075, 81088
```

While investigating the discrepancy I noticed that the columns FIBERASSIGN_X and FIBERASSIGN_Y also have "NaN" values where TARGET_RA/DEC have NaNs. This script patches all values "on the fly."

To patch the values, we use the latest version of fiberassign, and load the fiberassign*.fits.gz file. The header records all pertinent tile information (TILE_RA/DEC, hour angle, field rotation, and observation datetime). I use this to load the hardware state of the focal plane for that tile and then mimic the same code used in `fiberassign.assign.write_assignment_fits_tile`, which sets the RA/DEC of the stuck/broken positioners using the stored theta/phi angles of the positioners. I follow the same steps: for **only** the suck positioners where **TARGET_RA/DEC is nan**, I get from the hardware state the positioner x/y position based on their theta/phi values. I then convert those to RA/DEC and propagate those to the hdu as TARGET_RA/DEC. I then convert those XY to the CS5 XY to propogate as the FIBERASSIGN_X/Y, following the same procedure that fiberassign does now. 

The result is that the stuck fibers should now have the values they would have had had fiberassign been run with the code today. 

For documentation purposes, I added a comment to the fits header reading "NaN RA/DEC Patched on {time_string}", where time_string is the timestamp in UTC time that the patched file was written out. 

The patched versions of the files currently live here in my cfs: `${DESI_CFS}/dylang/tiles_patch/`, subdivided into directories in the same way as the tiles SVN. I would like an independent person to validate that 

1) I have only patched the strictly necessary rows, in the `FIBERASSIGN` header.
2) All other data is present in the fits files. 

The patched versions are slightly smaller on disk than the unpatched, and I'm confident that I didn't touch anything else, so this must be due to the gzip compression being slightly more efficient with no more NaN values.

I have made this a PR to include the script used to do the patching for documentation purposes. 

Once the files have been validated I will copy them to my personal checkout of the tiles SVN, and commit them there. 