### PR TITLE
Secondary Ledger Changes III: Read 1B secondary ledgers on 1A tiles

### DIFF
--- a/bin/fba_launch
+++ b/bin/fba_launch
@@ -316,15 +316,26 @@ def main():
     # AR if not backup
     if ("scnd" in steps):
         if ("scnd" in list(mydirs.keys())):
-            # AR handle dark1b/bright1b, where there is no secondary for now
-            # AR but could be in the future
-            # AR assume here that if there are some secondary, the ledgers should be there
-            if not os.path.isdir(mydirs["scndmtl"]):
+            # DG - For 1A targets we know load the 1b secondary mtls, so we
+            # need to check both scnd mtls, and then we only keep the ones that exist
+            # (in case the 1b ledgers aren't in place for some reason)
+            to_check = mydirs["scndmtl"]
+
+            if not isinstance(to_check, list):
+                to_check = [mydirs["scndmtl"]]
+
+            scnd_exists = []
+            for fname in to_check:
+                if os.path.isdir(fname):
+                    scnd_exists.append(fname)
+
+            if len(scnd_exists) == 0:
                 expected_files["scnd"] = False
                 log.info("")
                 log.info("")
                 log.info("{:.1f}s\tscnd\tno secondary ledgers {}".format(time() - start, mydirs["scndmtl"]))
             else:
+                mydirs["scndmtl"] = scnd_exists
                 targdirs = [mydirs["scnd"]]
                 for key in sorted(list(mydirs.keys())):
                     if (key[:4] == "scnd") & (key != "scnd") & (key != "scndmtl"):

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,9 @@ fiberassign change log
 
 5.9.2 (unreleased)
 ------------------
