### PR TITLE
attempt workaround for test package version incompatibilities

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,9 +59,7 @@ jobs:
             - name: Install Python dependencies
               run: |
                 python -m pip install --no-cache-dir --upgrade pip setuptools wheel pytest
-                python -m pip install --no-cache-dir pyyaml requests scipy matplotlib healpy
-                python -m pip install --no-cache-dir --upgrade "numpy${{ matrix.numpy-version }}"
-                python -m pip install --no-cache-dir --upgrade "astropy${{ matrix.astropy-version }}"
+                python -m pip install --no-cache-dir pyyaml requests scipy matplotlib healpy "numpy${{ matrix.numpy-version }}" "astropy${{ matrix.astropy-version }}"
                 python -m pip install --no-cache-dir fitsio
                 python -m pip install desiutil==${DESIUTIL_VERSION}
                 python -m pip install --no-build-isolation --no-cache-dir git+https://github.com/desihub/desimodel.git@${{ env.DESIMODEL_VERSION }}#egg=desimodel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,9 +122,7 @@ jobs:
             - name: Install Python dependencies
               run: |
                 python -m pip install --no-cache-dir --upgrade pip setuptools wheel pytest pytest-cov
-                python -m pip install --no-cache-dir pyyaml requests scipy matplotlib healpy
-                python -m pip install --no-cache-dir --upgrade "numpy${{ matrix.numpy-version }}"
-                python -m pip install --no-cache-dir --upgrade "astropy${{ matrix.astropy-version }}"
+                python -m pip install --no-cache-dir pyyaml requests scipy matplotlib healpy "numpy${{ matrix.numpy-version }}" "astropy${{ matrix.astropy-version }}"
                 python -m pip install --no-cache-dir fitsio
                 python -m pip install desiutil==${DESIUTIL_VERSION}
                 python -m pip install --no-build-isolation --no-cache-dir git+https://github.com/desihub/desimodel.git@${{ env.DESIMODEL_VERSION }}#egg=desimodel


### PR DESCRIPTION
This is an attempt at addressing #514 GitHub unit tests failing due to package incompatibilities.  Basically I'm trying installing a pinned version of numpy in the same pip command that installs healpy, in the hopes that it will pickup a compatible version of healpy.