### PR TITLE
Secondary Ledger Changes II: Enable Secondary Ledgers for BACKUP

### DIFF
--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -316,15 +316,26 @@ def main():
     # AR if not backup
     if ("scnd" in steps):
         if ("scnd" in list(mydirs.keys())):
-            # AR handle dark1b/bright1b, where there is no secondary for now
-            # AR but could be in the future
-            # AR assume here that if there are some secondary, the ledgers should be there
-            if not os.path.isdir(mydirs["scndmtl"]):
+            # DG - For 1A targets we know load the 1b secondary mtls, so we
+            # need to check both scnd mtls, and then we only keep the ones that exist
+            # (in case the 1b ledgers aren't in place for some reason)
+            to_check = mydirs["scndmtl"]
+
+            if not isinstance(to_check, list):
+                to_check = [mydirs["scndmtl"]]
+
+            scnd_exists = []
+            for fname in to_check:
+                if os.path.isdir(fname):
+                    scnd_exists.append(fname)
+
+            if len(scnd_exists) == 0:
                 expected_files["scnd"] = False
                 log.info("")
                 log.info("")
                 log.info("{:.1f}s\tscnd\tno secondary ledgers {}".format(time() - start, mydirs["scndmtl"]))
             else:
+                mydirs["scndmtl"] = scnd_exists
                 targdirs = [mydirs["scnd"]]
                 for key in sorted(list(mydirs.keys())):
                     if (key[:4] == "scnd") & (key != "scnd") & (key != "scndmtl"):

