### PR TITLE
Secondary Ledger Changes I: Enable Secondary Ledgers for DARK1B/BRIGHT1B 

### DIFF
--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -329,7 +329,7 @@ def main():
                 for key in sorted(list(mydirs.keys())):
                     if (key[:4] == "scnd") & (key != "scnd") & (key != "scndmtl"):
                         targdirs.append(mydirs[key])
-                create_mtl(
+                status = create_mtl(
                     mytmpouts["tiles"],
                     mydirs["scndmtl"],
                     args.mtltime,
@@ -344,6 +344,10 @@ def main():
                     step="scnd",
                     start=start,
                 )
+                # DG - We exited early for some reason, most likely because
+                # there were no targets in the secondary MTL.
+                if status == 1:
+                    expected_files["scnd"] = False
         else:
             expected_files["scnd"] = False
             log.info("")

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -7,8 +7,10 @@ fiberassign change log
 ------------------
 
 * Don't load MTL* columns for pre-1B tiles in fba_plot. (PR `#502`_).
+* Enable running fiberassign with secondary ledgers for 1B programs. (PR `#504`_).
 
 .. _`#502`: https://github.com/desihub/fiberassign/pull/502
+.. _`#504`: https://github.com/desihub/fiberassign/pull/504
 
 5.9.0 (2026-03-17)
 ------------------

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -1503,6 +1503,11 @@ def create_mtl(
             time() - start, step, len(d), mtldir
         )
     )
+    # Might happen if you load a secondadry 1B program leder before the ledgers
+    # were "turned on"
+    if len(d) == 0:
+        log.warning(f"No targets loaded from {mtldir}. Aborting MTL creation.")
+        return 1
 
     # AR standard stars only?
     if std_only:
@@ -1716,6 +1721,7 @@ def create_mtl(
         n, tmpfn = write_targets(
             tmpoutdir, d, indir=mtldir, indir2=targdirs[0], survey=survey, subpriority=False
         )
+
     _ = mv_write_targets_out(tmpfn, tmpoutdir, outfn, log=log, step=step, start=start,)
 
     # AR mtl: update header if pmcorr = "y"

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -1010,7 +1010,15 @@ def get_desitarget_paths(
                 if os.path.basename(fn) != survey
             ]
         )
-        count = 2
+
+        # DG - If the originally found main secondary target file does not exist then
+        # we will take the next found file to be the primary secondary file.
+        # This is for 1B programs, where the secondary targets files live in main4/
+        # not in main, so fiberassign will crash looking for it in main.
+        if not os.path.isfile(mydirs["scnd"]):
+            count = 1
+        else:
+            count = 2
         for extradir in extradirs:
             fn = os.path.join(
                 os.getenv("DESI_TARGET"),
@@ -1024,7 +1032,10 @@ def get_desitarget_paths(
                 "{}{}".format(extradir, basename),
             )
             if os.path.isfile(fn):
-                mydirs["scnd{}".format(count)] = fn
+                if count == 1:
+                    mydirs["scnd"] = fn
+                else:
+                    mydirs["scnd{}".format(count)] = fn
                 count += 1
 
     # AR log


### PR DESCRIPTION
In accordance with doing the updates in #503 piecemeal, this PR addresses Update 1: The 1B primary ledgers will need to read the 1B secondary ledgers.

Originally it was expected that this would be handled automatically int he code. In practice this required some small minor edits, namely the following two changes:

- Check if `mydirs["scnd"]` exists as a file, and if not, use `mydirs["scnd2"]` as the "primary" secondary targets file.
  - To find the secondary target files the code scans the directories in the`$DESI_TARGET/catalogs/dr9/{dtver}/` directory. It takes the secondary targets saved in `$DESI_TARGET/catalogs/dr9/{dtver}/main` as the "base" file, and scans the tree for main* for additional files. 
  - Previously, the code checked all secondary target files for existence after the base one (i.e. if it finds `main2` it checks if the secondary file there exists before adding it to the list of files to scan later), but never checked the base original file. We now also check the first found file exists. This has no effect on DARK/BRIGHT tiles, for whom the base secondary targets file always exists in the original `main` dir. The main effect is for 1B ledgers, where the targets file will be added to `main4`. 
  - We could also add the secondary targets files to `main` instead, but this is more robust anyway, because we _should_ check that the secondary file in `main` actually exists.
- If no targets are loaded in `create_mtl` exit that function early and inform fba_launch that you did so. 
  - If no targets are loaded, then the `desitarget` function that actually creates the augmented mtl does not create a file at all: https://github.com/desihub/desitarget/blob/81b91948d1d30498d21c7178d931a2b79bd02ba2/py/desitarget/io.py#L614-L616
  - Fiberassign then dies when it tries to use shutil to move the expected augmented mtl file out of its temporary directory to a new name (`[tileid}-scnd.fits`): https://github.com/desihub/fiberassign/blob/b66d17fd96f5661c28af26e4d3606c8c73d551ad/py/fiberassign/fba_launch_io.py#L1708
  - Now we don't die, and explicitly tell `fba_launch` that we did not find any targets. This way we also prevent a crash later, when we would also try move `{tileid}-scnd.fits` out of the temporary directory to the output directory. 
  - It was never expected to load *0* targets from an input target file / mtl. In this case it does happen when you try and reproduce tiles from before enabling the secondary 1b ledgers, and all the 1b secondary targets would get ignored. 

With these changes, fiberassign can now correctly use secondary ledgers in the 1b program.