### PR TITLE
Only try load MTL_* columns if desitarget >= 2.9.0

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,7 +6,9 @@ fiberassign change log
 5.9.1 (unreleased)
 ------------------
 
-* No changes yet.
+* Don't load MTL* columns for pre-1B tiles in fba_plot. (PR `#502`_).
+
+.. _`#482`: https://github.com/desihub/fiberassign/pull/502
 
 5.9.0 (2026-03-17)
 ------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -8,7 +8,7 @@ fiberassign change log
 
 * Don't load MTL* columns for pre-1B tiles in fba_plot. (PR `#502`_).
 
-.. _`#482`: https://github.com/desihub/fiberassign/pull/502
+.. _`#502`: https://github.com/desihub/fiberassign/pull/502
 
 5.9.0 (2026-03-17)
 ------------------

--- a/py/fiberassign/assign.py
+++ b/py/fiberassign/assign.py
@@ -812,7 +812,7 @@ def read_assignment_fits_tile(tile_file):
         # MTL_HIGHEST, MTL_CONTAINS, and MTL_WANTED. So we check the
         # desitarget version, and if it's below 2.9.0, when those columns
         # were added, we don't try and load those columns.
-        keys_to_check = [s for s in header.keys() if "DEPNAM" in s]
+        keys_to_check = [s for s in header if "DEPNAM" in s]
         version = "0.0.0"
         for k in keys_to_check:
             if header[k] == "desitarget":

--- a/py/fiberassign/assign.py
+++ b/py/fiberassign/assign.py
@@ -808,9 +808,25 @@ def read_assignment_fits_tile(tile_file):
                 if col in fbsky.dtype.names:
                     fiber_data[col][npos:] = fbsky[col]
 
-        full_targets_columns = [(x, y) for x, y in
-                                merged_targets_columns.items()]
-        full_names = [x for x, y in merged_targets_columns.items()]
+        # DG Tiles assigned before the 1b program don't have the columns
+        # MTL_HIGHEST, MTL_CONTAINS, and MTL_WANTED. So we check the
+        # desitarget version, and if it's below 2.9.0, when those columns
+        # were added, we don't try and load those columns.
+        keys_to_check = [s for s in header.keys() if "DEPNAM" in s]
+        version = "0.0.0"
+        for k in keys_to_check:
+            if header[k] == "desitarget":
+                version = header[k.replace("NAM", "VER")]
+
+        if version < "2.9.0":
+            full_targets_columns = [(x, y) for x, y in
+                                    merged_targets_columns.items() if "MTL" not in x]
+            full_names = [x for x, _ in merged_targets_columns.items() if "MTL" not in x]
+        else:
+            full_targets_columns = [(x, y) for x, y in
+                                    merged_targets_columns.items()]
+            full_names = [x for x, _ in merged_targets_columns.items()]
+
         fbtargets = fd["TARGETS"].read()
         nrawtarget = fd["TARGETS"].get_nrows()
 


### PR DESCRIPTION
This fixes the bug identified in #501 by checking the fiberassign headers for the desitarget version. 

This PR fixes the bug by checking the fiberassign header for the `desitarget` version, and then comparing whether its before or after 2.9.0. 2.9.0 is when the MTL* columns were added to desitarget, so those columns do not exist in the fiberassign file before that version. They do, however, exist afterwards.

Behaviour for fba_plot should remain the same for all tiles after desitarget 2.9.0. For tiles before, this PR restores the ability to plot those tiles by no longer attempting to load the MTL* columns. 

I tested this both on the tertiary tile and early BRIGHT tile identified in the ticket:

`fba_plot /global/cfs/cdirs/desi/target/fiberassign/tiles/trunk/023/fiberassign-023093.fits.gz  --out_dir .`
`fba_plot /global/cfs/cdirs/desi/target/fiberassign/tiles/trunk/083/fiberassign-083043.fits.gz --out_dir .`

As well as a new DARK tile:

`fba_plot /global/cfs/cdirs/desi/target/fiberassign/tiles/trunk/004/fiberassign-004170.fits.gz  --out_dir .`

all of which work and plot as expected.