+* Enable running fiberassign with secondary ledgers for BACKUP tiles. (PR `#505`_).
+
+.. _`#505`: https://github.com/desihub/fiberassign/pull/505
 
 5.9.1 (2026-04-20)
 ------------------

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -807,7 +807,7 @@ def get_ledger_paths(
         mtl2 = mtl.replace(progshort, "{}1b".format(progshort))
         mtl = [mtl, mtl2]
     # AR secondary (dark, dark1b, bright, bright1b; no secondary for backup)
-    if program.lower() in ["dark", "bright", "dark1b", "bright1b"]:
+    if program.lower() in ["dark", "bright", "dark1b", "bright1b", "backup"]:
         scndmtl = os.path.join(
             os.getenv("DESI_SURVEYOPS"),
             "mtl",
@@ -978,9 +978,9 @@ def get_desitarget_paths(
             targ = targ.replace(program.lower(), progshort)
             targ2 = targ.replace(progshort, "{}1b".format(progshort))
             mydirs["targ"] = [targ, targ2]
-    # AR secondary (dark, dark1b, bright, bright1b; no secondary for backup)
+    # AR secondary (dark, dark1b, bright, bright1b, backup)
     # AR only query program (in particular, only dark1b for dark1b; same for bright1b)
-    if program.lower() in ["dark", "bright", "dark1b", "bright1b"]:
+    if program.lower() in ["dark", "bright", "dark1b", "bright1b", "backup"]:
         if survey.lower() == "main":
             basename = "targets-{}-secondary.fits".format(program.lower())
         else:
@@ -1633,7 +1633,7 @@ def create_mtl(
     # AR mtl: case secondary
     else:
         # AR mtl: secondary for backup should never happen, but safe approach still
-        if ("backup" not in mtldir) & (desitarget.__version__ >= "1.2.2"):
+        if (desitarget.__version__ >= "1.2.2"):
             # AR mtl: hard-coding the columns, to speed up code
             columns = ["FLUX_G", "FLUX_R", "FLUX_Z", "GAIA_PHOT_G_MEAN_MAG", "GAIA_PHOT_BP_MEAN_MAG", "GAIA_PHOT_RP_MEAN_MAG"]
             # AR mtl: also add GAIA_ASTROMETRIC_EXCESS_NOISE, in case args.pmcorr == "y"
@@ -1661,12 +1661,12 @@ def create_mtl(
                 targ = Table(fitsio.read(targdir, columns = columns + ["TARGETID"], rows=rows))
                 targs.append(targ)
             d = match_ledger_to_targets(d, vstack(targs))
-        elif "backup" in mtldir:
-            log.info(
-                "{:.1f}s\t{}\tno secondary targets for BACKUP program".format(
-                    time() - start, step,
-                )
-            )
+        # elif "backup" in mtldir:
+        #     log.info(
+        #         "{:.1f}s\t{}\tno secondary targets for BACKUP program".format(
+        #             time() - start, step,
+        #         )
+        #     )
         else:
             log.info(
                 "{:.1f}s\t{}\tas desitarget.__version__={} < 1.2.2, we do not add columns from {}".format(

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -1040,13 +1040,22 @@ def get_desitarget_paths(
         # DG - Check for 1b secondary targeting files for 1a tiles.
         bases_to_test = [basename]
         if program.lower() in ["dark", "bright"]:
-            bases_to_test += f"{program.lower()}1b"
+            if survey.lower() == "main":
+                extra_base = "targets-{}1b-secondary.fits".format(program.lower())
+            else:
+                extra_base = "{}targets-{}1b-secondary.fits".format(survey.lower(), program.lower())
+            bases_to_test += [extra_base]
         if not os.path.isfile(mydirs["scnd"]):
             count = 1
         else:
             count = 2
         for extradir in extradirs:
             for base in bases_to_test:
+                prog = program.lower()
+
+                # DG - Correct the program for when searching for 1b secondaries on 1a tiles.
+                if ("1b" in base) and ("1b" not in prog):
+                    prog += "1b"
                 fn = os.path.join(
                     os.getenv("DESI_TARGET"),
                     "catalogs",
@@ -1055,9 +1064,10 @@ def get_desitarget_paths(
                     "targets",
                     extradir,
                     "secondary",
-                    program.lower(),
+                    prog,
                     "{}{}".format(extradir, base),
                 )
+
                 if os.path.isfile(fn):
                     if count == 1:
                         mydirs["scnd"] = fn

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -2332,7 +2332,7 @@ def update_fiberassign_header(
     desiroot = os.getenv("DESI_ROOT")
     fd["PRIMARY"].write_key("DESIROOT", desiroot)
     for key in np.sort(list(mydirs.keys())):
-        if key in ["mtl", "targ"]:
+        if key in ["mtl", "targ", "scndmtl"]:
             if isinstance(mydirs[key], list):
                 # AR header keywords: MTL, MTL2 (or TARG, TARG2)
                 suffixs = [""] + np.arange(2, len(mydirs[key]) + 1).astype(str).tolist()

--- a/py/fiberassign/fba_launch_io.py
+++ b/py/fiberassign/fba_launch_io.py
@@ -815,6 +815,28 @@ def get_ledger_paths(
             "secondary",
             program.lower(),
         )
+
+        # DG - Load the secondary ledgers from the 1B program in the 1A tiles.
+        if program.lower() in ["dark", "bright"]:
+            progshort = program.lower()
+
+            scnd1a = os.path.join(
+            os.getenv("DESI_SURVEYOPS"),
+            "mtl",
+            survey.lower(),
+            "secondary",
+            progshort,
+            )
+
+            scnd1b = os.path.join(
+            os.getenv("DESI_SURVEYOPS"),
+            "mtl",
+            survey.lower(),
+            "secondary",
+            f"{progshort}1b",
+            )
+
+            scndmtl = [scnd1a, scnd1b]
     else:
         scndmtl = None
     # AR ToO (same for dark, bright)
@@ -1015,28 +1037,33 @@ def get_desitarget_paths(
         # we will take the next found file to be the primary secondary file.
         # This is for 1B programs, where the secondary targets files live in main4/
         # not in main, so fiberassign will crash looking for it in main.
+        # DG - Check for 1b secondary targeting files for 1a tiles.
+        bases_to_test = [basename]
+        if program.lower() in ["dark", "bright"]:
+            bases_to_test += f"{program.lower()}1b"
         if not os.path.isfile(mydirs["scnd"]):
             count = 1
         else:
             count = 2
         for extradir in extradirs:
-            fn = os.path.join(
-                os.getenv("DESI_TARGET"),
-                "catalogs",
-                dr,
-                dtver,
-                "targets",
-                extradir,
-                "secondary",
-                program.lower(),
-                "{}{}".format(extradir, basename),
-            )
-            if os.path.isfile(fn):
-                if count == 1:
-                    mydirs["scnd"] = fn
-                else:
-                    mydirs["scnd{}".format(count)] = fn
-                count += 1
+            for base in bases_to_test:
+                fn = os.path.join(
+                    os.getenv("DESI_TARGET"),
+                    "catalogs",
+                    dr,
+                    dtver,
+                    "targets",
+                    extradir,
+                    "secondary",
+                    program.lower(),
+                    "{}{}".format(extradir, base),
+                )
+                if os.path.isfile(fn):
+                    if count == 1:
+                        mydirs["scnd"] = fn
+                    else:
+                        mydirs["scnd{}".format(count)] = fn
+                    count += 1
 
     # AR log
     for key in list(mydirs.keys()):
@@ -1447,6 +1474,13 @@ def create_mtl(
     # AR    which have imports from fba_launch_io.py...
     from fiberassign.assign import minimal_target_columns
 
+    # DG - "secondary" in mtldir will always fail if mtldir is a list of 2 dirs.
+    # So instead determine this ahead of time and account correctly.
+    is_secondary = "secondary" in mtldir
+    if isinstance(mtldir, list):
+        for mtl in mtldir:
+            is_secondary = is_secondary or ("secondary" in mtl)
+
     # AR check on mtl
     if isinstance(mtldir, list):
         # AR only two ledgers allowed (e.g. dark, dark1b)
@@ -1463,10 +1497,9 @@ def create_mtl(
             )
             log.error(msg)
             raise ValueError(msg)
-        if len(targdirs) > 2:
-            msg = "len(targdir) = {} > 2; only up two static folders can be provided".format(
-                len(targdir)
-            )
+        # DG - We only want to limit to 2 targ dirs if this is a primary mtl not a secondary.
+        if (len(targdirs) > 2) and not is_secondary:
+            msg = f"len(targdir) = {len(targdirs)} > 2; only up two static folders can be provided"
             log.error(msg)
             raise ValueError(msg)
 
@@ -1503,7 +1536,7 @@ def create_mtl(
             time() - start, step, len(d), mtldir
         )
     )
-    # Might happen if you load a secondadry 1B program leder before the ledgers
+    # Might happen if you load a secondadry 1B program ledger before the ledgers
     # were "turned on"
     if len(d) == 0:
         log.warning(f"No targets loaded from {mtldir}. Aborting MTL creation.")
@@ -1553,7 +1586,7 @@ def create_mtl(
     # AR mtl:    if backup or desitarget.__version__ < 1.2.2, no columns addition
     #
     # AR mtl: case not secondary
-    if "secondary" not in mtldir:
+    if not is_secondary:
         columns = [key for key in minimal_target_columns if key not in d.dtype.names]
         # AR mtl: also add GAIA_ASTROMETRIC_EXCESS_NOISE, in case args.pmcorr == "y"
         if pmcorr == "y":
@@ -1632,7 +1665,6 @@ def create_mtl(
             d = match_ledger_to_targets(d, targ)
     # AR mtl: case secondary
     else:
-        # AR mtl: secondary for backup should never happen, but safe approach still
         if (desitarget.__version__ >= "1.2.2"):
             # AR mtl: hard-coding the columns, to speed up code
             columns = ["FLUX_G", "FLUX_R", "FLUX_Z", "GAIA_PHOT_G_MEAN_MAG", "GAIA_PHOT_BP_MEAN_MAG", "GAIA_PHOT_RP_MEAN_MAG"]
@@ -1661,12 +1693,6 @@ def create_mtl(
                 targ = Table(fitsio.read(targdir, columns = columns + ["TARGETID"], rows=rows))
                 targs.append(targ)
             d = match_ledger_to_targets(d, vstack(targs))
-        # elif "backup" in mtldir:
-        #     log.info(
-        #         "{:.1f}s\t{}\tno secondary targets for BACKUP program".format(
-        #             time() - start, step,
-        #         )
-        #     )
         else:
             log.info(
                 "{:.1f}s\t{}\tas desitarget.__version__={} < 1.2.2, we do not add columns from {}".format(


### PR DESCRIPTION
Following https://github.com/desihub/fiberassign/pull/505, and addressing the last aspects of https://github.com/desihub/fiberassign/issues/503. This PR branches off the aforementioned PR, and the aforementioned PR should be  merged _before_ this PR.

In this PR fiberassign now reads the 1b secondary ledgers when generating the 1a tile assignments, to preempt the possibility that we may add more 1a tiles but want to include the 1b secondary targets. This required:

- Return both 1a and 1b secondary MTL directories from `get_ledger_paths()`.
- Return the set of secondary targeting files for both 1a and 1b targets in `get_desitarget_paths()`.
- Account for the fact that `os.path.exists(dirs["scndmtl"])` might be false if the scndmtl is a list of two items, so instead check for the existence of both scndmtls, and keep any that exist and fail if none of them do.
- Account for > 2 targeting files with exactly 2 mtl directories when assembling the mtl to make the targeting file.
- Add a more robust check for if this is a secondary file or not in `create_mtl` to handle that `mtl_dir` might be a list. 
- Add a robust check to write the correct ledger paths to the output file, since scndmtl might be a list now.

I _think_ that this is everything necessary to do what we want. Testing is still in progress, and this PR will move to "ready to merge" when I'm confident it works as intended. 