--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -659,12 +659,10 @@ if __name__ == "__main__":
                         help="Add margin (in mm) around GFA keep-out polygons (default: 0.4)")
     parser.add_argument(
         "--dr",
-        help="legacypipe dr (default=dr9). Accepts multiple arguments, if multiple data releases are passed the FIRST argument is used for sky/gfa targets.",
+        help="comma-separated list of legacypipe dr (default=dr9). If multiple data releases are passed the FIRST argument is used for sky/gfa targets.",
         type=str,
-        default=["dr9"], # DG - make this a list because with nargs even with one argument args.dr is a list.
+        default="dr9", # DG - make this a list because with nargs even with one argument args.dr is a list.
         required=False,
-        choices=["dr9", "dr11"],
-        nargs="*"
     )
     parser.add_argument(
         "--gaiadr",
@@ -794,6 +792,15 @@ if __name__ == "__main__":
     args = parser.parse_args()
     log = Logger.get()
     start = time()
+
+    # DG - Turn comma separated data release into list of strings.
+    allowed_dr = ["dr9", "dr11"]
+    args.dr = args.dr.split(",")
+    for dr in args.dr:
+        if dr not in allowed_dr:
+            msg = f"{dr} not in allowed legacypipe data releases: {allowed_dr}"
+            log.error(msg)
+            raise ValueError(msg)
 
     # AR safe: outdir
     if args.outdir[-1] != "/":

--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -659,11 +659,12 @@ if __name__ == "__main__":
                         help="Add margin (in mm) around GFA keep-out polygons (default: 0.4)")
     parser.add_argument(
         "--dr",
-        help="legacypipe dr (default=dr9)",
+        help="legacypipe dr (default=dr9). Accepts multiple arguments, if multiple data releases are passed the FIRST argument is used for sky/gfa targets.",
         type=str,
-        default="dr9",
+        default=["dr9"], # DG - make this a list because with nargs even with one argument args.dr is a list.
         required=False,
-        choices=["dr9"],
+        choices=["dr9", "dr11"],
+        nargs="*"
     )
     parser.add_argument(
         "--gaiadr",

--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -655,7 +655,7 @@ if __name__ == "__main__":
         "--dr",
         help="comma-separated list of legacypipe dr (default=dr9). If multiple data releases are passed the FIRST argument is used for sky/gfa targets.",
         type=str,
-        default="dr9", # DG - make this a list because with nargs even with one argument args.dr is a list.
+        default="dr9",
         required=False,
     )
     parser.add_argument(
@@ -668,7 +668,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--dtver",
-        help="desitarget catalogue version",
+        help="comma-separated list of desitarget catalogue version. If a single value is passed, it is used for ALL legacypipe data releases. If multiple are passed, exactly ONE must be passed for EACH legacypipe dr.",
         type=str,
         default=None,
         required=True,
@@ -795,6 +795,13 @@ if __name__ == "__main__":
             msg = f"{dr} not in allowed legacypipe data releases: {allowed_dr}"
             log.error(msg)
             raise ValueError(msg)
+
+    # DG - Turn comma separated dtver into list of strings.
+    args.dtver = args.dtver.split(",")
+    if (len(args.dtver) != 1) and (len(args.dtver) != len(args.dr)):
+        msg = f"If passing multiple dtver ({args.dtver}), must pass exactly one for each dr ({args.dr})."
+        log.error(msg)
+        raise ValueError(msg)
 
     # AR safe: outdir
     if args.outdir[-1] != "/":

--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -316,8 +316,6 @@ def main():
     # AR if not backup
     if ("scnd" in steps):
         if ("scnd" in list(mydirs.keys())):
-            # AR handle dark1b/bright1b, where there is no secondary for now
-            # AR but could be in the future
             # AR assume here that if there are some secondary, the ledgers should be there
             if not os.path.isdir(mydirs["scndmtl"]):
                 expected_files["scnd"] = False
@@ -325,15 +323,11 @@ def main():
                 log.info("")
                 log.info("{:.1f}s\tscnd\tno secondary ledgers {}".format(time() - start, mydirs["scndmtl"]))
             else:
-                targdirs = [mydirs["scnd"]]
-                for key in sorted(list(mydirs.keys())):
-                    if (key[:4] == "scnd") & (key != "scnd") & (key != "scndmtl"):
-                        targdirs.append(mydirs[key])
                 status = create_mtl(
                     mytmpouts["tiles"],
                     mydirs["scndmtl"],
                     args.mtltime,
-                    targdirs,
+                    mydirs["scnd"],
                     args.survey,
                     args.gaiadr.replace("gaia", ""),
                     args.pmcorr,

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,9 @@ fiberassign change log
 
 5.9.2 (unreleased)
 ------------------
+* Enable running fiberassign with secondary ledgers for BACKUP tiles. (PR `#505`_).
+
+.. _`#505`: https://github.com/desihub/fiberassign/pull/505
 
 5.9.1 (2026-04-20)
 ------------------

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -807,7 +807,7 @@ def get_ledger_paths(
         mtl2 = mtl.replace(progshort, "{}1b".format(progshort))
         mtl = [mtl, mtl2]
     # AR secondary (dark, dark1b, bright, bright1b; no secondary for backup)
-    if program.lower() in ["dark", "bright", "dark1b", "bright1b"]:
+    if program.lower() in ["dark", "bright", "dark1b", "bright1b", "backup"]:
         scndmtl = os.path.join(
             os.getenv("DESI_SURVEYOPS"),
             "mtl",
@@ -978,9 +978,9 @@ def get_desitarget_paths(
             targ = targ.replace(program.lower(), progshort)
             targ2 = targ.replace(progshort, "{}1b".format(progshort))
             mydirs["targ"] = [targ, targ2]
-    # AR secondary (dark, dark1b, bright, bright1b; no secondary for backup)
+    # AR secondary (dark, dark1b, bright, bright1b, backup)
     # AR only query program (in particular, only dark1b for dark1b; same for bright1b)
-    if program.lower() in ["dark", "bright", "dark1b", "bright1b"]:
+    if program.lower() in ["dark", "bright", "dark1b", "bright1b", "backup"]:
         if survey.lower() == "main":
             basename = "targets-{}-secondary.fits".format(program.lower())
         else:
@@ -1633,7 +1633,7 @@ def create_mtl(
     # AR mtl: case secondary
     else:
         # AR mtl: secondary for backup should never happen, but safe approach still
-        if ("backup" not in mtldir) & (desitarget.__version__ >= "1.2.2"):
+        if (desitarget.__version__ >= "1.2.2"):
             # AR mtl: hard-coding the columns, to speed up code
             columns = ["FLUX_G", "FLUX_R", "FLUX_Z", "GAIA_PHOT_G_MEAN_MAG", "GAIA_PHOT_BP_MEAN_MAG", "GAIA_PHOT_RP_MEAN_MAG"]
             # AR mtl: also add GAIA_ASTROMETRIC_EXCESS_NOISE, in case args.pmcorr == "y"
@@ -1661,12 +1661,12 @@ def create_mtl(
                 targ = Table(fitsio.read(targdir, columns = columns + ["TARGETID"], rows=rows))
                 targs.append(targ)
             d = match_ledger_to_targets(d, vstack(targs))
-        elif "backup" in mtldir:
-            log.info(
-                "{:.1f}s\t{}\tno secondary targets for BACKUP program".format(
-                    time() - start, step,
-                )
-            )
+        # elif "backup" in mtldir:
+        #     log.info(
+        #         "{:.1f}s\t{}\tno secondary targets for BACKUP program".format(
+        #             time() - start, step,
+        #         )
+        #     )
         else:
             log.info(
                 "{:.1f}s\t{}\tas desitarget.__version__={} < 1.2.2, we do not add columns from {}".format(

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -904,7 +904,7 @@ def get_desitarget_paths(
         Dictionary with the following keys:
         - sky: sky folder(s)
         - skysupp: skysupp folder(s)
-        - gfa: GFA folder
+        - gfa: GFA folder(s)
         - targ: targets folder(s) (static catalogs, with all columns); 2-elt list for main/{dark1b,bright1b}, str otherwise
         - mtl: MTL folder(s); 2-elt list for main/{dark1b,bright1b}, str otherwise
         - scnd: secondary fits catalog(s) (static, with all columns)
@@ -940,6 +940,11 @@ def get_desitarget_paths(
     # Listify for iteration code later.
     if isinstance(dtver, str):
         dtver = [dtver]
+    elif isinstance(dtver, list) and (len(dtver) != len(dr)):
+        curr_time = time() - start
+        msg = f"{curr_time:.1f}s\t{step}\tif dtver is a list, it must be the same length as dr (there must be ONE dtver for EACH dr)"
+        log.error(msg)
+        raise ValueError(msg)
 
     # AR expected survey, program?
     exp_surveys = ["sv1", "sv2", "sv3", "main"]
@@ -961,17 +966,11 @@ def get_desitarget_paths(
     mydirs = {}
     mydirs["sky"] = []
     mydirs["skysupp"] = []
-    mydirs["gfa"] = os.path.join(
-        os.getenv("DESI_TARGET"), "catalogs", dr[0], dtver[0], "gfas"
-    )
+    mydirs["gfa"] = []
 
-    if program.lower() == "backup":
-        dr_vals = [gaiadr]
-    else:
-        dr_vals = dr
-
+    # DG - Iterating over dr + dtversions for target directories
     all_targ_files = []
-    for i, release in enumerate(dr_vals):
+    for i, release in enumerate(dr):
         dt = dtver[0] if (len(dtver) == 1) else dtver[i]
 
         sky = os.path.join(os.getenv("DESI_TARGET"), "catalogs", release, dt, "skies")
@@ -979,6 +978,13 @@ def get_desitarget_paths(
 
         skysupp = os.path.join(os.getenv("DESI_TARGET"), "catalogs", gaiadr, dt, "skies-supp")
         if os.path.exists(skysupp): mydirs["skysupp"].append(skysupp)
+
+        gfa = os.path.join(os.getenv("DESI_TARGET"), "catalogs", release, dt, "gfas")
+        if os.path.exists(gfa): mydirs["gfa"].append(gfa)
+
+        # DG - Correct release for backup tiles.
+        if program.lower() == "backup":
+            release = gaiadr
 
         prog = program.lower()
         targ = os.path.join(
@@ -1276,7 +1282,7 @@ def create_targ_nomtl(
 
     Args:
         tilesfn: path to a tiles fits file (string)
-        targdir: desitarget target folder (string)
+        targdir: desitarget target folder (string or list of strings)
         survey: survey (string; e.g. "sv1", "sv2", "sv3", "main")
         gaiadr: Gaia dr ("dr2" or "edr3")
         pmcorr: apply proper-motion correction? ("y" or "n")
@@ -1311,7 +1317,18 @@ def create_targ_nomtl(
     log.info("{:.1f}s\t{}\tstart generating {}".format(time() - start, step, outfn))
     # AR targ_nomtl: read targets
     tiles = fits.open(tilesfn)[1].data
-    d = read_targets_in_tiles(targdir, tiles=tiles, quick=quick)
+
+    if isinstance(targdir, str):
+        targdirs = [targdir]
+    else:
+        targdirs = [t for t in targdir]
+
+    # DG - Code from create_sky
+    ds = [read_targets_in_tiles(targdir, tiles=tiles, quick=quick) for targdir in targdirs]
+    for targdir, d in zip(targdirs, ds):
+        log.info("{:.1f}s\t{}\treading {} targets from {}".format(time() - start, step, len(d), targdir))
+    d = np.concatenate(ds)
+
     log.info(
         "{:.1f}s\t{}\tkeeping {} targets to {}".format(
             time() - start, step, len(d), outfn
@@ -2309,16 +2326,13 @@ def update_fiberassign_header(
     desiroot = os.getenv("DESI_ROOT")
     fd["PRIMARY"].write_key("DESIROOT", desiroot)
     for key in np.sort(list(mydirs.keys())):
-        if key in ["mtl", "targ", "scnd", "sky", "skysupp"]:
-            if isinstance(mydirs[key], list):
-                # AR header keywords: MTL, MTL2 (or TARG, TARG2)
-                suffixs = [""] + np.arange(2, len(mydirs[key]) + 1).astype(str).tolist()
-                for path, suffix in zip(mydirs[key], suffixs):
-                    fd["PRIMARY"].write_key(
-                        "{}{}".format(key, suffix), path.replace(desiroot, "DESIROOT"),
-                    )
-            else:
-                fd["PRIMARY"].write_key(key, mydirs[key].replace(desiroot, "DESIROOT"))
+        if isinstance(mydirs[key], list):
+            # AR header keywords: MTL, MTL2 (or TARG, TARG2)
+            suffixs = [""] + np.arange(2, len(mydirs[key]) + 1).astype(str).tolist()
+            for path, suffix in zip(mydirs[key], suffixs):
+                fd["PRIMARY"].write_key(
+                    "{}{}".format(key, suffix), path.replace(desiroot, "DESIROOT"),
+                )
         else:
             fd["PRIMARY"].write_key(key, mydirs[key].replace(desiroot, "DESIROOT"))
     # AR storing some specific arguments

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -13,6 +13,7 @@ import tempfile
 import shutil
 import re
 from glob import glob
+from pathlib import Path
 
 # time
 from time import time
@@ -970,7 +971,7 @@ def get_desitarget_paths(
         dtcats = dr
 
     all_targ_files = []
-    for i, dtcat in enumerate(dtcats):
+    for dtcat in dtcats:
         prog = program.lower()
         targ = os.path.join(
             os.getenv("DESI_TARGET"),
@@ -989,78 +990,99 @@ def get_desitarget_paths(
 
     mydirs[f"targ"] = all_targ_files
 
-
-    # if survey.lower() == "main":
-    #     progshort = program.lower().replace("1b", "")
-    #     if program.lower() == "{}1b".format(progshort):
-    #         targ = targ.replace(program.lower(), progshort)
-    #         targ2 = targ.replace(progshort, "{}1b".format(progshort))
-    #         mydirs["targ"] = [targ, targ2]
-
-
     # AR secondary (dark, dark1b, bright, bright1b; no secondary for backup)
     # AR only query program (in particular, only dark1b for dark1b; same for bright1b)
     if program.lower() in ["dark", "bright", "dark1b", "bright1b"]:
-        if survey.lower() == "main":
-            basename = "targets-{}-secondary.fits".format(program.lower())
-        else:
-            basename = "{}targets-{}-secondary.fits".format(survey.lower(), program.lower())
-        mydirs["scnd"] = os.path.join(
-            os.getenv("DESI_TARGET"),
-            "catalogs",
-            dr[0], # DG - Base secondary target file will be the first data release. We check the rest as later files.
-            dtver,
-            "targets",
-            survey.lower(),
-            "secondary",
-            program.lower(),
-            basename,
-        )
+        # if survey.lower() == "main":
+        basename = "targets-{}-secondary.fits".format(program.lower())
+        # else:
+        #     basename = "{}targets-{}-secondary.fits".format(survey.lower(), program.lower())
 
-        # TODO: DG - This entire extra dirs section needs a total refactor. It's a disaster.
+        all_secondaries = []
+
+        for release in dr:
+            base_path = Path(os.getenv("DESI_TARGET"),
+                            "catalogs",
+                            release,
+                            dtver,
+                            "targets",
+                            )
+
+            # DG - Loop over all sub directories found that match this survey
+            # Then check if the associated secondary file exists. If it does
+            # store it. associated secondary file needs to be in the right form.
+            paths_to_check = base_path.glob(f"{survey.lower()}*")
+            for p in paths_to_check:
+                curr_survey = p.name # DG - "main" or "main2" etc.
+                curr_name = basename if curr_survey == "main" else curr_survey + basename
+                full_path = (p / "secondary" / program.lower() / curr_name)
+
+                if full_path.exists():
+                    all_secondaries.append(str(full_path))
+
+        # DG - Unwrap all_secondaries into the dictionary in the form expected
+        # by the rest of the code.
+        # TODO change the rest of the code to accept mydirs["scnd"] as a list instead of multie entries, like mydirs["targ"] does.
+        mydirs["scnd"] = all_secondaries[0]
+        for i in range(1, len(all_secondaries)):
+            mydirs[f"scnd{i + 1}"] = all_secondaries[i]
+
+        # mydirs["scnd"] = os.path.join(
+        #     os.getenv("DESI_TARGET"),
+        #     "catalogs",
+        #     dr[0], # DG - Base secondary target file will be the first data release. We check the rest as later files.
+        #     dtver,
+        #     "targets",
+        #     survey.lower(),
+        #     "secondary",
+        #     program.lower(),
+        #     basename,
+        # )
+
+        # # TODO: DG - This entire extra dirs section needs a total refactor. It's a disaster.
 
 
-        # AR check possible extra folders, like main2/, main3/, etc
-        # AR and store the file path in keys like scnd2, scnd3, etc
-        # AR note: the index in the key name is not related to the extra folder name,
-        # AR        it is just the order of appearance
-        extradirs = sorted(
-            [os.path.basename(fn)
-                for fn in glob(
-                    os.path.join(
-                        os.getenv("DESI_TARGET"), "catalogs", dr[0], dtver, "targets", "{}*".format(survey.lower())
-                    )
-                )
-                if os.path.basename(fn) != survey
-            ]
-        )
+        # # AR check possible extra folders, like main2/, main3/, etc
+        # # AR and store the file path in keys like scnd2, scnd3, etc
+        # # AR note: the index in the key name is not related to the extra folder name,
+        # # AR        it is just the order of appearance
+        # extradirs = sorted(
+        #     [os.path.basename(fn)
+        #         for fn in glob(
+        #             os.path.join(
+        #                 os.getenv("DESI_TARGET"), "catalogs", dr[0], dtver, "targets", "{}*".format(survey.lower())
+        #             )
+        #         )
+        #         if os.path.basename(fn) != survey
+        #     ]
+        # )
 
-        # DG - If the originally found main secondary target file does not exist then
-        # we will take the next found file to be the primary secondary file.
-        # This is for 1B programs, where the secondary targets files live in main4/
-        # not in main, so fiberassign will crash looking for it in main.
-        if not os.path.isfile(mydirs["scnd"]):
-            count = 1
-        else:
-            count = 2
-        for extradir in extradirs:
-            fn = os.path.join(
-                os.getenv("DESI_TARGET"),
-                "catalogs",
-                dr[0],
-                dtver,
-                "targets",
-                extradir,
-                "secondary",
-                program.lower(),
-                "{}{}".format(extradir, basename),
-            )
-            if os.path.isfile(fn):
-                if count == 1:
-                    mydirs["scnd"] = fn
-                else:
-                    mydirs["scnd{}".format(count)] = fn
-                count += 1
+        # # DG - If the originally found main secondary target file does not exist then
+        # # we will take the next found file to be the primary secondary file.
+        # # This is for 1B programs, where the secondary targets files live in main4/
+        # # not in main, so fiberassign will crash looking for it in main.
+        # if not os.path.isfile(mydirs["scnd"]):
+        #     count = 1
+        # else:
+        #     count = 2
+        # for extradir in extradirs:
+        #     fn = os.path.join(
+        #         os.getenv("DESI_TARGET"),
+        #         "catalogs",
+        #         dr[0],
+        #         dtver,
+        #         "targets",
+        #         extradir,
+        #         "secondary",
+        #         program.lower(),
+        #         "{}{}".format(extradir, basename),
+        #     )
+        #     if os.path.isfile(fn):
+        #         if count == 1:
+        #             mydirs["scnd"] = fn
+        #         else:
+        #             mydirs["scnd{}".format(count)] = fn
+        #         count += 1
 
     # AR log
     for key in list(mydirs.keys()):

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -2347,10 +2347,13 @@ def update_fiberassign_header(
     # AR     we exclude from FAARGS outdir, forcetiled, and any None argument
     tmparr = []
     for kwargs in args._get_kwargs():
-        if (kwargs[0].lower() not in ["outdir", "forcetileid"]) & (
+        if (kwargs[0].lower() not in ["outdir", "forcetileid", "dr"]) & (
             kwargs[1] is not None
         ):
             tmparr += ["--{} {}".format(kwargs[0], kwargs[1])]
+        # DG - Turn the list back into a comma separated string
+        elif kwargs[0].lower() == "dr" and kwargs[1] is not None:
+            tmparr += ["--{} {}".format(kwargs[0], ",".join(kwargs[1]))]
     fd["PRIMARY"].write_key(
         "faargs", " ".join(tmparr),
     )

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -883,7 +883,7 @@ def get_desitarget_paths(
     Obtain the folder/file full paths for desitarget products
 
     Args:
-        dtver: desitarget catalog version (string; e.g., "0.57.0")
+        dtver: desitarget catalog version (string or list of strings; e.g., ["0.57.0"])
         survey: survey (string; e.g. "sv1", "sv2", "sv3", "main")
         program: "dark", "dark1b", "bright", "bright1b" or "backup" (string)
         too_tile (optional, defaults to False):
@@ -953,6 +953,11 @@ def get_desitarget_paths(
         log.error(msg)
         raise ValueError(msg)
 
+    # Listify for iteration code later.
+    if isinstance(dtver, str):
+        dtver = [dtver]
+
+
     # AR folder architecture is now the same at NERSC/KPNO (https://github.com/desihub/fiberassign/issues/302)
     mydirs = {}
     mydirs["sky"] = os.path.join(
@@ -966,18 +971,19 @@ def get_desitarget_paths(
     )
 
     if program.lower() == "backup":
-        dtcats = [gaiadr]
+        dr_vals = [gaiadr]
     else:
-        dtcats = dr
+        dr_vals = dr
 
     all_targ_files = []
-    for dtcat in dtcats:
+    for i, release in enumerate(dr_vals):
+        dt = dtver[0] if (len(dtver) == 1) else dtver[i]
         prog = program.lower()
         targ = os.path.join(
             os.getenv("DESI_TARGET"),
             "catalogs",
-            dtcat,
-            dtver,
+            release,
+            dt,
             "targets",
             survey.lower(),
             "resolve",
@@ -1004,11 +1010,12 @@ def get_desitarget_paths(
 
         all_secondaries = []
 
-        for release in dr:
+        for i, release in enumerate(dr):
+            dt = dtver[0] if (len(dtver) == 1) else dtver[i]
             base_path = Path(os.getenv("DESI_TARGET"),
                             "catalogs",
                             release,
-                            dtver,
+                            dt,
                             "targets",
                             )
 
@@ -2309,12 +2316,12 @@ def update_fiberassign_header(
     # AR     we exclude from FAARGS outdir, forcetiled, and any None argument
     tmparr = []
     for kwargs in args._get_kwargs():
-        if (kwargs[0].lower() not in ["outdir", "forcetileid", "dr"]) & (
+        if (kwargs[0].lower() not in ["outdir", "forcetileid", "dr", "dtver"]) & (
             kwargs[1] is not None
         ):
             tmparr += ["--{} {}".format(kwargs[0], kwargs[1])]
         # DG - Turn the list back into a comma separated string
-        elif kwargs[0].lower() == "dr" and kwargs[1] is not None:
+        elif kwargs[0].lower() in ["dr", "dtver"] and kwargs[1] is not None:
             tmparr += ["--{} {}".format(kwargs[0], ",".join(kwargs[1]))]
     fd["PRIMARY"].write_key(
         "faargs", " ".join(tmparr),

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -985,7 +985,7 @@ def get_desitarget_paths(
         )
         if (survey.lower() == "main") and (prog[-2:] == "1b"):
             # Append the 1A target directory first before the 1B.
-            all_targ_files.append(targ.replace(prog, prog[-2:]))
+            all_targ_files.append(targ.replace(prog, prog[:-2]))
         all_targ_files.append(targ)
 
     mydirs[f"targ"] = all_targ_files
@@ -1026,63 +1026,6 @@ def get_desitarget_paths(
         mydirs["scnd"] = all_secondaries[0]
         for i in range(1, len(all_secondaries)):
             mydirs[f"scnd{i + 1}"] = all_secondaries[i]
-
-        # mydirs["scnd"] = os.path.join(
-        #     os.getenv("DESI_TARGET"),
-        #     "catalogs",
-        #     dr[0], # DG - Base secondary target file will be the first data release. We check the rest as later files.
-        #     dtver,
-        #     "targets",
-        #     survey.lower(),
-        #     "secondary",
-        #     program.lower(),
-        #     basename,
-        # )
-
-        # # TODO: DG - This entire extra dirs section needs a total refactor. It's a disaster.
-
-
-        # # AR check possible extra folders, like main2/, main3/, etc
-        # # AR and store the file path in keys like scnd2, scnd3, etc
-        # # AR note: the index in the key name is not related to the extra folder name,
-        # # AR        it is just the order of appearance
-        # extradirs = sorted(
-        #     [os.path.basename(fn)
-        #         for fn in glob(
-        #             os.path.join(
-        #                 os.getenv("DESI_TARGET"), "catalogs", dr[0], dtver, "targets", "{}*".format(survey.lower())
-        #             )
-        #         )
-        #         if os.path.basename(fn) != survey
-        #     ]
-        # )
-
-        # # DG - If the originally found main secondary target file does not exist then
-        # # we will take the next found file to be the primary secondary file.
-        # # This is for 1B programs, where the secondary targets files live in main4/
-        # # not in main, so fiberassign will crash looking for it in main.
-        # if not os.path.isfile(mydirs["scnd"]):
-        #     count = 1
-        # else:
-        #     count = 2
-        # for extradir in extradirs:
-        #     fn = os.path.join(
-        #         os.getenv("DESI_TARGET"),
-        #         "catalogs",
-        #         dr[0],
-        #         dtver,
-        #         "targets",
-        #         extradir,
-        #         "secondary",
-        #         program.lower(),
-        #         "{}{}".format(extradir, basename),
-        #     )
-        #     if os.path.isfile(fn):
-        #         if count == 1:
-        #             mydirs["scnd"] = fn
-        #         else:
-        #             mydirs["scnd{}".format(count)] = fn
-        #         count += 1
 
     # AR log
     for key in list(mydirs.keys()):

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -1040,13 +1040,22 @@ def get_desitarget_paths(
         # DG - Check for 1b secondary targeting files for 1a tiles.
         bases_to_test = [basename]
         if program.lower() in ["dark", "bright"]:
-            bases_to_test += f"{program.lower()}1b"
+            if survey.lower() == "main":
+                extra_base = "targets-{}1b-secondary.fits".format(program.lower())
+            else:
+                extra_base = "{}targets-{}1b-secondary.fits".format(survey.lower(), program.lower())
+            bases_to_test += [extra_base]
         if not os.path.isfile(mydirs["scnd"]):
             count = 1
         else:
             count = 2
         for extradir in extradirs:
             for base in bases_to_test:
+                prog = program.lower()
+
+                # DG - Correct the program for when searching for 1b secondaries on 1a tiles.
+                if ("1b" in base) and ("1b" not in prog):
+                    prog += "1b"
                 fn = os.path.join(
                     os.getenv("DESI_TARGET"),
                     "catalogs",
@@ -1055,9 +1064,10 @@ def get_desitarget_paths(
                     "targets",
                     extradir,
                     "secondary",
-                    program.lower(),
+                    prog,
                     "{}{}".format(extradir, base),
                 )
+
                 if os.path.isfile(fn):
                     if count == 1:
                         mydirs["scnd"] = fn

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -902,14 +902,13 @@ def get_desitarget_paths(
 
     Returns:
         Dictionary with the following keys:
-        - sky: sky folder
-        - skysupp: skysupp folder
+        - sky: sky folder(s)
+        - skysupp: skysupp folder(s)
         - gfa: GFA folder
         - targ: targets folder(s) (static catalogs, with all columns); 2-elt list for main/{dark1b,bright1b}, str otherwise
         - mtl: MTL folder(s); 2-elt list for main/{dark1b,bright1b}, str otherwise
-        - scnd: secondary fits catalog (static, with all columns)
+        - scnd: secondary fits catalog(s) (static, with all columns)
         - scndmtl: MTL folder for secondary targets
-        - scnd2, scnd3, etc: any other existing secondary fits catalog (static, with all columns)
         - too: ToO ecsv catalog
 
     Notes:

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -869,7 +869,7 @@ def get_desitarget_paths(
     survey,
     program,
     too_tile=False,
-    dr="dr9",
+    dr=["dr9"],
     gaiadr="gaiadr2",
     custom_too_file=None,
     custom_too_development=False,
@@ -889,7 +889,7 @@ def get_desitarget_paths(
                 if False and survey=="main" and ToO-fiber.ecsv exists, use ToO-fiber.ecsv (fiber-override only),
                 else, use ToO.ecsv (ToO for dedicated tiles)
                 (boolean)
-        dr (optional, defaults to "dr9"): legacypipe dr (string)
+        dr (optional, defaults to ["dr9"]): legacypipe dr (list of strings)
         gaiadr (optional, defaults to "gaiadr2"): gaia dr (string)
         custom_too_file (optional, default=None): comma-separated full paths to a custom ToO files, for development work, which overrides the official one (string)
         custom_too_development (optional, defaults to False): is this for development? (allows custom_too_file to be outside of $DESI_SURVEYOPS or $DESI_ROOT/survey/fiberassign/special/tertiary) (bool)
@@ -946,38 +946,58 @@ def get_desitarget_paths(
             )
         )
 
+    if (not isinstance(dr, list)) or (len(dr) < 1):
+        curr_time = time() - start
+        msg = f"{curr_time:.1f}s\t{step}\tdr must be a list of length at least 1"
+        log.error(msg)
+        raise ValueError(msg)
+
     # AR folder architecture is now the same at NERSC/KPNO (https://github.com/desihub/fiberassign/issues/302)
     mydirs = {}
     mydirs["sky"] = os.path.join(
-        os.getenv("DESI_TARGET"), "catalogs", dr, dtver, "skies"
+        os.getenv("DESI_TARGET"), "catalogs", dr[0], dtver, "skies"
     )
     mydirs["skysupp"] = os.path.join(
         os.getenv("DESI_TARGET"), "catalogs", gaiadr, dtver, "skies-supp"
     )
     mydirs["gfa"] = os.path.join(
-        os.getenv("DESI_TARGET"), "catalogs", dr, dtver, "gfas"
+        os.getenv("DESI_TARGET"), "catalogs", dr[0], dtver, "gfas"
     )
+
     if program.lower() == "backup":
-        dtcat = gaiadr
+        dtcats = [gaiadr]
     else:
-        dtcat = dr
-    targ = os.path.join(
-        os.getenv("DESI_TARGET"),
-        "catalogs",
-        dtcat,
-        dtver,
-        "targets",
-        survey.lower(),
-        "resolve",
-        program.lower(),
-    )
-    mydirs["targ"] = targ
-    if survey.lower() == "main":
-        progshort = program.lower().replace("1b", "")
-        if program.lower() == "{}1b".format(progshort):
-            targ = targ.replace(program.lower(), progshort)
-            targ2 = targ.replace(progshort, "{}1b".format(progshort))
-            mydirs["targ"] = [targ, targ2]
+        dtcats = dr
+
+    all_targ_files = []
+    for i, dtcat in enumerate(dtcats):
+        prog = program.lower()
+        targ = os.path.join(
+            os.getenv("DESI_TARGET"),
+            "catalogs",
+            dtcat,
+            dtver,
+            "targets",
+            survey.lower(),
+            "resolve",
+            prog,
+        )
+        if (survey.lower() == "main") and (prog[-2:] == "1b"):
+            # Append the 1A target directory first before the 1B.
+            all_targ_files.append(targ.replace(prog, prog[-2:]))
+        all_targ_files.append(targ)
+
+    mydirs[f"targ"] = all_targ_files
+
+
+    # if survey.lower() == "main":
+    #     progshort = program.lower().replace("1b", "")
+    #     if program.lower() == "{}1b".format(progshort):
+    #         targ = targ.replace(program.lower(), progshort)
+    #         targ2 = targ.replace(progshort, "{}1b".format(progshort))
+    #         mydirs["targ"] = [targ, targ2]
+
+
     # AR secondary (dark, dark1b, bright, bright1b; no secondary for backup)
     # AR only query program (in particular, only dark1b for dark1b; same for bright1b)
     if program.lower() in ["dark", "bright", "dark1b", "bright1b"]:
@@ -988,7 +1008,7 @@ def get_desitarget_paths(
         mydirs["scnd"] = os.path.join(
             os.getenv("DESI_TARGET"),
             "catalogs",
-            dr,
+            dr[0], # DG - Base secondary target file will be the first data release. We check the rest as later files.
             dtver,
             "targets",
             survey.lower(),
@@ -996,6 +1016,10 @@ def get_desitarget_paths(
             program.lower(),
             basename,
         )
+
+        # TODO: DG - This entire extra dirs section needs a total refactor. It's a disaster.
+
+
         # AR check possible extra folders, like main2/, main3/, etc
         # AR and store the file path in keys like scnd2, scnd3, etc
         # AR note: the index in the key name is not related to the extra folder name,
@@ -1004,7 +1028,7 @@ def get_desitarget_paths(
             [os.path.basename(fn)
                 for fn in glob(
                     os.path.join(
-                        os.getenv("DESI_TARGET"), "catalogs", dr, dtver, "targets", "{}*".format(survey.lower())
+                        os.getenv("DESI_TARGET"), "catalogs", dr[0], dtver, "targets", "{}*".format(survey.lower())
                     )
                 )
                 if os.path.basename(fn) != survey
@@ -1023,7 +1047,7 @@ def get_desitarget_paths(
             fn = os.path.join(
                 os.getenv("DESI_TARGET"),
                 "catalogs",
-                dr,
+                dr[0],
                 dtver,
                 "targets",
                 extradir,

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -2332,7 +2332,7 @@ def update_fiberassign_header(
     desiroot = os.getenv("DESI_ROOT")
     fd["PRIMARY"].write_key("DESIROOT", desiroot)
     for key in np.sort(list(mydirs.keys())):
-        if key in ["mtl", "targ"]:
+        if key in ["mtl", "targ", "scndmtl"]:
             if isinstance(mydirs[key], list):
                 # AR header keywords: MTL, MTL2 (or TARG, TARG2)
                 suffixs = [""] + np.arange(2, len(mydirs[key]) + 1).astype(str).tolist()

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -931,6 +931,17 @@ def get_desitarget_paths(
         [same for bright, bright1b]
 
     """
+
+    if (not isinstance(dr, list)) or (len(dr) < 1):
+        curr_time = time() - start
+        msg = f"{curr_time:.1f}s\t{step}\tdr must be a list of length at least 1"
+        log.error(msg)
+        raise ValueError(msg)
+
+    # Listify for iteration code later.
+    if isinstance(dtver, str):
+        dtver = [dtver]
+
     # AR expected survey, program?
     exp_surveys = ["sv1", "sv2", "sv3", "main"]
     exp_programs = ["dark", "dark1b", "bright", "bright1b", "backup"]
@@ -947,25 +958,10 @@ def get_desitarget_paths(
             )
         )
 
-    if (not isinstance(dr, list)) or (len(dr) < 1):
-        curr_time = time() - start
-        msg = f"{curr_time:.1f}s\t{step}\tdr must be a list of length at least 1"
-        log.error(msg)
-        raise ValueError(msg)
-
-    # Listify for iteration code later.
-    if isinstance(dtver, str):
-        dtver = [dtver]
-
-
     # AR folder architecture is now the same at NERSC/KPNO (https://github.com/desihub/fiberassign/issues/302)
     mydirs = {}
-    mydirs["sky"] = os.path.join(
-        os.getenv("DESI_TARGET"), "catalogs", dr[0], dtver[0], "skies"
-    )
-    mydirs["skysupp"] = os.path.join(
-        os.getenv("DESI_TARGET"), "catalogs", gaiadr, dtver[0], "skies-supp"
-    )
+    mydirs["sky"] = []
+    mydirs["skysupp"] = []
     mydirs["gfa"] = os.path.join(
         os.getenv("DESI_TARGET"), "catalogs", dr[0], dtver[0], "gfas"
     )
@@ -978,6 +974,13 @@ def get_desitarget_paths(
     all_targ_files = []
     for i, release in enumerate(dr_vals):
         dt = dtver[0] if (len(dtver) == 1) else dtver[i]
+
+        sky = os.path.join(os.getenv("DESI_TARGET"), "catalogs", release, dt, "skies")
+        if os.path.exists(sky): mydirs["sky"].append(sky)
+
+        skysupp = os.path.join(os.getenv("DESI_TARGET"), "catalogs", gaiadr, dt, "skies-supp")
+        if os.path.exists(skysupp): mydirs["skysupp"].append(skysupp)
+
         prog = program.lower()
         targ = os.path.join(
             os.getenv("DESI_TARGET"),
@@ -1188,9 +1191,9 @@ def create_sky(
 
     Args:
         tilesfn: path to a tiles fits file (string)
-        skydir: desitarget sky folder (string)
+        skydir: desitarget sky folder (list of string or string)
         outfn: fits file name to be written (string)
-        suppskydir (optional, defaults to None): desitarget suppsky folder (string)
+        suppskydir (optional, defaults to None): desitarget suppsky folder (list of string or string)
         tmpoutdir (optional, defaults to a temporary directory): temporary directory where
                 write_skies will write (creating some sub-directories)
         add_plate_cols (optional, defaults to True): adds a PLATE_RA, PLATE_DEC columns (boolean)
@@ -1213,9 +1216,17 @@ def create_sky(
     log.info("{:.1f}s\t{}\tstart generating {}".format(time() - start, step, outfn))
     # AR sky: read targets
     tiles = fits.open(tilesfn)[1].data
-    skydirs = [skydir]
+    if isinstance(skydir, str):
+        skydirs = [skydir]
+    else:
+        # DG - Copy, lists are pass by reference and we don't want suppsky written to FA header under skies
+        skydirs = [s for s in skydir]
+
     if suppskydir is not None:
-        skydirs.append(suppskydir)
+        if isinstance(suppskydir, str):
+            skydirs.append(suppskydir)
+        else:
+            skydirs += suppskydir
     ds = [read_targets_in_tiles(skydir, tiles=tiles, quick=True) for skydir in skydirs]
     for skydir, d in zip(skydirs, ds):
         log.info("{:.1f}s\t{}\treading {} targets from {}".format(time() - start, step, len(d), skydir))
@@ -2299,7 +2310,7 @@ def update_fiberassign_header(
     desiroot = os.getenv("DESI_ROOT")
     fd["PRIMARY"].write_key("DESIROOT", desiroot)
     for key in np.sort(list(mydirs.keys())):
-        if key in ["mtl", "targ", "scnd"]:
+        if key in ["mtl", "targ", "scnd", "sky", "skysupp"]:
             if isinstance(mydirs[key], list):
                 # AR header keywords: MTL, MTL2 (or TARG, TARG2)
                 suffixs = [""] + np.arange(2, len(mydirs[key]) + 1).astype(str).tolist()

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -1020,12 +1020,7 @@ def get_desitarget_paths(
                 if full_path.exists():
                     all_secondaries.append(str(full_path))
 
-        # DG - Unwrap all_secondaries into the dictionary in the form expected
-        # by the rest of the code.
-        # TODO change the rest of the code to accept mydirs["scnd"] as a list instead of multie entries, like mydirs["targ"] does.
-        mydirs["scnd"] = all_secondaries[0]
-        for i in range(1, len(all_secondaries)):
-            mydirs[f"scnd{i + 1}"] = all_secondaries[i]
+        mydirs["scnd"] = all_secondaries
 
     # AR log
     for key in list(mydirs.keys()):
@@ -2295,7 +2290,7 @@ def update_fiberassign_header(
     desiroot = os.getenv("DESI_ROOT")
     fd["PRIMARY"].write_key("DESIROOT", desiroot)
     for key in np.sort(list(mydirs.keys())):
-        if key in ["mtl", "targ"]:
+        if key in ["mtl", "targ", "scnd"]:
             if isinstance(mydirs[key], list):
                 # AR header keywords: MTL, MTL2 (or TARG, TARG2)
                 suffixs = [""] + np.arange(2, len(mydirs[key]) + 1).astype(str).tolist()

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -815,6 +815,28 @@ def get_ledger_paths(
             "secondary",
             program.lower(),
         )
+
+        # DG - Load the secondary ledgers from the 1B program in the 1A tiles.
+        if program.lower() in ["dark", "bright"]:
+            progshort = program.lower()
+
+            scnd1a = os.path.join(
+            os.getenv("DESI_SURVEYOPS"),
+            "mtl",
+            survey.lower(),
+            "secondary",
+            progshort,
+            )
+
+            scnd1b = os.path.join(
+            os.getenv("DESI_SURVEYOPS"),
+            "mtl",
+            survey.lower(),
+            "secondary",
+            f"{progshort}1b",
+            )
+
+            scndmtl = [scnd1a, scnd1b]
     else:
         scndmtl = None
     # AR ToO (same for dark, bright)
@@ -1015,28 +1037,33 @@ def get_desitarget_paths(
         # we will take the next found file to be the primary secondary file.
         # This is for 1B programs, where the secondary targets files live in main4/
         # not in main, so fiberassign will crash looking for it in main.
+        # DG - Check for 1b secondary targeting files for 1a tiles.
+        bases_to_test = [basename]
+        if program.lower() in ["dark", "bright"]:
+            bases_to_test += f"{program.lower()}1b"
         if not os.path.isfile(mydirs["scnd"]):
             count = 1
         else:
             count = 2
         for extradir in extradirs:
-            fn = os.path.join(
-                os.getenv("DESI_TARGET"),
-                "catalogs",
-                dr,
-                dtver,
-                "targets",
-                extradir,
-                "secondary",
-                program.lower(),
-                "{}{}".format(extradir, basename),
-            )
-            if os.path.isfile(fn):
-                if count == 1:
-                    mydirs["scnd"] = fn
-                else:
-                    mydirs["scnd{}".format(count)] = fn
-                count += 1
+            for base in bases_to_test:
+                fn = os.path.join(
+                    os.getenv("DESI_TARGET"),
+                    "catalogs",
+                    dr,
+                    dtver,
+                    "targets",
+                    extradir,
+                    "secondary",
+                    program.lower(),
+                    "{}{}".format(extradir, base),
+                )
+                if os.path.isfile(fn):
+                    if count == 1:
+                        mydirs["scnd"] = fn
+                    else:
+                        mydirs["scnd{}".format(count)] = fn
+                    count += 1
 
     # AR log
     for key in list(mydirs.keys()):
@@ -1447,6 +1474,13 @@ def create_mtl(
     # AR    which have imports from fba_launch_io.py...
     from fiberassign.assign import minimal_target_columns
 
+    # DG - "secondary" in mtldir will always fail if mtldir is a list of 2 dirs.
+    # So instead determine this ahead of time and account correctly.
+    is_secondary = "secondary" in mtldir
+    if isinstance(mtldir, list):
+        for mtl in mtldir:
+            is_secondary = is_secondary or ("secondary" in mtl)
+
     # AR check on mtl
     if isinstance(mtldir, list):
         # AR only two ledgers allowed (e.g. dark, dark1b)
@@ -1463,10 +1497,9 @@ def create_mtl(
             )
             log.error(msg)
             raise ValueError(msg)
-        if len(targdirs) > 2:
-            msg = "len(targdir) = {} > 2; only up two static folders can be provided".format(
-                len(targdir)
-            )
+        # DG - We only want to limit to 2 targ dirs if this is a primary mtl not a secondary.
+        if (len(targdirs) > 2) and not is_secondary:
+            msg = f"len(targdir) = {len(targdirs)} > 2; only up two static folders can be provided"
             log.error(msg)
             raise ValueError(msg)
 
@@ -1503,7 +1536,7 @@ def create_mtl(
             time() - start, step, len(d), mtldir
         )
     )
-    # Might happen if you load a secondadry 1B program leder before the ledgers
+    # Might happen if you load a secondadry 1B program ledger before the ledgers
     # were "turned on"
     if len(d) == 0:
         log.warning(f"No targets loaded from {mtldir}. Aborting MTL creation.")
@@ -1553,7 +1586,7 @@ def create_mtl(
     # AR mtl:    if backup or desitarget.__version__ < 1.2.2, no columns addition
     #
     # AR mtl: case not secondary
-    if "secondary" not in mtldir:
+    if not is_secondary:
         columns = [key for key in minimal_target_columns if key not in d.dtype.names]
         # AR mtl: also add GAIA_ASTROMETRIC_EXCESS_NOISE, in case args.pmcorr == "y"
         if pmcorr == "y":
@@ -1632,7 +1665,6 @@ def create_mtl(
             d = match_ledger_to_targets(d, targ)
     # AR mtl: case secondary
     else:
-        # AR mtl: secondary for backup should never happen, but safe approach still
         if (desitarget.__version__ >= "1.2.2"):
             # AR mtl: hard-coding the columns, to speed up code
             columns = ["FLUX_G", "FLUX_R", "FLUX_Z", "GAIA_PHOT_G_MEAN_MAG", "GAIA_PHOT_BP_MEAN_MAG", "GAIA_PHOT_RP_MEAN_MAG"]
@@ -1661,12 +1693,6 @@ def create_mtl(
                 targ = Table(fitsio.read(targdir, columns = columns + ["TARGETID"], rows=rows))
                 targs.append(targ)
             d = match_ledger_to_targets(d, vstack(targs))
-        # elif "backup" in mtldir:
-        #     log.info(
-        #         "{:.1f}s\t{}\tno secondary targets for BACKUP program".format(
-        #             time() - start, step,
-        #         )
-        #     )
         else:
             log.info(
                 "{:.1f}s\t{}\tas desitarget.__version__={} < 1.2.2, we do not add columns from {}".format(

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -961,13 +961,13 @@ def get_desitarget_paths(
     # AR folder architecture is now the same at NERSC/KPNO (https://github.com/desihub/fiberassign/issues/302)
     mydirs = {}
     mydirs["sky"] = os.path.join(
-        os.getenv("DESI_TARGET"), "catalogs", dr[0], dtver, "skies"
+        os.getenv("DESI_TARGET"), "catalogs", dr[0], dtver[0], "skies"
     )
     mydirs["skysupp"] = os.path.join(
-        os.getenv("DESI_TARGET"), "catalogs", gaiadr, dtver, "skies-supp"
+        os.getenv("DESI_TARGET"), "catalogs", gaiadr, dtver[0], "skies-supp"
     )
     mydirs["gfa"] = os.path.join(
-        os.getenv("DESI_TARGET"), "catalogs", dr[0], dtver, "gfas"
+        os.getenv("DESI_TARGET"), "catalogs", dr[0], dtver[0], "gfas"
     )
 
     if program.lower() == "backup":

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -1376,7 +1376,7 @@ def create_mtl(
         tilesfn: path to a tiles fits file (string)
         mtldir: desisurveyops MTL folder (string or list of two strings)
         mtltime: MTL isodate (string formatted as yyyy-mm-ddThh:mm:ss+00:00)
-        targdirs: desitarget targets folder (or file name(s) if secondary) for static fits catalog(s) (string or list)
+        targdirs: desitarget targets folder (or file name(s)) for static fits catalog(s) (string or list)
         survey: survey (string; e.g. "sv1", "sv2", "sv3", "main")
         gaiadr: Gaia dr ("dr2" or "edr3")
         pmcorr: apply proper-motion correction? ("y" or "n")
@@ -1447,12 +1447,12 @@ def create_mtl(
             )
             log.error(msg)
             raise ValueError(msg)
-        if len(targdirs) > 2:
-            msg = "len(targdir) = {} > 2; only up two static folders can be provided".format(
-                len(targdir)
-            )
-            log.error(msg)
-            raise ValueError(msg)
+        # if len(targdirs) > 2:
+        #     msg = "len(targdir) = {} > 2; only up two static folders can be provided".format(
+        #         len(targdir)
+        #     )
+        #     log.error(msg)
+        #     raise ValueError(msg)
 
     # AR change targdirs to list if a string is provided
     if isinstance(targdirs, str):

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -985,8 +985,12 @@ def get_desitarget_paths(
         )
         if (survey.lower() == "main") and (prog[-2:] == "1b"):
             # Append the 1A target directory first before the 1B.
-            all_targ_files.append(targ.replace(prog, prog[:-2]))
-        all_targ_files.append(targ)
+            temp_targ = targ.replace(prog, prog[:-2])
+            if os.path.exists(temp_targ):
+                all_targ_files.append(temp_targ)
+
+        if os.path.exists(targ):
+            all_targ_files.append(targ)
 
     mydirs[f"targ"] = all_targ_files
 

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -2129,8 +2129,6 @@ def launch_onetile_fa(
         "--ha",
         str(args.ha),
     ]
-    if args.ha != 0:
-        opts += ["--ha", str(args.ha)]
     if args.margin_pos != 0:
         opts += ["--margin-pos", str(args.margin_pos)]
     if args.margin_gfa != 0:


### PR DESCRIPTION
Following #504, and addressing more aspects of #503 piecemeal, this PR addresses enables using secondary targets on BACKUP tiles. This was a simple change after enabling the 1B survey secondaries, since most of the work required for this was done there. This PR simply removes any blocking `if` statements that prevent searching for and loading secondary target files and MTLs on backup tiles. 

Testing is still in progress, but that said, these changes do not affect the reproducibility of the CURRENT tiles in the CURRENT DESI software stack (in other words, since the actual on disk secondary files/ledgers do not exist for BACKUP tiles, this PR does nothing to change any reproducibility of any tiles). 